### PR TITLE
no-unused-vars in test/e2e

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'warn',
     '@typescript-eslint/no-this-alias': 'warn',
-    '@typescript-eslint/no-use-before-define': 'warn'
+    '@typescript-eslint/no-use-before-define': 'warn',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
   }
 };

--- a/test/e2e/ModelBased.spec.ts
+++ b/test/e2e/ModelBased.spec.ts
@@ -12,7 +12,7 @@ interface Model {
 
 class PushCommand implements fc.Command<Model, IList<number>> {
   constructor(readonly value: number) {}
-  check = (m: Readonly<Model>) => true;
+  check = (_m: Readonly<Model>) => true;
   run(m: Model, r: IList<number>): void {
     r.push(this.value);
     ++m.num;
@@ -31,7 +31,7 @@ class PopCommand implements fc.Command<Model, IList<number>> {
   toString = () => 'pop';
 }
 class SizeCommand implements fc.Command<Model, IList<number>> {
-  check = (m: Readonly<Model>) => true;
+  check = (_m: Readonly<Model>) => true;
   run(m: Model, r: IList<number>): void {
     expect(r.size()).toEqual(m.num);
   }

--- a/test/e2e/PreConditionChecks.spec.ts
+++ b/test/e2e/PreConditionChecks.spec.ts
@@ -12,7 +12,7 @@ describe(`PreConditionChecks (seed: ${seed})`, () => {
   });
   it('should consider run as failure on too many pre failures', () => {
     const out = fc.check(
-      fc.property(fc.integer(), fc.integer(), (x, y) => {
+      fc.property(fc.integer(), fc.integer(), (_x, _y) => {
         fc.pre(false);
         return true;
       })
@@ -20,7 +20,7 @@ describe(`PreConditionChecks (seed: ${seed})`, () => {
     expect(out.failed).toBe(true);
   });
   it('should not failed when no skips on no skips allowed', () => {
-    const out = fc.check(fc.property(fc.integer(), fc.integer(), (x, y) => true), { maxSkipsPerRun: 0 });
+    const out = fc.check(fc.property(fc.integer(), fc.integer(), (_x, _y) => true), { maxSkipsPerRun: 0 });
     expect(out.failed).toBe(false);
   });
 });

--- a/test/e2e/ReplayCommands.spec.ts
+++ b/test/e2e/ReplayCommands.spec.ts
@@ -6,19 +6,19 @@ type Model = { counter: number };
 type Real = {};
 class IncBy implements fc.Command<Model, Real> {
   constructor(readonly v: number) {}
-  check = (m: Readonly<Model>) => true;
-  run = (m: Model, r: Real) => (m.counter += this.v);
+  check = (_m: Readonly<Model>) => true;
+  run = (m: Model, _r: Real) => (m.counter += this.v);
   toString = () => `IncBy(${this.v})`;
 }
 class DecPosBy implements fc.Command<Model, Real> {
   constructor(readonly v: number) {}
   check = (m: Readonly<Model>) => m.counter > 0;
-  run = (m: Model, r: Real) => (m.counter -= this.v);
+  run = (m: Model, _r: Real) => (m.counter -= this.v);
   toString = () => `DecPosBy(${this.v})`;
 }
 class AlwaysPos implements fc.Command<Model, Real> {
-  check = (m: Readonly<Model>) => true;
-  run = (m: Model, r: Real) => {
+  check = (_m: Readonly<Model>) => true;
+  run = (m: Model, _r: Real) => {
     if (m.counter < 0) throw new Error('counter is supposed to be always greater or equal to zero');
   };
   toString = () => `AlwaysPos()`;

--- a/test/e2e/SkipAllAfterTime.spec.ts
+++ b/test/e2e/SkipAllAfterTime.spec.ts
@@ -5,7 +5,7 @@ describe(`SkipAllAfterTime (seed: ${seed})`, () => {
   it('should skip as soon as delay expires and mark run as failed', () => {
     let numRuns = 0;
     const out = fc.check(
-      fc.property(fc.integer(), x => {
+      fc.property(fc.integer(), _x => {
         ++numRuns;
         return true;
       }),

--- a/test/e2e/arbitraries/Arbitrary.spec.ts
+++ b/test/e2e/arbitraries/Arbitrary.spec.ts
@@ -49,7 +49,7 @@ describe(`Arbitrary (seed: ${seed})`, () => {
       expect(out.counterexample).toEqual([1]);
     });
     it('Should shrink chain on destination', () => {
-      const out = fc.check(fc.property(fc.constant(42).chain(v => fc.nat()), (v: number) => v < 1), { seed: seed });
+      const out = fc.check(fc.property(fc.constant(42).chain(_v => fc.nat()), (v: number) => v < 1), { seed: seed });
       expect(out.failed).toBe(true);
       expect(out.counterexample).toEqual([1]);
     });

--- a/test/e2e/model/CounterCommands.ts
+++ b/test/e2e/model/CounterCommands.ts
@@ -5,40 +5,40 @@ type R1 = {};
 
 export class IncreaseCommand implements fc.Command<M1, R1> {
   constructor(readonly n: number) {}
-  check = (m: Readonly<M1>) => true;
-  run = (m: M1, r: R1) => {
+  check = (_m: Readonly<M1>) => true;
+  run = (m: M1, _r: R1) => {
     m.count += this.n;
   };
   toString = () => `inc[${this.n}]`;
 }
 export class DecreaseCommand implements fc.Command<M1, R1> {
   constructor(readonly n: number) {}
-  check = (m: Readonly<M1>) => true;
-  run = (m: M1, r: R1) => {
+  check = (_m: Readonly<M1>) => true;
+  run = (m: M1, _r: R1) => {
     m.count -= this.n;
   };
   toString = () => `dec[${this.n}]`;
 }
 export class EvenCommand implements fc.Command<M1, R1> {
   check = (m: Readonly<M1>) => m.count % 2 === 0;
-  run = (m: M1, r: R1) => {};
+  run = (_m: M1, _r: R1) => {};
   toString = () => 'even';
 }
 export class OddCommand implements fc.Command<M1, R1> {
   check = (m: Readonly<M1>) => m.count % 2 !== 0;
-  run = (m: M1, r: R1) => {};
+  run = (_m: M1, _r: R1) => {};
   toString = () => 'odd';
 }
 export class CheckLessThanCommand implements fc.Command<M1, R1> {
   constructor(readonly lessThanValue: number) {}
-  check = (m: Readonly<M1>) => true;
-  run = (m: M1, r: R1) => {
+  check = (_m: Readonly<M1>) => true;
+  run = (m: M1, _r: R1) => {
     expect(m.count).toBeLessThan(this.lessThanValue);
   };
   toString = () => `check[${this.lessThanValue}]`;
 }
 export class SuccessAlwaysCommand implements fc.Command<M1, R1> {
-  check = (m: Readonly<M1>) => true;
-  run = (m: M1, r: R1) => {};
+  check = (_m: Readonly<M1>) => true;
+  run = (_m: M1, _r: R1) => {};
   toString = () => 'success';
 }

--- a/test/e2e/model/StepCommands.ts
+++ b/test/e2e/model/StepCommands.ts
@@ -8,12 +8,12 @@ type R2 = {};
 
 export class SuccessCommand implements fc.Command<M2, R2> {
   check = (m: Readonly<M2>) => m.validSteps.includes(m.current.stepId++);
-  run = (m: M2, r: R2) => {};
+  run = (_m: M2, _r: R2) => {};
   toString = () => 'success';
 }
 export class FailureCommand implements fc.Command<M2, R2> {
   check = (m: Readonly<M2>) => m.validSteps.includes(m.current.stepId++);
-  run = (m: M2, r: R2) => {
+  run = (_m: M2, _r: R2) => {
     throw 'failure';
   };
   toString = () => 'failure';


### PR DESCRIPTION
## Why is this PR for?

Added the `@typescript-eslint/no-unused-vars` eslint rule and prefixed all unused variables in test/e2e.

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
✔️ Other: New eslint rule 

(✔️: yes, ❌: no)

## Potential impacts

The addition of the rule will help prevent unwanted behavior related to unused variables.
