### PR TITLE
Build against node 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
  - '10'
  - '8'
  - '6'
+ - '11'
 
 cache:
   directories:


### PR DESCRIPTION
Node 11 is not a LTS version of node so it will be removed from the list as soon as node 12 becomes available.