### PR TITLE
Add minimum and maximum validation to integer and nat

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@ This file contains a list of people who've made non-trivial contribution to **fa
 People who commit code to the project are encouraged to add their names here. Please keep the list sorted by first names.
 
 - [Aaron Elligsen](https://github.com/hath995)
+- [Diego Pedro](https://github/diegopedro94)
 - [Nicolas Dubien](https://github.com/dubzzz)
 - [Gjorgji Kjosev](https://github.com/spion)
 - [Trey Davis](https://github.com/treydavis)

--- a/src/check/arbitrary/IntegerArbitrary.ts
+++ b/src/check/arbitrary/IntegerArbitrary.ts
@@ -59,6 +59,7 @@ function integer(max: number): ArbitraryWithShrink<number>;
  */
 function integer(min: number, max: number): ArbitraryWithShrink<number>;
 function integer(a?: number, b?: number): ArbitraryWithShrink<number> {
+  if (a && b && a > b) throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
   return b === undefined ? new IntegerArbitrary(undefined, a) : new IntegerArbitrary(a, b);
 }
 
@@ -79,6 +80,7 @@ function nat(): ArbitraryWithShrink<number>;
  */
 function nat(max: number): ArbitraryWithShrink<number>;
 function nat(a?: number): ArbitraryWithShrink<number> {
+  if (a && a < 0) throw new Error('fc.nat value should be greater than or equal to 0');
   return new IntegerArbitrary(0, a);
 }
 

--- a/src/check/arbitrary/IntegerArbitrary.ts
+++ b/src/check/arbitrary/IntegerArbitrary.ts
@@ -59,7 +59,8 @@ function integer(max: number): ArbitraryWithShrink<number>;
  */
 function integer(min: number, max: number): ArbitraryWithShrink<number>;
 function integer(a?: number, b?: number): ArbitraryWithShrink<number> {
-  if (a && b && a > b) throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
+  if (a !== undefined && b !== undefined && a > b)
+    throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
   return b === undefined ? new IntegerArbitrary(undefined, a) : new IntegerArbitrary(a, b);
 }
 
@@ -80,7 +81,7 @@ function nat(): ArbitraryWithShrink<number>;
  */
 function nat(max: number): ArbitraryWithShrink<number>;
 function nat(a?: number): ArbitraryWithShrink<number> {
-  if (a && a < 0) throw new Error('fc.nat value should be greater than or equal to 0');
+  if (a !== undefined && a < 0) throw new Error('fc.nat value should be greater than or equal to 0');
   return new IntegerArbitrary(0, a);
 }
 

--- a/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
@@ -146,6 +146,9 @@ describe('IntegerArbitrary', () => {
           return -log2(-min) <= g && g <= log2(max);
         })
       ));
+    it('Should throw when minimum number is greater than maximum one', () => {
+      expect(() => integer(-1, -5)).toThrowError();
+    });
     describe('Given no constraints [between -2**31 and 2**31 -1]', () => {
       genericHelper.isValidArbitrary(() => integer(), {
         isStrictlySmallerValue: isStrictlySmallerInteger,
@@ -181,6 +184,9 @@ describe('IntegerArbitrary', () => {
     });
   });
   describe('nat', () => {
+    it('Should throw when the number is less than 0', () => {
+      expect(() => nat(-1)).toThrowError();
+    });
     describe('Given no constraints [between 0 and 2**31 -1]', () => {
       genericHelper.isValidArbitrary(() => nat(), {
         isStrictlySmallerValue: isStrictlySmallerInteger,

--- a/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
@@ -146,9 +146,14 @@ describe('IntegerArbitrary', () => {
           return -log2(-min) <= g && g <= log2(max);
         })
       ));
-    it('Should throw when minimum number is greater than maximum one', () => {
-      expect(() => integer(-1, -5)).toThrowError();
-    });
+    it('Should throw when minimum number is greater than maximum one', () =>
+      fc.assert(
+        fc.property(fc.integer(), fc.integer(), (a, b) => {
+          fc.pre(a !== b);
+          if (a < b) expect(() => integer(b, a)).toThrowError();
+          else expect(() => integer(a, b)).toThrowError();
+        })
+      ));
     describe('Given no constraints [between -2**31 and 2**31 -1]', () => {
       genericHelper.isValidArbitrary(() => integer(), {
         isStrictlySmallerValue: isStrictlySmallerInteger,
@@ -184,9 +189,12 @@ describe('IntegerArbitrary', () => {
     });
   });
   describe('nat', () => {
-    it('Should throw when the number is less than 0', () => {
-      expect(() => nat(-1)).toThrowError();
-    });
+    it('Should throw when the number is less than 0', () =>
+      fc.assert(
+        fc.property(fc.integer(Number.MIN_SAFE_INTEGER, -1), n => {
+          expect(() => nat(n)).toThrowError();
+        })
+      ));
     describe('Given no constraints [between 0 and 2**31 -1]', () => {
       genericHelper.isValidArbitrary(() => nat(), {
         isStrictlySmallerValue: isStrictlySmallerInteger,


### PR DESCRIPTION
Fixes #293 

@dubzzz I noticed that BigInt and Float arbitraries have the same issue. If this solution is valid for you, I can take care of those cases in this PR as well.
