### PR TITLE
Towards cleaner arbitrary test suite

### DIFF
--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -74,6 +74,7 @@ import { ExecutionStatus } from './check/runner/reporter/ExecutionStatus';
 import { ExecutionTree } from './check/runner/reporter/ExecutionTree';
 import { cloneMethod } from './check/symbols';
 import { Stream, stream } from './stream/Stream';
+import { stringify } from './utils/stringify';
 
 // boolean
 // floating point types
@@ -170,6 +171,8 @@ export {
   Arbitrary,
   Shrinkable,
   cloneMethod,
+  // print values
+  stringify,
   // interfaces
   Context,
   ExecutionStatus,

--- a/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
@@ -82,15 +82,16 @@ describe('ArrayArbitrary', () => {
       array(withClonedAndCounter).generate(mrng);
       expect(numCallsToClone).toEqual(0);
     });
-    describe('Given no length constraints', () => {
+    it('Should pass arbitrary test suite: given no length constraints', () => {
       arbitraryTestSuite({
         arbitrary: array(nat())
       })
         .isReproducible()
         .isAlwaysLowerThanShrink(isStrictlySmallerArray)
-        .isValid((g: number[]) => Array.isArray(g) && g.every(v => typeof v === 'number'));
+        .isValid((g: number[]) => Array.isArray(g) && g.every(v => typeof v === 'number'))
+        .run();
     });
-    describe('Given maximal length only', () => {
+    it('Should pass arbitrary test suite: given maximal length only', () => {
       arbitraryTestSuite({
         arbitrary: {
           builder: (maxLength: number) => array(nat(), maxLength),
@@ -102,9 +103,10 @@ describe('ArrayArbitrary', () => {
         .isValid(
           (g: number[], maxLength: number) =>
             Array.isArray(g) && g.length <= maxLength && g.every(v => typeof v === 'number')
-        );
+        )
+        .run();
     });
-    describe('Given minimal and maximal lengths', () => {
+    it('Should pass arbitrary test suite: given minimal and maximal lengths', () => {
       arbitraryTestSuite({
         arbitrary: {
           builder: (constraints: { min: number; max: number }) => array(nat(), constraints.min, constraints.max),
@@ -119,7 +121,8 @@ describe('ArrayArbitrary', () => {
             g.length >= constraints.min &&
             g.length <= constraints.max &&
             g.every(v => typeof v === 'number')
-        );
+        )
+        .run();
     });
   });
 });

--- a/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
@@ -84,7 +84,7 @@ describe('ArrayArbitrary', () => {
     });
     it('Should pass arbitrary test suite: given no length constraints', () => {
       arbitraryTestSuite({
-        arbitrary: array(nat())
+        arbitrary: array(nat(10))
       })
         .isReproducible()
         .isAlwaysLowerThanShrink(isStrictlySmallerArray)
@@ -94,7 +94,7 @@ describe('ArrayArbitrary', () => {
     it('Should pass arbitrary test suite: given maximal length only', () => {
       arbitraryTestSuite({
         arbitrary: {
-          builder: (maxLength: number) => array(nat(), maxLength),
+          builder: (maxLength: number) => array(nat(10), maxLength),
           seed: fc.nat(100)
         }
       })
@@ -109,7 +109,7 @@ describe('ArrayArbitrary', () => {
     it('Should pass arbitrary test suite: given minimal and maximal lengths', () => {
       arbitraryTestSuite({
         arbitrary: {
-          builder: (constraints: { min: number; max: number }) => array(nat(), constraints.min, constraints.max),
+          builder: (constraints: { min: number; max: number }) => array(nat(10), constraints.min, constraints.max),
           seed: genericHelper.minMax(fc.nat(100))
         }
       })

--- a/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
+++ b/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
@@ -39,6 +39,7 @@ class ArbitraryTestSuite<T, U> {
       traverseShrink2(
         this.arbitraryBuilder.seed,
         [this.arbitraryBuilder.builder, this.arbitraryBuilder.builder],
+        () => {},
         ([v1, v2]: [T, T]) => eq(v1, v2),
         testSettings
       );
@@ -56,14 +57,17 @@ class ArbitraryTestSuite<T, U> {
   isNoInfiniteShrink(testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
     it('Should not loop in shrink [isNoInfiniteShrink]', () => {
       const neq = buildNotEq(this.equality);
-      const alreadySeen: T[] = [];
+      let shrinkHistory: T[] = [];
       traverseShrink1(
         this.arbitraryBuilder.seed,
         [this.arbitraryBuilder.builder],
+        () => {
+          shrinkHistory = [];
+        },
         ([t]: [T]) => {
           // Have we seen the value before?
-          alreadySeen.forEach(v => neq(v, t)); // throw if so
-          alreadySeen.push(t);
+          shrinkHistory.forEach(v => neq(v, t)); // throw if so
+          shrinkHistory.push(t);
         },
         testSettings
       );
@@ -80,14 +84,17 @@ class ArbitraryTestSuite<T, U> {
   ): ArbitraryTestSuite<T, U> {
     it('Should strictly decrease during shrink [isAlwaysLowerThanShrink]', () => {
       const lt = buildCmp(lowerThan, 'strictly lower');
-      let lastSeen: null | { value: T } = null;
+      let lastSeenValue: { value: T } | null = null;
       traverseShrink1(
         this.arbitraryBuilder.seed,
         [this.arbitraryBuilder.builder],
+        () => {
+          lastSeenValue = null;
+        },
         ([t]: [T]) => {
           // Strictly lower than the last one
-          if (lastSeen !== null) lt(t, lastSeen.value);
-          lastSeen = { value: t };
+          if (lastSeenValue !== null) lt(t, lastSeenValue.value);
+          lastSeenValue = { value: t };
         },
         testSettings
       );
@@ -106,6 +113,7 @@ class ArbitraryTestSuite<T, U> {
       traverseShrink1(
         this.arbitraryBuilder.seed,
         [this.arbitraryBuilder.builder],
+        () => {},
         ([t]: [T], u: U) => valid(t, u),
         testSettings
       );
@@ -127,6 +135,7 @@ class ArbitraryTestSuite<T, U> {
       traverseShrink2(
         this.arbitraryBuilder.seed,
         [this.arbitraryBuilder.builder, anotherBuilder],
+        () => {},
         ([v1, v2]: [T, T]) => eq(v1, v2),
         testSettings
       );

--- a/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
+++ b/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
@@ -1,0 +1,140 @@
+import fc from '../../../../../lib/fast-check';
+
+import { Arbitrary } from '../../../../../src/check/arbitrary/definition/Arbitrary';
+import { ArbitraryBuilder, TestSuiteSettings, buildEq, buildNotEq, buildCmp } from './helpers/TestSuiteSettings';
+import { traverseShrink1, traverseShrink2, TestSettings } from './helpers/TraverseShrink';
+
+class ArbitraryTestSuite<T, U> {
+  private readonly arbitraryBuilder: ArbitraryBuilder<T, U>;
+  private readonly equality?: (a: T, b: T) => boolean | void;
+
+  private static isArbitraryBuilder<T, U>(
+    arbitrary: ArbitraryBuilder<T, U> | Arbitrary<T>
+  ): arbitrary is ArbitraryBuilder<T, U> {
+    return (arbitrary as any).builder !== undefined && (arbitrary as any).seed !== undefined;
+  }
+  private static extractBuilder<T, U>(settings: TestSuiteSettings<T, U>): ArbitraryBuilder<T, U> {
+    const { arbitrary } = settings;
+    if (ArbitraryTestSuite.isArbitraryBuilder(arbitrary)) return arbitrary;
+    return (({
+      builder: () => arbitrary,
+      seed: fc.constant(null)
+    } as ArbitraryBuilder<T, any>) as any) as ArbitraryBuilder<T, U>;
+  }
+
+  constructor(suiteSettings: TestSuiteSettings<T, U>) {
+    this.arbitraryBuilder = ArbitraryTestSuite.extractBuilder(suiteSettings);
+    this.equality = suiteSettings.equal;
+  }
+
+  /**
+   * RECOMMENDED -
+   * Assess an arbitrary is fully reproducible
+   *
+   * Check both the generation and the shrinking
+   */
+  isReproducible(testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
+    it('Should be reproducible [isReproducible]', () => {
+      const eq = buildEq(this.equality);
+      traverseShrink2(
+        this.arbitraryBuilder.seed,
+        [this.arbitraryBuilder.builder, this.arbitraryBuilder.builder],
+        ([v1, v2]: [T, T]) => eq(v1, v2),
+        testSettings
+      );
+    });
+    return this;
+  }
+
+  /**
+   * RECOMMENDED -
+   * Assess shrink path is finite
+   * and cannot go into an infinite loop
+   *
+   * Shrink path is not producing shrank values from which it shrank
+   */
+  isNoInfiniteShrink(testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
+    it('Should not loop in shrink [isNoInfiniteShrink]', () => {
+      const neq = buildNotEq(this.equality);
+      const alreadySeen: T[] = [];
+      traverseShrink1(
+        this.arbitraryBuilder.seed,
+        [this.arbitraryBuilder.builder],
+        ([t]: [T]) => {
+          // Have we seen the value before?
+          alreadySeen.forEach(v => neq(v, t)); // throw if so
+          alreadySeen.push(t);
+        },
+        testSettings
+      );
+    });
+    return this;
+  }
+
+  /**
+   * Assess shrink path is strictly decreasing
+   */
+  isAlwaysLowerThanShrink(
+    lowerThan: (a: T, b: T) => boolean | void,
+    testSettings?: TestSettings<U>
+  ): ArbitraryTestSuite<T, U> {
+    it('Should strictly decrease during shrink [isAlwaysLowerThanShrink]', () => {
+      const lt = buildCmp(lowerThan, 'strictly lower');
+      let lastSeen: null | { value: T } = null;
+      traverseShrink1(
+        this.arbitraryBuilder.seed,
+        [this.arbitraryBuilder.builder],
+        ([t]: [T]) => {
+          // Strictly lower than the last one
+          if (lastSeen !== null) lt(t, lastSeen.value);
+          lastSeen = { value: t };
+        },
+        testSettings
+      );
+    });
+    return this;
+  }
+
+  /**
+   * Assess both generation and shrink produce valid values
+   */
+  isValid(validValue: (t: T, u: U) => boolean | void, testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
+    it('Should only produce valid values [isValid]', () => {
+      const valid = (t: T, u: U) => {
+        if (!validValue(t, u)) throw new Error(`Invalid value encountered: ${fc.stringify(t)}`);
+      };
+      traverseShrink1(
+        this.arbitraryBuilder.seed,
+        [this.arbitraryBuilder.builder],
+        ([t]: [T], u: U) => valid(t, u),
+        testSettings
+      );
+    });
+    return this;
+  }
+
+  /**
+   * Assess the arbitrary is fully equivalent to another one
+   */
+  isEquivalentTo(
+    label: string,
+    anotherArbitrary: ((u: U) => Arbitrary<T>) | Arbitrary<T>,
+    testSettings?: TestSettings<U>
+  ): ArbitraryTestSuite<T, U> {
+    const eq = buildEq(this.equality);
+    const anotherBuilder = typeof anotherArbitrary === 'function' ? anotherArbitrary : () => anotherArbitrary;
+    it(`Should be equivalent to ${label} [isEquivalentTo]`, () => {
+      traverseShrink2(
+        this.arbitraryBuilder.seed,
+        [this.arbitraryBuilder.builder, anotherBuilder],
+        ([v1, v2]: [T, T]) => eq(v1, v2),
+        testSettings
+      );
+    });
+    return this;
+  }
+}
+
+export const arbitraryTestSuite = function<T, U>(suiteSettings: TestSuiteSettings<T, U>) {
+  return new ArbitraryTestSuite<T, U>(suiteSettings);
+};

--- a/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
+++ b/test/unit/check/arbitrary/generic/ArbitraryTestSuite.ts
@@ -2,11 +2,14 @@ import fc from '../../../../../lib/fast-check';
 
 import { Arbitrary } from '../../../../../src/check/arbitrary/definition/Arbitrary';
 import { ArbitraryBuilder, TestSuiteSettings, buildEq, buildNotEq, buildCmp } from './helpers/TestSuiteSettings';
-import { traverseShrink1, traverseShrink2, TestSettings } from './helpers/TraverseShrink';
+import { TestSettings, traverseShrinkN } from './helpers/TraverseShrink';
 
 class ArbitraryTestSuite<T, U> {
   private readonly arbitraryBuilder: ArbitraryBuilder<T, U>;
   private readonly equality?: (a: T, b: T) => boolean | void;
+  private readonly builders: ((u: U) => Arbitrary<T>)[];
+  private resetAssert: () => void;
+  private assert: (t: T[], u: U) => void;
 
   private static isArbitraryBuilder<T, U>(
     arbitrary: ArbitraryBuilder<T, U> | Arbitrary<T>
@@ -25,6 +28,9 @@ class ArbitraryTestSuite<T, U> {
   constructor(suiteSettings: TestSuiteSettings<T, U>) {
     this.arbitraryBuilder = ArbitraryTestSuite.extractBuilder(suiteSettings);
     this.equality = suiteSettings.equal;
+    this.builders = [this.arbitraryBuilder.builder];
+    this.resetAssert = () => {};
+    this.assert = () => {};
   }
 
   /**
@@ -33,17 +39,17 @@ class ArbitraryTestSuite<T, U> {
    *
    * Check both the generation and the shrinking
    */
-  isReproducible(testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
-    it('Should be reproducible [isReproducible]', () => {
-      const eq = buildEq(this.equality);
-      traverseShrink2(
-        this.arbitraryBuilder.seed,
-        [this.arbitraryBuilder.builder, this.arbitraryBuilder.builder],
-        () => {},
-        ([v1, v2]: [T, T]) => eq(v1, v2),
-        testSettings
-      );
-    });
+  isReproducible(): ArbitraryTestSuite<T, U> {
+    const builderId = this.builders.length;
+    this.builders.push(this.arbitraryBuilder.builder);
+
+    const eq = buildEq(this.equality);
+    const prevAssert = this.assert;
+    this.assert = (t: T[], u: U) => {
+      eq(t[0], t[builderId]);
+      prevAssert(t, u);
+    };
+
     return this;
   }
 
@@ -54,93 +60,86 @@ class ArbitraryTestSuite<T, U> {
    *
    * Shrink path is not producing shrank values from which it shrank
    */
-  isNoInfiniteShrink(testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
-    it('Should not loop in shrink [isNoInfiniteShrink]', () => {
-      const neq = buildNotEq(this.equality);
-      let shrinkHistory: T[] = [];
-      traverseShrink1(
-        this.arbitraryBuilder.seed,
-        [this.arbitraryBuilder.builder],
-        () => {
-          shrinkHistory = [];
-        },
-        ([t]: [T]) => {
-          // Have we seen the value before?
-          shrinkHistory.forEach(v => neq(v, t)); // throw if so
-          shrinkHistory.push(t);
-        },
-        testSettings
-      );
-    });
+  isNoInfiniteShrink(): ArbitraryTestSuite<T, U> {
+    let shrinkHistory: T[] = [];
+
+    const prevResetAssert = this.resetAssert;
+    this.resetAssert = () => {
+      shrinkHistory = [];
+      prevResetAssert();
+    };
+
+    const neq = buildNotEq(this.equality);
+    const prevAssert = this.assert;
+    this.assert = (t: T[], u: U) => {
+      // Have we seen the value before?
+      shrinkHistory.forEach(v => neq(v, t[0])); // throw if so
+      shrinkHistory.push(t[0]);
+
+      // Other assertions
+      prevAssert(t, u);
+    };
     return this;
   }
 
   /**
    * Assess shrink path is strictly decreasing
    */
-  isAlwaysLowerThanShrink(
-    lowerThan: (a: T, b: T) => boolean | void,
-    testSettings?: TestSettings<U>
-  ): ArbitraryTestSuite<T, U> {
-    it('Should strictly decrease during shrink [isAlwaysLowerThanShrink]', () => {
-      const lt = buildCmp(lowerThan, 'strictly lower');
-      let lastSeenValue: { value: T } | null = null;
-      traverseShrink1(
-        this.arbitraryBuilder.seed,
-        [this.arbitraryBuilder.builder],
-        () => {
-          lastSeenValue = null;
-        },
-        ([t]: [T]) => {
-          // Strictly lower than the last one
-          if (lastSeenValue !== null) lt(t, lastSeenValue.value);
-          lastSeenValue = { value: t };
-        },
-        testSettings
-      );
-    });
+  isAlwaysLowerThanShrink(lowerThan: (a: T, b: T) => boolean | void): ArbitraryTestSuite<T, U> {
+    let lastSeenValue: { value: T } | null = null;
+
+    const prevResetAssert = this.resetAssert;
+    this.resetAssert = () => {
+      lastSeenValue = null;
+      prevResetAssert();
+    };
+
+    const lt = buildCmp(lowerThan, 'strictly lower');
+    const prevAssert = this.assert;
+    this.assert = (t: T[], u: U) => {
+      // Strictly lower than the last one
+      if (lastSeenValue !== null) lt(t[0], lastSeenValue.value);
+      lastSeenValue = { value: t[0] };
+
+      // Other assertions
+      prevAssert(t, u);
+    };
     return this;
   }
 
   /**
    * Assess both generation and shrink produce valid values
    */
-  isValid(validValue: (t: T, u: U) => boolean | void, testSettings?: TestSettings<U>): ArbitraryTestSuite<T, U> {
-    it('Should only produce valid values [isValid]', () => {
-      const valid = (t: T, u: U) => {
-        if (!validValue(t, u)) throw new Error(`Invalid value encountered: ${fc.stringify(t)}`);
-      };
-      traverseShrink1(
-        this.arbitraryBuilder.seed,
-        [this.arbitraryBuilder.builder],
-        () => {},
-        ([t]: [T], u: U) => valid(t, u),
-        testSettings
-      );
-    });
+  isValid(validValue: (t: T, u: U) => boolean | void): ArbitraryTestSuite<T, U> {
+    const prevAssert = this.assert;
+    this.assert = (t: T[], u: U) => {
+      if (!validValue(t[0], u)) throw new Error(`Invalid value encountered: ${fc.stringify(t)}`);
+      prevAssert(t, u);
+    };
     return this;
   }
 
   /**
    * Assess the arbitrary is fully equivalent to another one
    */
-  isEquivalentTo(
-    label: string,
-    anotherArbitrary: ((u: U) => Arbitrary<T>) | Arbitrary<T>,
-    testSettings?: TestSettings<U>
-  ): ArbitraryTestSuite<T, U> {
-    const eq = buildEq(this.equality);
+  isEquivalentTo(anotherArbitrary: ((u: U) => Arbitrary<T>) | Arbitrary<T>): ArbitraryTestSuite<T, U> {
+    const builderId = this.builders.length;
+
     const anotherBuilder = typeof anotherArbitrary === 'function' ? anotherArbitrary : () => anotherArbitrary;
-    it(`Should be equivalent to ${label} [isEquivalentTo]`, () => {
-      traverseShrink2(
-        this.arbitraryBuilder.seed,
-        [this.arbitraryBuilder.builder, anotherBuilder],
-        () => {},
-        ([v1, v2]: [T, T]) => eq(v1, v2),
-        testSettings
-      );
-    });
+    this.builders.push(anotherBuilder);
+
+    const eq = buildEq(this.equality);
+    const prevAssert = this.assert;
+    this.assert = (t: T[], u: U) => {
+      eq(t[0], t[builderId]);
+      prevAssert(t, u);
+    };
+
     return this;
+  }
+
+  run(testSettings?: TestSettings<U>): void {
+    traverseShrinkN(this.arbitraryBuilder.seed, this.builders, this.resetAssert, this.assert, testSettings);
   }
 }
 

--- a/test/unit/check/arbitrary/generic/helpers/TestSuiteSettings.ts
+++ b/test/unit/check/arbitrary/generic/helpers/TestSuiteSettings.ts
@@ -1,0 +1,41 @@
+import fc from '../../../../../../lib/fast-check';
+
+import { Arbitrary } from '../../../../../../src/check/arbitrary/definition/Arbitrary';
+
+export type ArbitraryBuilder<T, U> = {
+  builder: (u: U) => Arbitrary<T>;
+  seed: fc.Arbitrary<U>;
+};
+
+type Cmp<T> = (a: T, b: T) => boolean | void;
+type ThrowCmp<T> = (a: T, b: T) => void;
+
+export type TestSuiteSettings<T, U = any> = {
+  arbitrary: ArbitraryBuilder<T, U> | Arbitrary<T>;
+  equal?: Cmp<T>;
+};
+
+export function buildEq<T>(eq?: Cmp<T>): ThrowCmp<T> {
+  return eq
+    ? buildCmp(eq, 'equal')
+    : (a: T, b: T) => {
+        expect(a).toEqual(b);
+      };
+}
+export function buildNotEq<T>(eq?: Cmp<T>): ThrowCmp<T> {
+  return eq
+    ? buildNotCmp(eq, 'equal')
+    : (a: T, b: T) => {
+        expect(a).not.toStrictEqual(b);
+      };
+}
+export function buildCmp<T>(cmp: Cmp<T>, label: string): ThrowCmp<T> {
+  return (a: T, b: T) => {
+    if (!cmp(a, b)) throw new Error(`<a> is not ${label} to <b>\na = ${fc.stringify(a)}\nb = ${fc.stringify(b)}`);
+  };
+}
+export function buildNotCmp<T>(cmp: Cmp<T>, label: string): ThrowCmp<T> {
+  return (a: T, b: T) => {
+    if (cmp(a, b)) throw new Error(`<a> is ${label} to <b>\na = ${fc.stringify(a)}\nb = ${fc.stringify(b)}`);
+  };
+}

--- a/test/unit/check/arbitrary/generic/helpers/TraverseShrink.ts
+++ b/test/unit/check/arbitrary/generic/helpers/TraverseShrink.ts
@@ -1,0 +1,61 @@
+import * as prand from 'pure-rand';
+import fc, { Parameters } from '../../../../../../lib/fast-check';
+
+import { Arbitrary } from '../../../../../../src/check/arbitrary/definition/Arbitrary';
+import { Shrinkable } from '../../../../../../src/check/arbitrary/definition/Shrinkable';
+import { Random } from '../../../../../../src/random/generator/Random';
+
+export type TestSettings<U> = Parameters<[[number, number[]], U]>;
+
+function traverseShrinkN<T, U>(
+  seedProducer: fc.Arbitrary<U>,
+  arbitraryBuilders: ((u: U) => Arbitrary<T>)[],
+  assertFunction: (args: T[], u: U) => void,
+  testSettings?: TestSettings<U>
+): void {
+  fc.assert(
+    fc.property(
+      fc.tuple(fc.integer().noShrink(), fc.array(fc.nat(), 1, 10)),
+      seedProducer,
+      ([seed, shrinkPath], arbitrarySettings) => {
+        const arbs = arbitraryBuilders.map(b => b(arbitrarySettings));
+        const shrinkables: (Shrinkable<T> | null)[] = arbs.map(a =>
+          a.generate(new Random(prand.xorshift128plus(seed)))
+        );
+
+        expect(shrinkables.every(s => s !== null)).toBe(true);
+
+        let id = 0;
+        while (shrinkables.some(s => s !== null)) {
+          // Assert
+          assertFunction(shrinkables.map(s => s!.value), arbitrarySettings); // throw if failure
+
+          // Go to the next level of shrink
+          const shrinkOffset = shrinkPath[id++];
+          for (let i = 0; i !== shrinkables.length; ++i)
+            shrinkables[i] = shrinkables[i]!.shrink().getNthOrLast(shrinkOffset);
+          id = (id + 1) % shrinkPath.length;
+        }
+      }
+    ),
+    testSettings
+  );
+}
+
+export function traverseShrink1<T, U>(
+  seedProducer: fc.Arbitrary<U>,
+  arbitraryBuilders: [(u: U) => Arbitrary<T>],
+  assertFunction: (args: [T], u: U) => void,
+  testSettings?: TestSettings<U>
+): void {
+  return traverseShrinkN(seedProducer, arbitraryBuilders, assertFunction, testSettings);
+}
+
+export function traverseShrink2<T, U>(
+  seedProducer: fc.Arbitrary<U>,
+  arbitraryBuilders: [(u: U) => Arbitrary<T>, (u: U) => Arbitrary<T>],
+  assertFunction: (args: [T, T], u: U) => void,
+  testSettings?: TestSettings<U>
+): void {
+  return traverseShrinkN(seedProducer, arbitraryBuilders, assertFunction, testSettings);
+}

--- a/test/unit/check/arbitrary/generic/helpers/TraverseShrink.ts
+++ b/test/unit/check/arbitrary/generic/helpers/TraverseShrink.ts
@@ -5,7 +5,9 @@ import { Arbitrary } from '../../../../../../src/check/arbitrary/definition/Arbi
 import { Shrinkable } from '../../../../../../src/check/arbitrary/definition/Shrinkable';
 import { Random } from '../../../../../../src/random/generator/Random';
 
-export type TestSettings<U> = Parameters<[[number, number, number], U]>;
+export type TestSettings<U> = Parameters<
+  [{ seed: number; shrinkPathSeed: number; bias: number | null; arbitrarySettings: U }]
+>;
 
 const seedArbitrary = fc.integer().noShrink();
 const biasArbitrary = fc.option(fc.integer(2, 10).noShrink());
@@ -27,9 +29,13 @@ export function traverseShrinkN<T, U>(
 ): void {
   fc.assert(
     fc.property(
-      fc.tuple(seedArbitrary, seedArbitrary, biasArbitrary),
-      seedProducer,
-      ([seed, shrinkPathSeed, bias], arbitrarySettings) => {
+      fc.record({
+        seed: seedArbitrary,
+        shrinkPathSeed: seedArbitrary,
+        bias: biasArbitrary,
+        arbitrarySettings: seedProducer
+      }),
+      ({ seed, shrinkPathSeed, bias, arbitrarySettings }) => {
         resetAssertFunction();
 
         // Generate base shrinkables


### PR DESCRIPTION
Today arbitraries are checked using the helper function `genericHelper.isValidArbitrary`.

But this helper comes with very poor traces and proved difficult to troubleshoot when adding new arbitraries to fast-check.