### PR TITLE
Fix type inferrence bug in modelRun

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ People who commit code to the project are encouraged to add their names here. Pl
 - [Nicolas Dubien](https://github.com/dubzzz)
 - [Gjorgji Kjosev](https://github.com/spion)
 - [Trey Davis](https://github.com/treydavis)
+- [Peter Hamilton](https://github.com/hamiltop)

--- a/src/check/model/ModelRunner.ts
+++ b/src/check/model/ModelRunner.ts
@@ -80,8 +80,8 @@ const internalAsyncModelRun = async <Model extends object, Real, CheckAsync exte
  * @param s Initial state provider
  * @param cmds Synchronous commands to be executed
  */
-export const modelRun = <Model extends object, Real>(
-  s: Setup<Model, Real>,
+export const modelRun = <Model extends object, Real, InitialModel extends Model>(
+  s: Setup<InitialModel, Real>,
   cmds: Iterable<Command<Model, Real>> | CommandsIterable<Model, Real, void>
 ): void => {
   internalModelRun(s, cmds);
@@ -95,8 +95,8 @@ export const modelRun = <Model extends object, Real>(
  * @param s Initial state provider
  * @param cmds Asynchronous commands to be executed
  */
-export const asyncModelRun = async <Model extends object, Real, CheckAsync extends boolean>(
-  s: Setup<Model, Real> | AsyncSetup<Model, Real>,
+export const asyncModelRun = async <Model extends object, Real, CheckAsync extends boolean, InitialModel extends Model>(
+  s: Setup<InitialModel, Real> | AsyncSetup<InitialModel, Real>,
   cmds: Iterable<AsyncCommand<Model, Real, CheckAsync>> | CommandsIterable<Model, Real, Promise<void>, CheckAsync>
 ): Promise<void> => {
   await internalAsyncModelRun(s, cmds);


### PR DESCRIPTION
Example of bug:
```
interface Model {
  foo: string;
  bar: number;
}

type Real = number;

class Command implements fc.Command<Model, Real> {
  check(m: Model) {
    return true;
  }
  run(m: Model, r: Real) {}
  toString() {
    return "";
  }
}

it("should fail typecheck", () => {
  return fc.assert(
    fc.property(fc.commands([fc.constant(new Command())]), cmds => {
      const c = 5;
      return fc.modelRun(
        () => ({ model: { foo: "what about bar?" }, real: c }),
        cmds
      );
    })
  );
});
```
This should ideally not type-check, because `{foo: "what about bar?"}` does not meet the requirement s for the `Model` interface. The generic type parameters for `modelRun` are inferred to be `<{foo: string}, number>` and conveniently `Command<Model, number>` structurally matches `Command<{foo: string", number>` which is why the typescript misses this.

In this PR, I introduce another type parameter for `modelRun` that explicitly extends the other type parameter. This forces the setup function to structurally match the type parameter in the commands rather than the other way around.