### PR TITLE
Docs: Use diff format in shrinking example

### DIFF
--- a/documentation/1-Guides/HandsOnPropertyBased.md
+++ b/documentation/1-Guides/HandsOnPropertyBased.md
@@ -141,7 +141,7 @@ Copy and paste the code above into `specs/sort.spec.ts` and run `npm run test`.
 
 If you want to experiment shrinking you might change the `sort` implementation as follow:
 
-```ts
+```diff
 --- if (!cmp(tab[start], tab[idx])) {
 +++ if (cmp(tab[start], tab[idx])) {
 ```


### PR DESCRIPTION
##  Why is this PR for?

Uses `diff` syntax highlighting in a code example. It looks like this is what you were going for with the `---`/`+++`. Note that only 1 line is changed (the github UI highlights the 2 lines below but that's actually the preview :P

## In a nutshell

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.
