### PR TITLE
Set "sideEffects" to `false` into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       ]
     }
   },
+  "sideEffects": false,
   "scripts": {
     "perf": "node perf/benchmark.js",
     "profile": "node --prof --no-logfile-per-isolate --trace-deopt --trace-opt-verbose perf/profiler.js > deopt.out && node --prof-process v8.log > v8.out",


### PR DESCRIPTION
## Why is this PR for?

This flag can be used by webpack to enable tree-shaking on the module.
See https://webpack.js.org/guides/tree-shaking/

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.
