### PR TITLE
Generate string representations of JS objects in fc.object/fc.anything

### DIFF
--- a/documentation/1-Guides/Arbitraries.md
+++ b/documentation/1-Guides/Arbitraries.md
@@ -110,6 +110,7 @@ export module ObjectConstraints {
         withBoxedValues?: boolean; // adapt all entries within `values` to generate boxed version of the value too
         withMap?: boolean;         // also generate Map
         withSet?: boolean;         // also generate Set
+        withObjectString?: boolean;// also generate string representations of object instances
     };
 };
 ```

--- a/test/e2e/GenerateAllValues.spec.ts
+++ b/test/e2e/GenerateAllValues.spec.ts
@@ -57,7 +57,7 @@ describe(`Generate all values (seed: ${seed})`, () => {
       it(`should be able to generate ${label}`, () => {
         let numTries = 0;
         const mrng = new fc.Random(prand.xorshift128plus(seed));
-        const arb = fc.anything({ withBoxedValues: true, withMap: true, withSet: true });
+        const arb = fc.anything({ withBoxedValues: true, withMap: true, withSet: true, withObjectString: true });
         while (++numTries <= 10000) {
           const { value } = arb.generate(mrng);
           if (typeof value === typeofLabel && Object.prototype.toString.call(value) === toStringLabel) {

--- a/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
@@ -203,7 +203,8 @@ describe('ObjectArbitrary', () => {
               values: fc.constant([constant('single-value')]),
               withBoxedValues: fc.boolean(),
               withMap: fc.boolean(),
-              withSet: fc.boolean()
+              withSet: fc.boolean(),
+              withObjectString: fc.boolean()
             },
             { withDeletedKeys: true }
           ),


### PR DESCRIPTION
## Why is this PR for?

The current implementation of `fc.object`/`fc.anything` was rarely able to generate strings looking as string representations of real objects. As this kind of objects is a known source of issues in computer science, I wanted to add an easy way to generate some of those instances.

By settings `withObjectString` to `true` on your `fc.object` arbitraries you'll be able to get strings looking as objects more often (as values but also as keys).

## In a nutshell

- [x] New feature
- [ ] Fix an issue
- [ ] Documentation improvement
- [ ] Other: *please explain*

## Potential impacts

No impact expected as the feature has been added as a flag.
We might find ways to put such flag as the default in the future.
