### PR TITLE
Reduce flakyness of letrec e2e tests

### DIFF
--- a/documentation/1-Guides/Arbitraries.md
+++ b/documentation/1-Guides/Arbitraries.md
@@ -130,8 +130,11 @@ Default for `values` are: `fc.boolean()`, `fc.integer()`, `fc.double()`, `fc.str
 ```typescript
 const { tree } = fc.letrec(tie => ({
   // tree is 1 / 3 of node, 2 / 3 of leaf
-  // Warning: if the probability of nodes equals or is greater
-  //          than the one of leafs we might generate infinite trees
+  // Warning: as there is no control over the depth of the data-structures generated
+  //   by letrec, high probability of node can lead to very deep trees
+  //   thus we limit the probability of a node to p = 1 / 3 in this example
+  // with p = 0.50 the probability to have a tree of depth above 10 is 13.9 %
+  // with p = 0.33 the probability to have a tree of depth above 10 is  0.6 %
   tree: fc.oneof(tie('node'), tie('leaf'), tie('leaf')),
   node: fc.tuple(tie('tree'), tie('tree')),
   leaf: fc.nat()
@@ -142,8 +145,7 @@ tree() // Is a tree arbitrary (as fc.nat() is an integer arbitrary)
 - `fc.memo<T>(builder: (n: number) => Arbitrary<T>): ((n?: number) => Arbitrary<T>)` produce arbitraries as specified by builder function. Contrary to `fc.letrec`, `fc.memo` can control the maximal depth of your recursive structure by relying on the `n` parameter given as input of the `builder` function
 
 ```typescript
-// tree is 1 / 3 of node, 2 / 3 of leaf
-const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf(), leaf()));
+const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf()));
 const node: fc.Memo<Tree> = fc.memo(n => {
   if (n <= 1) return fc.record({ left: leaf(), right: leaf() });
   return fc.record({ left: tree(), right: tree() }); // tree() is equivalent to tree(n-1)

--- a/test/e2e/arbitraries/LetRecArbitrary.spec.ts
+++ b/test/e2e/arbitraries/LetRecArbitrary.spec.ts
@@ -15,8 +15,7 @@ describe(`LetRecArbitrary (seed: ${seed})`, () => {
     });
     it('Should be usable to build deep tree instances', () => {
       const { tree } = fc.letrec(tie => ({
-        // tree is 1 / 3 of node, 2 / 3 of leaf
-        tree: fc.oneof(tie('node'), tie('leaf'), tie('leaf')),
+        tree: fc.frequency({ arbitrary: tie('node'), weight: 45 }, { arbitrary: tie('leaf'), weight: 55 }),
         node: fc.tuple(tie('tree'), tie('tree')),
         leaf: fc.nat()
       }));

--- a/test/e2e/arbitraries/MemoArbitrary.spec.ts
+++ b/test/e2e/arbitraries/MemoArbitrary.spec.ts
@@ -12,9 +12,7 @@ describe(`MemoArbitrary (seed: ${seed})`, () => {
   describe('memo', () => {
     it('Should be able to build deep tree instances (manual depth)', () => {
       const leaf = fc.nat;
-
-      // tree is 1 / 3 of node, 2 / 3 of leaf
-      const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf(), leaf()));
+      const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf()));
       const node: fc.Memo<Tree> = fc.memo(n => {
         if (n <= 1) return fc.record({ left: leaf(), right: leaf() });
         return fc.record({ left: tree(), right: tree() }); // tree() is equivalent to tree(n-1)
@@ -35,9 +33,7 @@ describe(`MemoArbitrary (seed: ${seed})`, () => {
     });
     it('Should be able to build tree instances with limited depth (manual depth)', () => {
       const leaf = fc.nat;
-
-      // tree is 1 / 3 of node, 2 / 3 of leaf
-      const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf(), leaf()));
+      const tree: fc.Memo<Tree> = fc.memo(n => fc.oneof(node(n), leaf()));
       const node: fc.Memo<Tree> = fc.memo(n => {
         if (n <= 1) return fc.record({ left: leaf(), right: leaf() });
         return fc.record({ left: tree(), right: tree() }); // tree() is equivalent to tree(n-1)

--- a/test/legacy/main.js
+++ b/test/legacy/main.js
@@ -98,7 +98,7 @@ testArbitrary(
 testArbitrary(
   (function() {
     const tree = fc.memo(function(n) {
-      return fc.oneof(node(n), leaf(), leaf());
+      return fc.oneof(node(n), leaf());
     });
     const node = fc.memo(function(n) {
       if (n <= 1) return fc.record({ left: leaf(), right: leaf() });


### PR DESCRIPTION
## Why is this PR for?

Reduce the flakyness of one of the end-to-end tests on `fc.letrec`.

The test generated trees with a probability to generate a node instance of 1/3.
This probability was too small to ensure that we can find trees of depth >=5 with a high certainty (it failed 1 run every 104 runs).

We increased the probability of generating a node to 45 %.
It provides a very high stability of the test that will theoretically fail every 18.087.934 runs.

## In a nutshell

- [ ] New feature
- [x] Fix an issue
- [ ] Documentation improvement
- [ ] Other: *please explain*

## Potential impacts

None