### PR TITLE
skipAllAfterTimeLimit throws an error instead of skipping tests

### DIFF
--- a/src/check/property/SkipAfterProperty.ts
+++ b/src/check/property/SkipAfterProperty.ts
@@ -1,5 +1,5 @@
 import { Random } from '../../random/generator/Random';
-import { pre } from '../precondition/Pre';
+import { PreconditionFailure } from '../precondition/PreconditionFailure';
 import { IProperty } from './IProperty';
 
 /** @hidden */
@@ -11,7 +11,9 @@ export class SkipAfterProperty<Ts> implements IProperty<Ts> {
   isAsync = () => this.property.isAsync();
   generate = (mrng: Random, runId?: number) => this.property.generate(mrng, runId);
   run = (v: Ts) => {
-    pre(this.getTime() < this.skipAfterTime);
+    if (this.getTime() >= this.skipAfterTime) {
+      return new PreconditionFailure();
+    }
     return this.property.run(v);
   };
 }

--- a/test/e2e/SkipAllAfterTime.spec.ts
+++ b/test/e2e/SkipAllAfterTime.spec.ts
@@ -1,0 +1,20 @@
+import * as fc from '../../src/fast-check';
+
+const seed = Date.now();
+describe(`SkipAllAfterTime (seed: ${seed})`, () => {
+  it('should skip as soon as delay expires and mark run as failed', () => {
+    let numRuns = 0;
+    const out = fc.check(
+      fc.property(fc.integer(), x => {
+        ++numRuns;
+        return true;
+      }),
+      { skipAllAfterTimeLimit: 0 }
+    );
+    expect(out.failed).toBe(true); // Not enough tests have been executed
+    expect(out.numRuns).toBe(0);
+    expect(out.numShrinks).toBe(0);
+    expect(out.numSkips).toBe(10001); // maxSkipsPerRun(100) * numRuns(100) +1
+    expect(numRuns).toBe(0); // Expired immediately (timeout = 0)
+  });
+});

--- a/test/unit/check/property/SkipAfterProperty.spec.ts
+++ b/test/unit/check/property/SkipAfterProperty.spec.ts
@@ -3,6 +3,7 @@ import { SkipAfterProperty } from '../../../../src/check/property/SkipAfterPrope
 
 // Mocks
 import { Random } from '../../../../src/random/generator/Random';
+import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure';
 jest.mock('../../../../src/random/generator/Random');
 
 function buildProperty() {
@@ -73,8 +74,9 @@ describe('SkipAfterProperty', () => {
     const { mocks: propertyMock, property } = buildProperty();
 
     const p = new SkipAfterProperty(property, timerMock, timeLimitMs);
-    expect(() => p.run({})).toThrowError();
+    const out = p.run({});
 
+    expect(PreconditionFailure.isFailure(out)).toBe(true);
     expect(timerMock.mock.calls.length).toBe(2);
     expect(propertyMock.isAsync.mock.calls.length).toBe(0);
     expect(propertyMock.generate.mock.calls.length).toBe(0);


### PR DESCRIPTION
## Why is this PR for?

Related to #423

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
✔️/❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

If you expect some noticeable impacts with your change please explain.

Here are some examples of impacts that might be reported into this section:
- Run execution

Here are the possible scenarii:
- the code was never reaching the timeout: no change expected
- the code was reaching a timeout during generation phase: it still throws but this time it throws and tell the user that it has not succeeded to generate enough values to conclude (before it was a crash of fast-check)
- the code was reaching a timeout during shrinking phase: it still throws but this time it throws a classical fast-check error with a shrink that has been stopped at the middle (before it was a crash of fast-check)
