### PR TITLE
🚨 Fix eslint errors related to no-prototype-builtins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
     'prettier/@typescript-eslint'
   ],
   rules: {
-    'no-prototype-builtins': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-empty-function': 'warn',

--- a/src/check/arbitrary/LetRecArbitrary.ts
+++ b/src/check/arbitrary/LetRecArbitrary.ts
@@ -53,7 +53,7 @@ export class LazyArbitrary extends Arbitrary<any> {
 
 /** @hidden */
 function isLazyArbitrary(arb: Arbitrary<any> | undefined): arb is LazyArbitrary {
-  return arb !== undefined && arb.hasOwnProperty('underlying');
+  return arb !== undefined && Object.prototype.hasOwnProperty.call(arb, 'underlying');
 }
 
 /**
@@ -80,7 +80,7 @@ export function letrec<T>(
   };
   const strictArbs = builder(tie as any);
   for (const key in strictArbs) {
-    if (!strictArbs.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(strictArbs, key)) {
       // Prevents accidental iteration over properties inherited from an object’s prototype
       continue;
     }

--- a/src/check/arbitrary/MemoArbitrary.ts
+++ b/src/check/arbitrary/MemoArbitrary.ts
@@ -49,7 +49,7 @@ export const memo = <T>(builder: (maxDepth: number) => Arbitrary<T>): Memo<T> =>
   const previous: { [depth: number]: Arbitrary<T> } = {};
   return ((maxDepth?: number): Arbitrary<T> => {
     const n = maxDepth !== undefined ? maxDepth : contextRemainingDepth;
-    if (!previous.hasOwnProperty(n)) {
+    if (!Object.prototype.hasOwnProperty.call(previous, n)) {
       const prev = contextRemainingDepth;
       contextRemainingDepth = n - 1;
       previous[n] = new MemoArbitrary(builder(n));

--- a/src/check/arbitrary/OptionArbitrary.ts
+++ b/src/check/arbitrary/OptionArbitrary.ts
@@ -62,7 +62,7 @@ function option<T, TNil>(arb: Arbitrary<T>, constraints?: number | OptionConstra
   return new OptionArbitrary(
     arb,
     constraints.freq == null ? 5 : constraints.freq,
-    constraints.hasOwnProperty('nil') ? constraints.nil : (null as any)
+    Object.prototype.hasOwnProperty.call(constraints, 'nil') ? constraints.nil : (null as any)
   );
 }
 

--- a/src/check/runner/Sampler.ts
+++ b/src/check/runner/Sampler.ts
@@ -13,7 +13,7 @@ import { pathWalk } from './utils/PathWalker';
 
 /** @hidden */
 function toProperty<Ts>(generator: IProperty<Ts> | Arbitrary<Ts>, qParams: QualifiedParameters<Ts>): IProperty<Ts> {
-  const prop = !generator.hasOwnProperty('isAsync')
+  const prop = !Object.prototype.hasOwnProperty.call(generator, 'isAsync')
     ? new Property(generator as Arbitrary<Ts>, () => true)
     : (generator as IProperty<Ts>);
   return qParams.unbiased === true ? new UnbiasedProperty(prop) : prop;

--- a/test/unit/check/arbitrary/RecordArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/RecordArbitrary.spec.ts
@@ -22,7 +22,7 @@ describe('RecordArbitrary', () => {
           const arb = record(recordModel, { withDeletedKeys: true });
           for (let idx = 0; idx != 1000; ++idx) {
             const g = arb.generate(mrng).value;
-            if (!g.hasOwnProperty(keys[missingIdx % keys.length])) return true;
+            if (!Object.prototype.hasOwnProperty.call(g, keys[missingIdx % keys.length])) return true;
           }
           return false;
         })
@@ -68,7 +68,7 @@ describe('RecordArbitrary', () => {
             }
             for (const m of metas) {
               // values are associated to the right key (if key required)
-              if (constraints.withDeletedKeys === true && !(r as any).hasOwnProperty(m.key)) continue;
+              if (constraints.withDeletedKeys === true && !Object.prototype.hasOwnProperty.call(r, m.key)) continue;
               if (typeof r[m.key] !== 'number') return false;
               if (r[m.key] < m.valueStart) return false;
               if (r[m.key] > m.valueStart + 10) return false;


### PR DESCRIPTION
## Why is this PR for?

Replace `obj.hasOwnProperty(propertyName)`by `Object.prototype.hasOwnProperty.call(obj, propertyName)` in order to fix errors raised by [eslint no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.
