### PR TITLE
Rollup should build iife module first

### DIFF
--- a/test/rollup/rollup.config.js
+++ b/test/rollup/rollup.config.js
@@ -5,7 +5,8 @@ export default {
   input: 'test/rollup/main.js',
   output: {
     file: 'test/rollup/dist/main.js',
-    format: 'cjs'
+    format: 'iife',
+    name: 'RunFastCheck'
   },
   plugins: [ resolve(), cjs() ],
 


### PR DESCRIPTION
Basically IIFE and ESM are the two recommended build formats for web applications.
Both of them need to be supported correctly.