### PR TITLE
:white_check_mark: Use ts-jest/utils mocked instead of our own

### DIFF
--- a/test/unit/check/arbitrary/DateArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/DateArbitrary.utest.spec.ts
@@ -1,6 +1,6 @@
 import { date } from '../../../../src/check/arbitrary/DateArbitrary';
 import * as stubRng from '../../stubs/generators';
-import { mockModule } from './generic/MockedModule';
+import { mocked } from 'ts-jest/utils';
 import * as fc from '../../../../lib/fast-check';
 
 jest.mock('../../../../src/check/arbitrary/IntegerArbitrary');
@@ -16,7 +16,7 @@ describe('DateArbitrary', () => {
     });
     it('Should be able to build the minimal valid date', () => {
       // Arrange
-      const { integer } = mockModule(IntegerArbitraryMock);
+      const { integer } = mocked(IntegerArbitraryMock);
       integer.mockImplementationOnce((a, b) => arbitraryFor([{ value: a }]));
 
       // Act
@@ -30,7 +30,7 @@ describe('DateArbitrary', () => {
     });
     it('Should be able to build the maximal valid date', () => {
       // Arrange
-      const { integer } = mockModule(IntegerArbitraryMock);
+      const { integer } = mocked(IntegerArbitraryMock);
       integer.mockImplementationOnce((a, b) => arbitraryFor([{ value: b }]));
 
       // Act
@@ -47,7 +47,7 @@ describe('DateArbitrary', () => {
         fc
           .property(constraintsArb(), fc.nat(), (constraints, seed) => {
             // Arrange
-            const { integer } = mockModule(IntegerArbitraryMock);
+            const { integer } = mocked(IntegerArbitraryMock);
             integer.mockImplementationOnce((a, b) => {
               const d = b - a + 1;
               const r = (seed % d) + a; // random between a and b
@@ -94,7 +94,7 @@ describe('DateArbitrary', () => {
     });
     it('Should preserve shrinking capabilities', () => {
       // Arrange
-      const { integer } = mockModule(IntegerArbitraryMock);
+      const { integer } = mocked(IntegerArbitraryMock);
       integer.mockReturnValueOnce(arbitraryFor([{ value: 42, shrinks: [{ value: 48 }, { value: 69 }] }]));
 
       // Act

--- a/test/unit/check/arbitrary/MixedCaseArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/MixedCaseArbitrary.utest.spec.ts
@@ -5,7 +5,7 @@ import { mixedCase, countToggledBits, computeNextFlags } from '../../../../src/c
 jest.mock('../../../../src/check/arbitrary/BigIntArbitrary');
 import * as BigIntArbitraryMock from '../../../../src/check/arbitrary/BigIntArbitrary';
 import * as stubRng from '../../stubs/generators';
-import { mockModule } from './generic/MockedModule';
+import { mocked } from 'ts-jest/utils';
 import { arbitraryFor } from './generic/ArbitraryBuilder';
 
 const mrng = () => stubRng.mutable.nocall();
@@ -25,7 +25,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should not toggle any character if flags are null', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementationOnce(n => arbitraryFor([{ value: BigInt(0) }]));
       const stringArb = arbitraryFor([{ value: 'azerty' }]);
 
@@ -39,7 +39,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should toggle characters according to flags', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementationOnce(n => arbitraryFor([{ value: BigInt(9) /* 001001 */ }]));
       const stringArb = arbitraryFor([{ value: 'azerty' }]);
 
@@ -53,7 +53,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should toggle both lower and upper characters', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementationOnce(n => arbitraryFor([{ value: BigInt(9) /* 001001 */ }]));
       const stringArb = arbitraryFor([{ value: 'azERty' }]);
 
@@ -67,7 +67,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should not try to toggle characters that do not have lower/upper versions', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementationOnce(n => arbitraryFor([{ value: BigInt(0) }]));
       const stringArb = arbitraryFor([{ value: 'az01ty' }]); // 01 upper version is the same
 
@@ -81,7 +81,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should shrink by merging string and flags shrinkers', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementation(n => {
         switch (n) {
           case 6: // azerty
@@ -148,7 +148,7 @@ describe('MixedCaseArbitrary', () => {
     });
     it('should use toggle function when provided to check what can be toggled or not', () => {
       // Arrange
-      const { bigUintN } = mockModule(BigIntArbitraryMock);
+      const { bigUintN } = mocked(BigIntArbitraryMock);
       bigUintN.mockImplementationOnce(n => arbitraryFor([{ value: BigInt(63) /* 111111 */ }]));
       const stringArb = arbitraryFor([{ value: 'azerty' }]);
       const customToggle = jest.fn();

--- a/test/unit/check/arbitrary/UuidArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/UuidArbitrary.utest.spec.ts
@@ -1,6 +1,6 @@
 import { uuid, uuidV } from '../../../../src/check/arbitrary/UuidArbitrary';
 import * as stubRng from '../../stubs/generators';
-import { mockModule } from './generic/MockedModule';
+import { mocked } from 'ts-jest/utils';
 
 jest.mock('../../../../src/check/arbitrary/IntegerArbitrary');
 jest.mock('../../../../src/check/arbitrary/TupleArbitrary');
@@ -17,8 +17,8 @@ describe('UuidArbitrary', () => {
     });
     it('Should be able to build the smallest uuid', () => {
       // Arrange
-      const { nat, integer } = mockModule(IntegerArbitraryMock);
-      const { tuple } = mockModule(TupleArbitraryMock);
+      const { nat, integer } = mocked(IntegerArbitraryMock);
+      const { tuple } = mocked(TupleArbitraryMock);
       nat.mockImplementation(() => arbitraryFor([{ value: 0 }, { value: 0 }, { value: 0 }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: a }]));
       tuple.mockImplementation((...arbs) => arbitraryFor([{ value: arbs.map(a => a.generate(mrng()).value_) as any }]));
@@ -33,8 +33,8 @@ describe('UuidArbitrary', () => {
     });
     it('Should be able to build the largest uuid', () => {
       // Arrange
-      const { nat, integer } = mockModule(IntegerArbitraryMock);
-      const { tuple } = mockModule(TupleArbitraryMock);
+      const { nat, integer } = mocked(IntegerArbitraryMock);
+      const { tuple } = mocked(TupleArbitraryMock);
       nat.mockImplementation(a => arbitraryFor([{ value: a }, { value: a }, { value: a }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: b }]));
       tuple.mockImplementation((...arbs) => arbitraryFor([{ value: arbs.map(a => a.generate(mrng()).value_) as any }]));
@@ -54,8 +54,8 @@ describe('UuidArbitrary', () => {
     });
     it('Should be able to build the smallest versioned uuid', () => {
       // Arrange
-      const { nat, integer } = mockModule(IntegerArbitraryMock);
-      const { tuple } = mockModule(TupleArbitraryMock);
+      const { nat, integer } = mocked(IntegerArbitraryMock);
+      const { tuple } = mocked(TupleArbitraryMock);
       nat.mockImplementation(() => arbitraryFor([{ value: 0 }, { value: 0 }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: a }]));
       tuple.mockImplementation((...arbs) => arbitraryFor([{ value: arbs.map(a => a.generate(mrng()).value_) as any }]));
@@ -70,8 +70,8 @@ describe('UuidArbitrary', () => {
     });
     it('Should be able to build the largest versioned uuid', () => {
       // Arrange
-      const { nat, integer } = mockModule(IntegerArbitraryMock);
-      const { tuple } = mockModule(TupleArbitraryMock);
+      const { nat, integer } = mocked(IntegerArbitraryMock);
+      const { tuple } = mocked(TupleArbitraryMock);
       nat.mockImplementation(a => arbitraryFor([{ value: a }, { value: a }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: b }]));
       tuple.mockImplementation((...arbs) => arbitraryFor([{ value: arbs.map(a => a.generate(mrng()).value_) as any }]));

--- a/test/unit/check/arbitrary/generic/MockedModule.ts
+++ b/test/unit/check/arbitrary/generic/MockedModule.ts
@@ -1,7 +1,0 @@
-type MockedFunction<T> = T extends (...args: infer Args) => infer Result
-  ? jest.Mock<Result, Args>
-  : jest.Mock<any, any>;
-
-type MockedModule<T> = { [K in keyof T]: MockedFunction<T[K]> };
-
-export const mockModule = <T>(module: T): MockedModule<T> => module as any;


### PR DESCRIPTION
## Why is this PR for?

Use ts-jest/utils mocked instead of our own.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: Test

(✔️: yes, ❌: no)

## Potential impacts

None.
