### PR TITLE
Prepare for TypeScript 3.7 and PR 33401

### DIFF
--- a/test/unit/check/arbitrary/LetRecArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/LetRecArbitrary.spec.ts
@@ -181,7 +181,11 @@ describe('LetRecArbitrary', () => {
 
 const buildArbitrary = (generate: (mrng: Random) => Shrinkable<any>, withBias?: (n: number) => Arbitrary<any>) => {
   return new (class extends Arbitrary<any> {
-    generate = generate;
-    withBias = (n: number): Arbitrary<any> => (withBias ? withBias(n) : this);
+    generate(mrng: Random) {
+      return generate(mrng);
+    }
+    withBias(n: number): Arbitrary<any> {
+      return withBias ? withBias(n) : this;
+    }
   })();
 };

--- a/test/unit/check/arbitrary/MemoArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/MemoArbitrary.spec.ts
@@ -139,7 +139,11 @@ describe('MemoArbitrary', () => {
 
 const buildArbitrary = (generate: (mrng: Random) => Shrinkable<any>, withBias?: (n: number) => Arbitrary<any>) => {
   return new (class extends Arbitrary<any> {
-    generate = generate;
-    withBias = (n: number): Arbitrary<any> => (withBias ? withBias(n) : this);
+    generate(mrng: Random) {
+      return generate(mrng);
+    }
+    withBias(n: number): Arbitrary<any> {
+      return withBias ? withBias(n) : this;
+    }
   })();
 };

--- a/test/unit/check/arbitrary/TupleArbitrary.generic.spec.ts
+++ b/test/unit/check/arbitrary/TupleArbitrary.generic.spec.ts
@@ -83,13 +83,13 @@ describe('TupleArbitrary', () => {
       [cloneMethod] = () => new CloneableInstance();
     }
     const cloneableArbitrary = new (class extends Arbitrary<CloneableInstance> {
-      generate = () => {
+      generate() {
         function* g() {
           yield new Shrinkable(new CloneableInstance());
           yield new Shrinkable(new CloneableInstance());
         }
         return new Shrinkable(new CloneableInstance(), () => stream(g()));
-      };
+      }
     })();
     const arbs = genericTuple([nat(16), cloneableArbitrary, nat(16)] as Arbitrary<any>[]);
     const extractId = (shrinkable: Shrinkable<[number, CloneableInstance, number]>) => shrinkable.value_[1].id;

--- a/test/unit/check/runner/Sampler.spec.ts
+++ b/test/unit/check/runner/Sampler.spec.ts
@@ -69,7 +69,9 @@ describe('Sampler', () => {
         }
       };
       const arb = new (class extends Arbitrary<typeof cloneable> {
-        generate = () => new Shrinkable(cloneable);
+        generate() {
+          return new Shrinkable(cloneable);
+        }
       })();
       sample(arb, { seed: 42 });
     });


### PR DESCRIPTION
## Why is this PR for?

The preview version of TypeScript in https://github.com/microsoft/TypeScript/pull/33401 requires some code changes to be done in the unit-tests of fast-check.

No other breaking changes detected.

See https://github.com/dubzzz/fast-check/tree/ts3.7-pr33401

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.
