### PR TITLE
any -> unknown in exported signatures for object/anything arbitraries

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ People who commit code to the project are encouraged to add their names here. Pl
 - [Aaron Elligsen](https://github.com/hath995)
 - [Diego Pedro](https://github/diegopedro94)
 - [Nicolas Dubien](https://github.com/dubzzz)
+- [Giovanni Gonzaga](https://github.com/giogonzo)
 - [Gjorgji Kjosev](https://github.com/spion)
 - [Thibaut Boulard](https://github.com/volrk)
 - [Trey Davis](https://github.com/treydavis)

--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -17,7 +17,7 @@ import { tuple } from './TupleArbitrary';
 export class ObjectConstraints {
   constructor(
     readonly key: Arbitrary<string>,
-    readonly values: Arbitrary<any>[],
+    readonly values: Arbitrary<unknown>[],
     readonly maxDepth: number,
     readonly maxKeys: number,
     readonly withSet: boolean,
@@ -28,7 +28,7 @@ export class ObjectConstraints {
   /**
    * Default value of ObjectConstraints.Settings.values field
    */
-  static defaultValues(): Arbitrary<any>[] {
+  static defaultValues(): Arbitrary<unknown>[] {
     return [
       boolean(),
       integer(),
@@ -131,7 +131,7 @@ export namespace ObjectConstraints {
      *  - `Number.POSITIVE_INFINITY`,
      *  - `Number.NEGATIVE_INFINITY`
      */
-    values?: Arbitrary<any>[];
+    values?: Arbitrary<unknown>[];
     /** Also generate boxed versions of values */
     withBoxedValues?: boolean;
     /** Also generate Set */
@@ -208,7 +208,7 @@ const objectInternal = (constraints: ObjectConstraints): Arbitrary<any> => {
  * @example
  * ```null, undefined, 42, 6.5, 'Hello', {} or {k: [{}, 1, 2]}```
  */
-function anything(): Arbitrary<any>;
+function anything(): Arbitrary<unknown>;
 /**
  * For any type of values following the constraints defined by `settings`
  *
@@ -234,8 +234,8 @@ function anything(): Arbitrary<any>;
  *
  * @param settings Constraints to apply when building instances
  */
-function anything(settings: ObjectConstraints.Settings): Arbitrary<any>;
-function anything(settings?: ObjectConstraints.Settings): Arbitrary<any> {
+function anything(settings: ObjectConstraints.Settings): Arbitrary<unknown>;
+function anything(settings?: ObjectConstraints.Settings): Arbitrary<unknown> {
   return anythingInternal(ObjectConstraints.from(settings));
 }
 
@@ -247,7 +247,7 @@ function anything(settings?: ObjectConstraints.Settings): Arbitrary<any> {
  * @example
  * ```{} or {k: [{}, 1, 2]}```
  */
-function object(): Arbitrary<any>;
+function object(): Arbitrary<unknown>;
 /**
  * For any objects following the constraints defined by `settings`
  *
@@ -258,8 +258,8 @@ function object(): Arbitrary<any>;
  *
  * @param settings Constraints to apply when building instances
  */
-function object(settings: ObjectConstraints.Settings): Arbitrary<any>;
-function object(settings?: ObjectConstraints.Settings): Arbitrary<any> {
+function object(settings: ObjectConstraints.Settings): Arbitrary<unknown>;
+function object(settings?: ObjectConstraints.Settings): Arbitrary<unknown> {
   return objectInternal(ObjectConstraints.from(settings));
 }
 
@@ -275,7 +275,7 @@ function jsonSettings(stringArbitrary: Arbitrary<string>, maxDepth?: number) {
  *
  * Keys and string values rely on {@link string}
  */
-function jsonObject(): Arbitrary<any>;
+function jsonObject(): Arbitrary<unknown>;
 /**
  * For any JSON compliant values with a maximal depth
  *
@@ -283,8 +283,8 @@ function jsonObject(): Arbitrary<any>;
  *
  * @param maxDepth Maximal depth of the generated values
  */
-function jsonObject(maxDepth: number): Arbitrary<any>;
-function jsonObject(maxDepth?: number): Arbitrary<any> {
+function jsonObject(maxDepth: number): Arbitrary<unknown>;
+function jsonObject(maxDepth?: number): Arbitrary<unknown> {
   return anything(jsonSettings(string(), maxDepth));
 }
 
@@ -293,7 +293,7 @@ function jsonObject(maxDepth?: number): Arbitrary<any> {
  *
  * Keys and string values rely on {@link unicode}
  */
-function unicodeJsonObject(): Arbitrary<any>;
+function unicodeJsonObject(): Arbitrary<unknown>;
 /**
  * For any JSON compliant values with unicode support and a maximal depth
  *
@@ -301,8 +301,8 @@ function unicodeJsonObject(): Arbitrary<any>;
  *
  * @param maxDepth Maximal depth of the generated values
  */
-function unicodeJsonObject(maxDepth: number): Arbitrary<any>;
-function unicodeJsonObject(maxDepth?: number): Arbitrary<any> {
+function unicodeJsonObject(maxDepth: number): Arbitrary<unknown>;
+function unicodeJsonObject(maxDepth?: number): Arbitrary<unknown> {
   return anything(jsonSettings(unicodeString(), maxDepth));
 }
 

--- a/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
@@ -333,7 +333,7 @@ describe('ObjectArbitrary', () => {
         fc.property(fc.integer(), seed => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = jsonObject().generate(mrng).value;
-          expect(JSON.parse(JSON.stringify(g))).toStrictEqual(g);
+          expect(JSON.parse(JSON.stringify(g))).toStrictEqual(g as any);
         })
       ));
   });
@@ -350,7 +350,7 @@ describe('ObjectArbitrary', () => {
         fc.property(fc.integer(), seed => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = unicodeJsonObject().generate(mrng).value;
-          expect(JSON.parse(JSON.stringify(g))).toStrictEqual(g);
+          expect(JSON.parse(JSON.stringify(g))).toStrictEqual(g as any);
         })
       ));
   });
@@ -401,7 +401,7 @@ describe('ObjectArbitrary', () => {
           while (shrinkable.shrink().has(v => true)[0]) {
             shrinkable = shrinkable.shrink().next().value;
           } // only check one shrink path
-          return typeof shrinkable.value === 'object' && Object.keys(shrinkable.value).length === 0;
+          return typeof shrinkable.value === 'object' && Object.keys(shrinkable.value as any).length === 0;
         })
       ));
     it('Should not suggest input in shrinked values', () =>
@@ -409,7 +409,7 @@ describe('ObjectArbitrary', () => {
         fc.property(fc.integer(), seed => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const shrinkable = object().generate(mrng);
-          for (const s of shrinkable.shrink()) expect(s.value).not.toStrictEqual(shrinkable.value);
+          for (const s of shrinkable.shrink()) expect(s.value).not.toStrictEqual(shrinkable.value as any);
         })
       ));
   });

--- a/test/unit/utils/stringify.spec.ts
+++ b/test/unit/utils/stringify.spec.ts
@@ -47,7 +47,7 @@ describe('stringify', () => {
   it('Should be readable from eval', () =>
     fc.assert(
       fc.property(fc.anything(), obj => {
-        expect(eval(`(function() { return ${stringify(obj)}; })()`)).toStrictEqual(obj);
+        expect(eval(`(function() { return ${stringify(obj)}; })()`)).toStrictEqual(obj as any);
       })
     ));
   it('Should stringify differently distinct objects', () =>


### PR DESCRIPTION
## Why is this PR for?

closes #435 

I only changed the exported definitions signatures in `object` arbitrary to use `unknown` instead of `any`. I believe there might be other instances where this change could be done (I didn't check yet), this could be a first step

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact

This might be breaking for some users, but for the better 😎 
