### PR TITLE
Commands generator should not rely on arrays generator

### DIFF
--- a/src/check/arbitrary/ArrayArbitrary.ts
+++ b/src/check/arbitrary/ArrayArbitrary.ts
@@ -13,8 +13,7 @@ class ArrayArbitrary<T> extends Arbitrary<T[]> {
     readonly arb: Arbitrary<T>,
     readonly minLength: number,
     readonly maxLength: number,
-    readonly preFilter: (tab: Shrinkable<T>[]) => Shrinkable<T>[] = tab => tab,
-    readonly preShrink: (tab: Shrinkable<T>[]) => Shrinkable<T>[] = tab => tab
+    readonly preFilter: (tab: Shrinkable<T>[]) => Shrinkable<T>[] = tab => tab
   ) {
     super();
     this.lengthArb = integer(minLength, maxLength);
@@ -27,16 +26,13 @@ class ArrayArbitrary<T> extends Arbitrary<T[]> {
   }
   generate(mrng: Random): Shrinkable<T[]> {
     const size = this.lengthArb.generate(mrng);
-    const items = Array(size.value);
+    const items: Shrinkable<T>[] = Array(size.value);
     for (let idx = 0; idx !== size.value; ++idx) {
       items[idx] = this.arb.generate(mrng);
     }
     return this.wrapper(items, false);
   }
-  private shrinkImpl(itemsRaw: Shrinkable<T>[], shrunkOnce: boolean): Stream<Shrinkable<T>[]> {
-    // shrinking one by one is the not the most comprehensive
-    // but allows a reasonable number of entries in the shrink
-    const items = this.preShrink(itemsRaw);
+  private shrinkImpl(items: Shrinkable<T>[], shrunkOnce: boolean): Stream<Shrinkable<T>[]> {
     if (items.length === 0) {
       return Stream.nil<Shrinkable<T>[]>();
     }

--- a/src/check/model/ModelRunner.ts
+++ b/src/check/model/ModelRunner.ts
@@ -1,6 +1,7 @@
 import { AsyncCommand } from './command/AsyncCommand';
 import { Command } from './command/Command';
 import { ICommand } from './command/ICommand';
+import { CommandsIterable } from './commands/CommandsIterable';
 
 type Setup<Model, Real> = () => { model: Model; real: Real };
 
@@ -23,6 +24,38 @@ const genericModelRun = <Model extends object, Real, P>(
   return state;
 };
 
+/** @hidden */
+const internalModelRun = <Model extends object, Real>(
+  s: Setup<Model, Real>,
+  cmds: Iterable<Command<Model, Real>> | CommandsIterable<Model, Real, void>
+): void => {
+  const then = (p: undefined, c: () => undefined) => c();
+  try {
+    return genericModelRun(s, cmds, undefined, then);
+  } catch (err) {
+    if ('errorDetected' in cmds && typeof cmds.errorDetected === 'function') {
+      cmds.errorDetected();
+    }
+    throw err;
+  }
+};
+
+/** @hidden */
+const internalAsyncModelRun = async <Model extends object, Real>(
+  s: Setup<Model, Real>,
+  cmds: Iterable<AsyncCommand<Model, Real>> | CommandsIterable<Model, Real, Promise<void>>
+): Promise<void> => {
+  const then = (p: Promise<void>, c: () => Promise<void> | undefined) => p.then(c);
+  try {
+    return await genericModelRun(s, cmds, Promise.resolve(), then);
+  } catch (err) {
+    if ('errorDetected' in cmds && typeof cmds.errorDetected === 'function') {
+      cmds.errorDetected();
+    }
+    throw err;
+  }
+};
+
 /**
  * Run synchronous commands over a `Model` and the `Real` system
  *
@@ -33,10 +66,9 @@ const genericModelRun = <Model extends object, Real, P>(
  */
 export const modelRun = <Model extends object, Real>(
   s: Setup<Model, Real>,
-  cmds: Iterable<Command<Model, Real>>
+  cmds: Iterable<Command<Model, Real>> | CommandsIterable<Model, Real, void>
 ): void => {
-  const then = (p: undefined, c: () => undefined) => c();
-  genericModelRun(s, cmds, undefined, then);
+  internalModelRun(s, cmds);
 };
 
 /**
@@ -47,10 +79,9 @@ export const modelRun = <Model extends object, Real>(
  * @param s Initial state provider
  * @param cmds Asynchronous commands to be executed
  */
-export const asyncModelRun = <Model extends object, Real>(
+export const asyncModelRun = async <Model extends object, Real>(
   s: Setup<Model, Real>,
-  cmds: Iterable<AsyncCommand<Model, Real>>
+  cmds: Iterable<AsyncCommand<Model, Real>> | CommandsIterable<Model, Real, Promise<void>>
 ): Promise<void> => {
-  const then = (p: Promise<void>, c: () => Promise<void> | undefined) => p.then(c);
-  return genericModelRun(s, cmds, Promise.resolve(), then);
+  await internalAsyncModelRun(s, cmds);
 };

--- a/src/check/model/commands/CommandWrapper.ts
+++ b/src/check/model/commands/CommandWrapper.ts
@@ -15,6 +15,6 @@ export class CommandWrapper<Model extends object, Real, RunResult> implements IC
     return new CommandWrapper<Model, Real, RunResult>(this.cmd);
   }
   toString(): string {
-    return this.hasRan ? this.cmd.toString() : '-';
+    return this.cmd.toString();
   }
 }

--- a/src/check/model/commands/CommandsArbitrary.ts
+++ b/src/check/model/commands/CommandsArbitrary.ts
@@ -1,9 +1,61 @@
-import { ArrayArbitrary } from '../../arbitrary/ArrayArbitrary';
+import { Random } from '../../../random/generator/Random';
+import { Stream } from '../../../stream/Stream';
 import { Arbitrary } from '../../arbitrary/definition/Arbitrary';
+import { ArbitraryWithShrink } from '../../arbitrary/definition/ArbitraryWithShrink';
 import { Shrinkable } from '../../arbitrary/definition/Shrinkable';
+import { nat } from '../../arbitrary/IntegerArbitrary';
 import { oneof } from '../../arbitrary/OneOfArbitrary';
 import { ICommand } from '../command/ICommand';
+import { CommandsIterable } from './CommandsIterable';
 import { CommandWrapper } from './CommandWrapper';
+
+class CommandsArbitrary<Model extends object, Real, RunResult> extends Arbitrary<
+  CommandsIterable<Model, Real, RunResult>
+> {
+  readonly oneCommandArb: Arbitrary<CommandWrapper<Model, Real, RunResult>>;
+  readonly lengthArb: ArbitraryWithShrink<number>;
+  constructor(commandArbs: Arbitrary<ICommand<Model, Real, RunResult>>[], maxCommands: number) {
+    super();
+    this.oneCommandArb = oneof(...commandArbs).map(c => new CommandWrapper(c));
+    this.lengthArb = nat(maxCommands);
+  }
+  private static cloneCommands<Model extends object, Real, RunResult>(
+    cmds: Shrinkable<CommandWrapper<Model, Real, RunResult>>[]
+  ) {
+    return cmds.map(c => new Shrinkable(c.value.clone(), c.shrink));
+  }
+  private wrapper(
+    items: Shrinkable<CommandWrapper<Model, Real, RunResult>>[],
+    shrunkOnce: boolean
+  ): Shrinkable<CommandsIterable<Model, Real, RunResult>> {
+    return new Shrinkable(new CommandsIterable(items.map(s => s.value)), () =>
+      this.shrinkImpl(items, shrunkOnce).map(v => this.wrapper(CommandsArbitrary.cloneCommands(v), true))
+    );
+  }
+  generate(mrng: Random): Shrinkable<CommandsIterable<Model, Real, RunResult>> {
+    const size = this.lengthArb.generate(mrng);
+    const items: Shrinkable<CommandWrapper<Model, Real, RunResult>>[] = Array(size.value);
+    for (let idx = 0; idx !== size.value; ++idx) {
+      items[idx] = this.oneCommandArb.generate(mrng);
+    }
+    return this.wrapper(items, false);
+  }
+  private shrinkImpl(
+    itemsRaw: Shrinkable<CommandWrapper<Model, Real, RunResult>>[],
+    shrunkOnce: boolean
+  ): Stream<Shrinkable<CommandWrapper<Model, Real, RunResult>>[]> {
+    const items = itemsRaw.filter(c => c.value.hasRan); // filter out commands that have not been executed
+    if (items.length === 0) {
+      return Stream.nil<Shrinkable<CommandWrapper<Model, Real, RunResult>>[]>();
+    }
+    const size = this.lengthArb.shrinkableFor(items.length, shrunkOnce);
+    return size
+      .shrink()
+      .map(l => items.slice(items.length - l.value)) // try: remove items at the beginning
+      .join(this.shrinkImpl(items.slice(1), false).map(vs => [items[0]].concat(vs))) // try: keep first, shrink remaining
+      .join(items[0].shrink().map(v => [v].concat(items.slice(1)))); // try: shrink first, keep others
+  }
+}
 
 /**
  * For arrays of {@link ICommand} to be executed by {@link modelRun} or {@link asyncModelRun}
@@ -18,14 +70,5 @@ export const commands = <Model extends object, Real, RunResult>(
   commandArbs: Arbitrary<ICommand<Model, Real, RunResult>>[],
   maxCommands?: number
 ): Arbitrary<Iterable<ICommand<Model, Real, RunResult>>> => {
-  const internalCommandArb: Arbitrary<CommandWrapper<Model, Real, RunResult>> = oneof(...commandArbs).map(
-    c => new CommandWrapper(c)
-  );
-  return new ArrayArbitrary(
-    internalCommandArb,
-    0,
-    maxCommands != null ? maxCommands : 10,
-    cs => cs.map(c => new Shrinkable(c.value.clone(), c.shrink)),
-    cs => cs.filter(c => c.value.hasRan)
-  );
+  return new CommandsArbitrary(commandArbs, maxCommands != null ? maxCommands : 10);
 };

--- a/src/check/model/commands/CommandsArbitrary.ts
+++ b/src/check/model/commands/CommandsArbitrary.ts
@@ -9,6 +9,7 @@ import { ICommand } from '../command/ICommand';
 import { CommandsIterable } from './CommandsIterable';
 import { CommandWrapper } from './CommandWrapper';
 
+/** @hidden */
 class CommandsArbitrary<Model extends object, Real, RunResult> extends Arbitrary<
   CommandsIterable<Model, Real, RunResult>
 > {

--- a/src/check/model/commands/CommandsArbitrary.ts
+++ b/src/check/model/commands/CommandsArbitrary.ts
@@ -48,11 +48,15 @@ class CommandsArbitrary<Model extends object, Real, RunResult> extends Arbitrary
     if (items.length === 0) {
       return Stream.nil<Shrinkable<CommandWrapper<Model, Real, RunResult>>[]>();
     }
-    const size = this.lengthArb.shrinkableFor(items.length, shrunkOnce);
-    return size
-      .shrink()
-      .map(l => items.slice(items.length - l.value)) // try: remove items at the beginning
-      .join(this.shrinkImpl(items.slice(1), false).map(vs => [items[0]].concat(vs))) // try: keep first, shrink remaining
+    // The shrinker of commands have to keep the last item
+    // because it is the one causing the failure
+    const emptyOrNil = shrunkOnce
+      ? Stream.nil<Shrinkable<CommandWrapper<Model, Real, RunResult>>[]>()
+      : new Stream([[]][Symbol.iterator]());
+    const size = this.lengthArb.shrinkableFor(items.length - 1, shrunkOnce);
+    return emptyOrNil
+      .join(size.shrink().map(l => items.slice(0, l.value).concat(items[items.length - 1]))) // try: remove items except the last one
+      .join(this.shrinkImpl(items.slice(0, items.length - 1), false).map(vs => vs.concat(items[items.length - 1]))) // try: keep last, shrink remaining (rec)
       .join(items[0].shrink().map(v => [v].concat(items.slice(1)))); // try: shrink first, keep others
   }
 }

--- a/src/check/model/commands/CommandsIterable.ts
+++ b/src/check/model/commands/CommandsIterable.ts
@@ -1,0 +1,15 @@
+import { CommandWrapper } from './CommandWrapper';
+
+export class CommandsIterable<Model extends object, Real, RunResult>
+  implements Iterable<CommandWrapper<Model, Real, RunResult>> {
+  constructor(readonly commands: CommandWrapper<Model, Real, RunResult>[]) {}
+  [Symbol.iterator](): Iterator<CommandWrapper<Model, Real, RunResult>> {
+    return this.commands[Symbol.iterator]();
+  }
+  toString(): string {
+    return this.commands
+      .filter(c => c.hasRan)
+      .map(c => c.toString())
+      .join(',');
+  }
+}

--- a/src/check/model/commands/CommandsIterable.ts
+++ b/src/check/model/commands/CommandsIterable.ts
@@ -1,15 +1,23 @@
 import { CommandWrapper } from './CommandWrapper';
 
+/** @hidden */
 export class CommandsIterable<Model extends object, Real, RunResult>
   implements Iterable<CommandWrapper<Model, Real, RunResult>> {
+  private lastErrorDetectedStr: string = '';
   constructor(readonly commands: CommandWrapper<Model, Real, RunResult>[]) {}
   [Symbol.iterator](): Iterator<CommandWrapper<Model, Real, RunResult>> {
+    for (let idx = 0; idx !== this.commands.length; ++idx) {
+      this.commands[idx].hasRan = false;
+    }
     return this.commands[Symbol.iterator]();
   }
-  toString(): string {
-    return this.commands
+  errorDetected() {
+    this.lastErrorDetectedStr = this.commands
       .filter(c => c.hasRan)
       .map(c => c.toString())
       .join(',');
+  }
+  toString(): string {
+    return this.lastErrorDetectedStr;
   }
 }

--- a/test/e2e/model/CommandsArbitrary.spec.ts
+++ b/test/e2e/model/CommandsArbitrary.spec.ts
@@ -28,7 +28,7 @@ class FailureCommand implements fc.Command<Model, Real> {
 const seed = Date.now();
 describe(`CommandsArbitrary (seed: ${seed})`, () => {
   describe('commands', () => {
-    it.skip('Should print only the commands corresponding to the failure', () => {
+    it('Should print only the commands corresponding to the failure', () => {
       // Why this test?
       //
       // fc.commands is one of the rare Arbitrary relying on an internal state.
@@ -57,8 +57,9 @@ describe(`CommandsArbitrary (seed: ${seed})`, () => {
       assert.ok(out.failed, 'Should have failed');
       const cmdsRepr = out.counterexample![1].toString();
       const validSteps = [...out.counterexample![0], ...out.counterexample![2]];
-      assert.ok(
-        /^(-,)*failure(,-)*$/.test(cmdsRepr),
+      assert.equal(
+        cmdsRepr,
+        'failure',
         `Expected the only played command to be 'failure', got: ${cmdsRepr} for steps ${validSteps.sort().join(',')}`
       );
     });

--- a/test/e2e/model/CommandsArbitrary.spec.ts
+++ b/test/e2e/model/CommandsArbitrary.spec.ts
@@ -1,0 +1,61 @@
+import * as assert from 'assert';
+import * as fc from '../../../src/fast-check';
+
+type Model = {
+  current: { stepId: number };
+  validSteps: number[];
+};
+type Real = {};
+
+class SuccessCommand implements fc.Command<Model, Real> {
+  check = (m: Readonly<Model>) => m.validSteps.includes(m.current.stepId++);
+  run = (m: Model, r: Real) => {};
+  toString = () => 'success';
+}
+class FailureCommand implements fc.Command<Model, Real> {
+  check = (m: Readonly<Model>) => m.validSteps.includes(m.current.stepId++);
+  run = (m: Model, r: Real) => {
+    throw 'failure';
+  };
+  toString = () => 'failure';
+}
+
+const seed = Date.now();
+describe(`CommandsArbitrary (seed: ${seed})`, () => {
+  describe('commands', () => {
+    it.skip('Should print only the commands corresponding to the failure', () => {
+      // Why this test?
+      //
+      // fc.commands is one of the rare Arbitrary relying on an internal state.
+      // By generating commands along with other arbitraries, we could highlight states issues.
+      // Basically shrinking will re-use the generated commands multiple times along with a shrunk array.
+      //
+      // First version was failing on this test with the following output:
+      // Expected the only played command to be 'failure', got: -,success,failure for steps 2
+      // The output for 'steps 2' should have been '-,-,failure'
+
+      const out = fc.check(
+        fc.property(
+          fc.array(fc.nat(9), 0, 3),
+          fc.commands([fc.constant(new FailureCommand()), fc.constant(new SuccessCommand())]),
+          fc.array(fc.nat(9), 0, 3),
+          (validSteps1: number[], cmds: Iterable<fc.Command<Model, Real>>, validSteps2: number[]) => {
+            const setup = () => ({
+              model: { current: { stepId: 0 }, validSteps: [...validSteps1, ...validSteps2] },
+              real: {}
+            });
+            fc.modelRun(setup, cmds);
+          }
+        ),
+        { seed: seed }
+      );
+      assert.ok(out.failed, 'Should have failed');
+      const cmdsRepr = out.counterexample![1].toString();
+      const validSteps = [...out.counterexample![0], ...out.counterexample![2]];
+      assert.ok(
+        /^(-,)*failure(,-)*$/.test(cmdsRepr),
+        `Expected the only played command to be 'failure', got: ${cmdsRepr} for steps ${validSteps.sort().join(',')}`
+      );
+    });
+  });
+});

--- a/test/unit/check/model/commands/CommandWrapper.spec.ts
+++ b/test/unit/check/model/commands/CommandWrapper.spec.ts
@@ -8,14 +8,14 @@ type Model = {};
 type Real = {};
 
 describe('CommandWrapper', () => {
-  it('Should hide name of the command if it has not run', () => {
+  it('Should show name of the command if it has not run', () => {
     const cmd = new class implements Command<Model, Real> {
       check = (m: Readonly<Model>) => true;
       run = (m: Model, r: Real) => {};
       toString = () => 'sync command';
     }();
     const wrapper = new CommandWrapper(cmd);
-    assert.strictEqual(wrapper.toString(), '-');
+    assert.strictEqual(wrapper.toString(), 'sync command');
   });
   it('Should show name of the command if it has run', () => {
     const cmd = new class implements Command<Model, Real> {

--- a/test/unit/check/model/commands/CommandsArbitrary.spec.ts
+++ b/test/unit/check/model/commands/CommandsArbitrary.spec.ts
@@ -79,7 +79,7 @@ describe('CommandWrapper', () => {
       ));
     // TODO: revamp the arbitrary so that this test
     //       can be enabled
-    /*it('Should shrink with failure at the end', () =>
+    it.skip('Should shrink with failure at the end', () =>
         fc.assert(
           fc.property(fc.integer(), (seed: number) => {
             const mrng = new Random(prand.xorshift128plus(seed));
@@ -98,7 +98,7 @@ describe('CommandWrapper', () => {
   
             for (const shrunkCmds of baseCommands.shrink()) {
               logOnCheck.data = [];
-              shrunkCmds.value.forEach(c => c.check(model));
+              [...shrunkCmds.value].forEach(c => c.check(model));
               assert.ok(
                   logOnCheck.data.length === 0
                   || logOnCheck.data[logOnCheck.data.length - 1] === 'failure',
@@ -106,7 +106,7 @@ describe('CommandWrapper', () => {
               );
             }
           })
-        ));*/
+        ));
     it('Should shrink with at most one failure and all successes', () =>
       fc.assert(
         fc.property(fc.integer(), (seed: number) => {

--- a/test/unit/check/model/commands/CommandsArbitrary.spec.ts
+++ b/test/unit/check/model/commands/CommandsArbitrary.spec.ts
@@ -77,36 +77,33 @@ describe('CommandWrapper', () => {
           }
         })
       ));
-    // TODO: revamp the arbitrary so that this test
-    //       can be enabled
-    it.skip('Should shrink with failure at the end', () =>
-        fc.assert(
-          fc.property(fc.integer(), (seed: number) => {
-            const mrng = new Random(prand.xorshift128plus(seed));
-            let logOnCheck: { data: string[] } = { data: [] };
-  
-            const baseCommands = commands([
-              constant(new SuccessCommand(logOnCheck)),
-              constant(new SkippedCommand(logOnCheck)),
-              constant(new FailureCommand(logOnCheck))
-            ]).generate(mrng);
-            simulateCommands(baseCommands.value);
-  
-            const lastWasFailure = logOnCheck.data[logOnCheck.data.length - 1] === 'failure';
-            const initialData = [...logOnCheck.data];
-            fc.pre(lastWasFailure);
-  
-            for (const shrunkCmds of baseCommands.shrink()) {
-              logOnCheck.data = [];
-              [...shrunkCmds.value].forEach(c => c.check(model));
-              assert.ok(
-                  logOnCheck.data.length === 0
-                  || logOnCheck.data[logOnCheck.data.length - 1] === 'failure',
-                  `Shrunk initial data ${initialData.join(',')} into ${logOnCheck.data.join(',')}`
-              );
-            }
-          })
-        ));
+    it('Should shrink with failure at the end', () =>
+      fc.assert(
+        fc.property(fc.integer(), (seed: number) => {
+          const mrng = new Random(prand.xorshift128plus(seed));
+          let logOnCheck: { data: string[] } = { data: [] };
+
+          const baseCommands = commands([
+            constant(new SuccessCommand(logOnCheck)),
+            constant(new SkippedCommand(logOnCheck)),
+            constant(new FailureCommand(logOnCheck))
+          ]).generate(mrng);
+          simulateCommands(baseCommands.value);
+
+          const lastWasFailure = logOnCheck.data[logOnCheck.data.length - 1] === 'failure';
+          const initialData = [...logOnCheck.data];
+          fc.pre(lastWasFailure);
+
+          for (const shrunkCmds of baseCommands.shrink()) {
+            logOnCheck.data = [];
+            [...shrunkCmds.value].forEach(c => c.check(model));
+            assert.ok(
+              logOnCheck.data.length === 0 || logOnCheck.data[logOnCheck.data.length - 1] === 'failure',
+              `Shrunk initial data ${initialData.join(',')} into ${logOnCheck.data.join(',')}`
+            );
+          }
+        })
+      ));
     it('Should shrink with at most one failure and all successes', () =>
       fc.assert(
         fc.property(fc.integer(), (seed: number) => {

--- a/test/unit/check/model/commands/CommandsArbitrary.spec.ts
+++ b/test/unit/check/model/commands/CommandsArbitrary.spec.ts
@@ -6,7 +6,6 @@ import { Command } from '../../../../../src/check/model/command/Command';
 import { Random } from '../../../../../src/random/generator/Random';
 import { constant } from '../../../../../src/check/arbitrary/ConstantArbitrary';
 import { commands } from '../../../../../src/check/model/commands/CommandsArbitrary';
-import { modelRun } from '../../../../../src/check/model/ModelRunner';
 
 type Model = {};
 type Real = {};


### PR DESCRIPTION
Fixes #192

Before this development `fc.commands` was relying on `fc.array` to build and shrink commands correctly.
Unfortunately, with this setup it was not possible to benefit from assumptions we can make on commands while shrinking them:
- the last started command should always be kept because it is the one causing the failure (or none of the commands caused the failure)
- string representation was featuring dash (`-`) for non executed commands
- string representation was not reliable when commands were used along with other shrinkable arbitraries