### PR TITLE
Provide compilable typings for users not using TypeScript >=3.2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ perf/
 prebuild/
 src/
 test/
+buildTypes.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
       if: tag =~ ^v\d+\.
       script:
         - npm run prebuild
+        - npm run build:publish-types
         - npm run build:publish-cjs
         - npm run build:publish-esm
         - npm run webbuild

--- a/README.md
+++ b/README.md
@@ -128,15 +128,3 @@ leftPad('abc', 4, '\u{1f431}') //=> '\u{1f431}abc' -- in: 3 code points, out: 4 
 m.stringify({bar: ['a', null, 'b']}, {arrayFormat: 'bracket'}) //=> "bar[]=a&bar&bar[]=b"
 m.parse('bar[]=a&bar&bar[]=b', {arrayFormat: 'bracket'})       //=> {bar: [null, 'b']}
 ```
-
-## TypeScript compatibility
-
-### Cannot find name 'bigint'
-
-There are 4 different ways to get rid of this compiler error:
-- Move to TypeScript >=3.2
-- Skip lib checks by adding `"skipLibCheck": true` in your `tsconfig.json`
-- Import a polyfill for type bigint: see https://www.npmjs.com/package/bigint-as-any-ts
-- Add the `declare global { type bigint = any; }` before importing fast-check
-
-More details: https://github.com/dubzzz/fast-check/issues/277

--- a/buildTypes.js
+++ b/buildTypes.js
@@ -1,0 +1,50 @@
+// @ts-check
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+/**
+ * @param {string} fileDir
+ * @returns {void}
+ */
+const mkdirRec = fileDir => {
+  if (fs.existsSync(fileDir)) return;
+
+  const parentDir = path.dirname(fileDir);
+  if (parentDir.length === 0) return;
+
+  mkdirRec(parentDir);
+  fs.mkdirSync(fileDir);
+};
+
+/**
+ * @param {string} toLabel
+ * @param {((ctn: string) => string)[]} transformations
+ * @returns {void}
+ */
+const rewriteTypesTo = (toLabel, transformations) => {
+  glob('lib/types/**/*.d.ts', {}, function(err, files) {
+    for (const f of files) {
+      const newFileName = f.replace('/types/', '/' + toLabel + '/');
+      const directoryPath = path.dirname(newFileName);
+      mkdirRec(directoryPath);
+      const originalContent = fs.readFileSync(f).toString();
+      let content = originalContent;
+      for (const t of transformations) {
+        content = t(content);
+      }
+      fs.writeFileSync(newFileName, content);
+    }
+  });
+};
+
+/**
+ * @param {string} content
+ * @returns {string}
+ */
+const bigintToAny = content => {
+  return content.replace(/([^\w\d]|^)bigint([^\w\d]|$)/g, '$1any$2');
+};
+
+rewriteTypesTo('ts3.2', []);
+rewriteTypesTo('types', [bigintToAny]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5114,9 +5114,9 @@
       "dev": true
     },
     "pure-rand": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-1.6.0.tgz",
-      "integrity": "sha512-L6ER1SlIhjuuoWf8N5J3ipzkFeBVduRgeOk87XuPdCp0xSPm4WYz9CteM7fCFaiPYVmVMkoI/nt6dRkVZ9SDNA=="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-1.6.2.tgz",
+      "integrity": "sha512-HNwHOH63m7kCxe0kWEe5jSLwJiL2N83RUUN8POniFuZS+OsbFcMWlvXgxIU2nwKy2zYG2bQan40WBNK4biYPRg=="
     },
     "qs": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lorem-ipsum": "~1.0.6",
-    "pure-rand": "^1.6.0"
+    "pure-rand": "^1.6.2"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,20 @@
   "description": "Property based testing framework for JavaScript (like QuickCheck)",
   "main": "lib/fast-check.js",
   "module": "lib/esm/fast-check.js",
-  "types": "lib/fast-check.d.ts",
+  "types": "lib/types/fast-check.d.ts",
+  "typesVersions": {
+    ">=3.2": {
+      "*": [
+        "lib/ts3.2/fast-check.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "perf": "node perf/benchmark.js",
     "profile": "node --prof --no-logfile-per-isolate --trace-deopt --trace-opt-verbose perf/profiler.js > deopt.out && node --prof-process v8.log > v8.out",
     "prebuild": "ts-node prebuild/prebuild.ts",
     "build": "tsc",
+    "build:publish-types": "tsc -p tsconfig.publish.types.json && node ./buildTypes.js",
     "build:publish-cjs": "tsc -p tsconfig.publish.json",
     "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm",
     "webbuild": "browserify lib/fast-check.js --s fastcheck | uglifyjs -cm > lib/bundle.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fast-check",
   "version": "1.9.1",
   "description": "Property based testing framework for JavaScript (like QuickCheck)",
+  "browser": "lib/bundle.js",
   "main": "lib/fast-check.js",
   "module": "lib/esm/fast-check.js",
   "types": "lib/types/fast-check.d.ts",

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
+        "declaration": false,
         "sourceMap": false
     }
 }

--- a/tsconfig.publish.types.json
+++ b/tsconfig.publish.types.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.publish.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "lib/types"
+    }
+}


### PR DESCRIPTION
As soon as it will be released, there would be no more need to use any of the workarounds defined in #277