### PR TITLE
Make seed and path copy pasteable

### DIFF
--- a/src/check/runner/utils/utils.ts
+++ b/src/check/runner/utils/utils.ts
@@ -31,9 +31,11 @@ function throwIfFailed<Ts>(out: RunDetails<Ts>) {
       );
     }
     throw new Error(
-      `Property failed after ${out.numRuns} tests (seed: ${out.seed}, path: ${out.counterexamplePath}): ${pretty(
-        out.counterexample
-      )}\nShrunk ${out.numShrinks} time(s)\nGot error: ${out.error}\n\n${
+      `Property failed after ${out.numRuns} tests\n{ seed: ${out.seed}, path: "${
+        out.counterexamplePath
+      }" }\nCounterexample: ${pretty(out.counterexample)}\nShrunk ${out.numShrinks} time(s)\nGot error: ${
+        out.error
+      }\n\n${
         out.failures.length === 0
           ? 'Hint: Enable verbose mode in order to have the list of all failing values encountered during the run'
           : `Encountered failures were:\n- ${out.failures.map(pretty).join('\n- ')}`

--- a/test/e2e/Shadows.spec.ts
+++ b/test/e2e/Shadows.spec.ts
@@ -176,7 +176,7 @@ describe(`Shadows (seed: ${seed})`, () => {
     } catch (err) {
       failed = true;
       const msg = err.message as string;
-      assert.ok(msg.indexOf(`(seed: ${seed}, path:`) !== -1, `Message contains the seed, got: ${err}`);
+      assert.ok(msg.indexOf(`seed: ${seed}, path:`) !== -1, `Message contains the seed, got: ${err}`);
       assert.ok(
         /\[Space\(grid\{x:\d+,y:\d+\},solution\{x:\d+,y:\d+\},initial\{x:\d+,y:\d+\}\),\d+\]/.exec(msg) !== null,
         `Message contains the failing entry, got: ${err}`

--- a/test/unit/check/runner/Runner.spec.ts
+++ b/test/unit/check/runner/Runner.spec.ts
@@ -427,7 +427,7 @@ describe('Runner', () => {
       try {
         rAssert(failingProperty, { seed: 42 });
       } catch (err) {
-        assert.ok(err.message.indexOf(`(seed: 42, path:`) !== -1, `Cannot find the seed in: ${err.message}`);
+        assert.ok(err.message.indexOf(`seed: 42, path:`) !== -1, `Cannot find the seed in: ${err.message}`);
         return;
       }
       assert.ok(false, 'Expected an exception, got success');


### PR DESCRIPTION
This PR changes the error message on a failed test slightly. It looks like this:

```
Property failed after 1 tests
{ seed: 1530466923032, path: "1:1:0:0:0:0:0:0:1:1:3:8:8:9:11:16:20:19:19:19:19:19:22:23" }
Counterexample: [[32,32738,34]]
Shrunk 0 time(s)
```

The major change is that the `seed` and the `path` is now printed so that they can be easily copy-pasted into one's code as an argument to `assert`. Additionally, the counterexample is prefixed with the text "Counterexample" to make it easier to understand and distinguish.