### PR TITLE
Remove lorem-ipsum dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -523,12 +523,6 @@
       "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==",
       "dev": true
     },
-    "@types/lorem-ipsum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/lorem-ipsum/-/lorem-ipsum-1.0.2.tgz",
-      "integrity": "sha1-d7EbAoT+MV7+25oxwPHhSIRp2Zw=",
-      "dev": true
-    },
     "@types/marked": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
@@ -712,7 +706,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -874,7 +868,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2674,7 +2668,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -2721,7 +2715,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3736,14 +3730,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lorem-ipsum": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.6.tgz",
-      "integrity": "sha512-Rx4XH8X4KSDCKAVvWGYlhAfNqdUP5ZdT4rRyf0jjrvWgtViZimDIlopWNfn/y3lGM5K4uuiAoY28TaD+7YKFrQ==",
-      "requires": {
-        "minimist": "~1.2.0"
-      }
-    },
     "magic-string": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
@@ -3914,7 +3900,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -4914,7 +4901,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -5449,7 +5436,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6110,7 +6097,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -6135,7 +6122,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
     "node": ">=0.12"
   },
   "dependencies": {
-    "lorem-ipsum": "~1.0.6",
     "pure-rand": "^1.6.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.11",
-    "@types/lorem-ipsum": "^1.0.2",
     "@types/node": "^11.11.3",
     "benchmark": "^2.1.4",
     "browserify": "^16.2.3",

--- a/src/check/arbitrary/LoremArbitrary.ts
+++ b/src/check/arbitrary/LoremArbitrary.ts
@@ -1,31 +1,188 @@
-import * as loremIpsum from 'lorem-ipsum';
-
-import { Random } from '../../random/generator/Random';
+import { array } from './ArrayArbitrary';
+import { constant } from './ConstantArbitrary';
 import { Arbitrary } from './definition/Arbitrary';
-import { Shrinkable } from './definition/Shrinkable';
-import { nat } from './IntegerArbitrary';
+import { frequency } from './FrequencyArbitrary';
 
-let loremGen = loremIpsum;
-// @ts-ignore
-if (loremIpsum.default) {
-  // @ts-ignore
-  loremGen = loremIpsum.default;
-}
+/**
+ * @hidden
+ * Helper function responsible to build the entries for frequency
+ */
+const h = (v: string, w: number) => {
+  return { arbitrary: constant(v), weight: w };
+};
 
-/** @hidden */
-class LoremArbitrary extends Arbitrary<string> {
-  constructor(readonly numWords: number, readonly mode: 'words' | 'sentences' | 'paragraphs') {
-    super();
-  }
-  generate(mrng: Random): Shrinkable<string> {
-    const loremString = loremGen({
-      count: this.numWords,
-      units: this.mode,
-      random: () => mrng.nextDouble()
-    });
-    return new Shrinkable(loremString);
-  }
-}
+/**
+ * @hidden
+ * Number of occurences extracted from the lorem ipsum:
+ * https://fr.wikipedia.org/wiki/Faux-texte#Lorem_ipsum_(version_populaire)
+ *
+ * Code generated using:
+ * >  Object.entries(
+ * >    text
+ * >      .replace(/[\r\n]/g, ' ')
+ * >      .split(' ')
+ * >      .filter(w => w.length > 0)
+ * >      .map(w => w.toLowerCase())
+ * >      .map(w => w[w.length-1] === '.' ? w.substr(0, w.length -1) : w)
+ * >      .reduce((acc, cur) => { acc[cur] = (acc[cur] || 0) + 1; return acc; }, {})
+ * >  )
+ * >  .sort(([w1, n1], [w2, n2]) => n2 - n1)
+ * >  .reduce((acc, [w, n]) => acc.concat([`h(${JSON.stringify(w)}, ${n})`]), [])
+ * >  .join(',')
+ */
+const loremWord = () =>
+  frequency(
+    h('non', 6),
+    h('adipiscing', 5),
+    h('ligula', 5),
+    h('enim', 5),
+    h('pellentesque', 5),
+    h('in', 5),
+    h('augue', 5),
+    h('et', 5),
+    h('nulla', 5),
+    h('lorem', 4),
+    h('sit', 4),
+    h('sed', 4),
+    h('diam', 4),
+    h('fermentum', 4),
+    h('ut', 4),
+    h('eu', 4),
+    h('aliquam', 4),
+    h('mauris', 4),
+    h('vitae', 4),
+    h('felis', 4),
+    h('ipsum', 3),
+    h('dolor', 3),
+    h('amet,', 3),
+    h('elit', 3),
+    h('euismod', 3),
+    h('mi', 3),
+    h('orci', 3),
+    h('erat', 3),
+    h('praesent', 3),
+    h('egestas', 3),
+    h('leo', 3),
+    h('vel', 3),
+    h('sapien', 3),
+    h('integer', 3),
+    h('curabitur', 3),
+    h('convallis', 3),
+    h('purus', 3),
+    h('risus', 2),
+    h('suspendisse', 2),
+    h('lectus', 2),
+    h('nec,', 2),
+    h('ultricies', 2),
+    h('sed,', 2),
+    h('cras', 2),
+    h('elementum', 2),
+    h('ultrices', 2),
+    h('maecenas', 2),
+    h('massa,', 2),
+    h('varius', 2),
+    h('a,', 2),
+    h('semper', 2),
+    h('proin', 2),
+    h('nec', 2),
+    h('nisl', 2),
+    h('amet', 2),
+    h('duis', 2),
+    h('congue', 2),
+    h('libero', 2),
+    h('vestibulum', 2),
+    h('pede', 2),
+    h('blandit', 2),
+    h('sodales', 2),
+    h('ante', 2),
+    h('nibh', 2),
+    h('ac', 2),
+    h('aenean', 2),
+    h('massa', 2),
+    h('suscipit', 2),
+    h('sollicitudin', 2),
+    h('fusce', 2),
+    h('tempus', 2),
+    h('aliquam,', 2),
+    h('nunc', 2),
+    h('ullamcorper', 2),
+    h('rhoncus', 2),
+    h('metus', 2),
+    h('faucibus,', 2),
+    h('justo', 2),
+    h('magna', 2),
+    h('at', 2),
+    h('tincidunt', 2),
+    h('consectetur', 1),
+    h('tortor,', 1),
+    h('dignissim', 1),
+    h('congue,', 1),
+    h('non,', 1),
+    h('porttitor,', 1),
+    h('nonummy', 1),
+    h('molestie,', 1),
+    h('est', 1),
+    h('eleifend', 1),
+    h('mi,', 1),
+    h('arcu', 1),
+    h('scelerisque', 1),
+    h('vitae,', 1),
+    h('consequat', 1),
+    h('in,', 1),
+    h('pretium', 1),
+    h('volutpat', 1),
+    h('pharetra', 1),
+    h('tempor', 1),
+    h('bibendum', 1),
+    h('odio', 1),
+    h('dui', 1),
+    h('primis', 1),
+    h('faucibus', 1),
+    h('luctus', 1),
+    h('posuere', 1),
+    h('cubilia', 1),
+    h('curae,', 1),
+    h('hendrerit', 1),
+    h('velit', 1),
+    h('mauris,', 1),
+    h('gravida', 1),
+    h('ornare', 1),
+    h('ut,', 1),
+    h('pulvinar', 1),
+    h('varius,', 1),
+    h('turpis', 1),
+    h('nibh,', 1),
+    h('eros', 1),
+    h('id', 1),
+    h('aliquet', 1),
+    h('quis', 1),
+    h('lobortis', 1),
+    h('consectetuer', 1),
+    h('morbi', 1),
+    h('vehicula', 1),
+    h('tortor', 1),
+    h('tellus,', 1),
+    h('id,', 1),
+    h('eu,', 1),
+    h('quam', 1),
+    h('feugiat,', 1),
+    h('posuere,', 1),
+    h('iaculis', 1),
+    h('lectus,', 1),
+    h('tristique', 1),
+    h('mollis,', 1),
+    h('nisl,', 1),
+    h('vulputate', 1),
+    h('sem', 1),
+    h('vivamus', 1),
+    h('placerat', 1),
+    h('imperdiet', 1),
+    h('cursus', 1),
+    h('rutrum', 1),
+    h('iaculis,', 1),
+    h('augue,', 1),
+    h('lacus', 1)
+  );
 
 /**
  * For lorem ipsum strings of words
@@ -43,8 +200,19 @@ function lorem(maxWordsCount: number): Arbitrary<string>;
  */
 function lorem(maxWordsCount: number, sentencesMode: boolean): Arbitrary<string>;
 function lorem(maxWordsCount?: number, sentencesMode?: boolean): Arbitrary<string> {
-  const mode = sentencesMode ? 'sentences' : 'words';
-  return nat(maxWordsCount || 5).chain(numWords => new LoremArbitrary(numWords, mode));
+  const maxCount = maxWordsCount || 5;
+  if (maxCount < 1) throw new Error(`lorem has to produce at least one word/sentence`);
+  if (sentencesMode) {
+    const sentence = array(loremWord(), 1, 10)
+      .map(words => words.join(' '))
+      .map(s => (s[s.length - 1] === ',' ? s.substr(0, s.length - 1) : s))
+      .map(s => s[0].toUpperCase() + s.substring(1) + '.');
+    return array(sentence, 1, maxCount).map(sentences => sentences.join(' '));
+  } else {
+    return array(loremWord(), 1, maxCount).map(words =>
+      words.map(w => (w[w.length - 1] === ',' ? w.substr(0, w.length - 1) : w)).join(' ')
+    );
+  }
 }
 
 export { lorem };

--- a/test/unit/check/arbitrary/LoremArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/LoremArbitrary.spec.ts
@@ -22,15 +22,37 @@ describe('LoremArbitrary', () => {
         fc.property(fc.integer(), fc.integer(0, 100), (seed, num) => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = lorem(num).generate(mrng).value;
-          return g.indexOf('.') === -1;
+          expect(g).not.toContain('.');
         })
       ));
