### PR TITLE
Document how to add new arbitraries into fast-check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,40 @@ You should also check for linting by running `npm run lint:check`.
 
 All pull requests will trigger Travis CI builds.
 It ensures that the pull request follow the code style of the project and do not break existing tests.
+
+#### Adding a new arbitrary
+
+✔️ *Create a feature request*
+
+Before adding any new arbitrary into fast-check please make sure to fill a `Feature request` to justify the need for such arbitrary.
+
+✔️ *Code the arbitrary*
+
+All the arbitraries defined by fast-check are available in `src/check/arbitrary`.
+Create a new file for the new one if it does not fit into the existing ones.
+
+✔️ *Test the arbitrary*
+
+Most of the newly added arbitraries will just be a combination of existing ones (mostly mapping from one entry to another).
+We expect a quite minimal amount of tests to be added as most of the logic depends on the built-in blocks.
+
+- *Unit-test* - in `test/unit/check/arbitrary`
+
+```js
+import { myArb } from '../../../../src/check/arbitrary/MyArbitrary';
+import * as genericHelper from './generic/GenericArbitraryHelper';
+
+describe('MyArbitrary', () => {
+  describe('myArb', () => {
+    // genericHelper.isValidArbitrary is repsonsible to ensure that the arbitrary is valid
+    // and fulfill the minimum requirements asked by fast-check
+    genericHelper.isValidArbitrary((settings) => myArb(settings), {
+      isValidValue: (g: MyArbGeneratedType, settings) => isValidMyArbOutput(g),
+      seedGenerator: anArbitraryProducingSettingsExpectedByMyArb // optional field
+    });
+  });
+});
+```
+
+- No regression test - in `test/e2e/NoRegression.spec.ts`
+- Legacy support test - in `test/legacy/main.js`


### PR DESCRIPTION
## Why is this PR for?

Adding a new arbitrary within fast-check was not so easy for people outside of the project because it required to use some very specific helpers to assess the arbitrary is ok.

The contributing file has been updated to help people understand what to edit in case they want to contribute and add arbitraries.

## In a nutshell

- [ ] New feature
- [ ] Fix an issue
- [x] Documentation improvement
- [ ] Other: *please explain*

## Potential impacts

None.
