### PR TITLE
docs: Use assert()

### DIFF
--- a/documentation/HandsOnPropertyBased.md
+++ b/documentation/HandsOnPropertyBased.md
@@ -113,9 +113,9 @@ test('should contain the same items', () => {
   fc.assert(
     fc.property(fc.array(fc.integer()), data => {
       const sorted = sort(data);
-      expect(sorted.length).toEqual(data.length);
+      assert(sorted.length === data.length);
       for (const item of data) {
-        expect(count(sorted, item)).toEqual(count(data, item));
+        assert(sorted.includes(item));
       }
     })
   );
@@ -126,7 +126,7 @@ test('should produce ordered array', () => {
     fc.property(fc.array(fc.integer()), data => {
       const sorted = sort(data);
       for (let idx = 1; idx < sorted.length; ++idx) {
-        expect(sorted[idx - 1]).toBeLessThanOrEqual(sorted[idx]);
+        assert(sorted[idx - 1] <= sorted[idx]);
       }
     })
   );


### PR DESCRIPTION
- Replaces `chai` for `assert`, in order to make it more readable for people without prior knowledge of the library.
- Also, replaces `.filter().length` with `.includes()`.