-    it('Should generate sentences when asked too', () =>
+    it('Should not generate commas for words', () =>
+      fc.assert(
+        fc.property(fc.integer(), fc.integer(0, 100), (seed, num) => {
+          const mrng = new Random(prand.xorshift128plus(seed));
+          const g = lorem(num).generate(mrng).value;
+          expect(g).not.toContain(',');
+        })
+      ));
+    it('Should generate sentences ending by dot', () =>
       fc.assert(
         fc.property(fc.integer(), seed => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = lorem(5, true).generate(mrng).value;
-          return g.indexOf('.') !== -1;
+          expect(g).toContain('.');
+          expect(g[g.length - 1]).toEqual('.');
+
+          // we remove the trailing dot at the end of the generated string
+          // we remove the leading space for sentences with index greater than 0
+          const sentences = g
+            .substr(0, g.length - 1)
+            .split('.')
+            .map((s, i) => (i === 0 ? s : s.substring(1)));
+          for (const s of sentences) {
+            expect(s).not.toEqual('');
+            expect(s).toMatch(/^[A-Z](, | )?([a-z]+(, | )?)*$/);
+          }
+          expect(sentences.length).toBeGreaterThanOrEqual(1);
+          expect(sentences.length).toBeLessThanOrEqual(5);
         })
       ));
   });


### PR DESCRIPTION
Fixes #335

The choices has been to removed the dependency towards lorem-ipsum package because:
- Version 2 of the package is not compatible with legacy versions of node
- Package size skyrocketed with the latest major
  - https://arve0.github.io/npm-download-size/#lorem-ipsum@2.0.0-alpha.2 - 42.8KiB for a total size of 93.9KiB
  - https://arve0.github.io/npm-download-size/#lorem-ipsum@1.0.6 - 4.9KiB for a total size of 12.4KiB
- Up to version 1, the code was doing a simple random on words: relying on built-ins of fast-check to compute the lorem will provide better shrinking capabilities