### PR TITLE
More stability for e2e checking bias of bigint

### DIFF
--- a/test/e2e/arbitraries/ArrayArbitrary.spec.ts
+++ b/test/e2e/arbitraries/ArrayArbitrary.spec.ts
@@ -41,7 +41,7 @@ describe(`ArrayArbitrary (seed: ${seed})`, () => {
     });
     biasIts('integer', fc.integer());
     if (typeof BigInt !== 'undefined') {
-      biasIts('bigint', fc.bigInt());
+      biasIts('bigint', fc.bigIntN(64));
     }
   });
 });


### PR DESCRIPTION
The test `Should be biased by default and suggest small entries [bigint]` was quite unstable on Travis.

The commit replaces the usage of fc.bigInt(), which is equivalent to fc.bigIntN(256), by fc.bigIntN(64).

It should highly reduce the size of generated values and thus increase the probality of collision.