### PR TITLE
✅  By default tests within example/ run against published fast-check 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
 script:
   - yarn prebuild
   - yarn build
-  - yarn test -- --maxWorkers=4
-  - yarn e2e -- --maxWorkers=4
+  - yarn test --maxWorkers=4
+  - yarn e2e --maxWorkers=4
 
 after_success:
   - if [[ $(node --version) == "v12."* ]]; then yarn coverage; fi
@@ -43,8 +43,9 @@ jobs:
         - yarn build:publish-cjs
         - yarn build:publish-esm
         - yarn webbuild
+        - yarn link
         - cd example ;
-          yarn --no-progress --frozen-lockfile --ignore-engines ;
+          yarn --ignore-engines ;
           bash run.sh ;
           cd ..
         - yarn test:rollup-esm
@@ -56,8 +57,8 @@ jobs:
       script:
         - yarn prebuild
         - yarn build
-        - yarn test -- --maxWorkers=4
-        - yarn e2e -- --maxWorkers=4
+        - yarn test --maxWorkers=4
+        - yarn e2e --maxWorkers=4
     - stage: publish documentation
       if: branch = master AND type = push
       script:

--- a/example/async-property/test.ts
+++ b/example/async-property/test.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../lib/fast-check';
+import * as fc from 'fast-check';
 import { FakeApi } from './FakeApi';
 
 describe('Asynchronous example', () => {

--- a/example/binary-trees/arbitraries/BinarySearchTreeArbitrary.ts
+++ b/example/binary-trees/arbitraries/BinarySearchTreeArbitrary.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { Tree } from '../models/BinaryTree';
 

--- a/example/binary-trees/arbitraries/BinaryTreeArbitrary.ts
+++ b/example/binary-trees/arbitraries/BinaryTreeArbitrary.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { Tree } from '../models/BinaryTree';
 

--- a/example/binary-trees/arbitraries/FullBinaryTreeArbitrary.ts
+++ b/example/binary-trees/arbitraries/FullBinaryTreeArbitrary.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { Tree } from '../models/BinaryTree';
 

--- a/example/binary-trees/arbitraries/PerfectBinaryTreeArbitrary.ts
+++ b/example/binary-trees/arbitraries/PerfectBinaryTreeArbitrary.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { Tree } from '../models/BinaryTree';
 

--- a/example/binary-trees/test.ts
+++ b/example/binary-trees/test.ts
@@ -1,4 +1,4 @@
-import * as fc from '../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { Tree } from './models/BinaryTree';
 

--- a/example/model-based-testing/test.ts
+++ b/example/model-based-testing/test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as fc from '../../lib/fast-check';
+import * as fc from 'fast-check';
 
 import { MusicPlayer, MusicPlayerA, MusicPlayerB } from './MusicPlayer';
 

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "test:tree": "mocha --require ts-node/register binary-trees/test.ts"
   },
   "devDependencies": {
-    "fast-check": "file:..",
+    "fast-check": "*",
     "mocha": "^5.0.0",
     "ts-node": "^6.1.0"
   },

--- a/example/run.sh
+++ b/example/run.sh
@@ -33,6 +33,8 @@ do
     fi
 done
 
+# Take published version of fast-check
 yarn unlink "fast-check"
+yarn --force
 
 exit $status

--- a/example/run.sh
+++ b/example/run.sh
@@ -2,6 +2,9 @@
 
 mkdir -p output
 
+# Run `yarn link` in parent directory first
+yarn link "fast-check"
+
 status=0
 
 for testUnit in "async:1:1" "contains:6:0" "knight:15:1" "settings:0:1" "model:1:1" "tree:12:8"
@@ -29,5 +32,7 @@ do
         fi
     fi
 done
+
+yarn unlink "fast-check"
 
 exit $status

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -57,11 +57,13 @@ escape-string-regexp@1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-"fast-check@file:..":
-  version "1.17.0"
+fast-check@*:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-1.18.1.tgz#64568dd417bca4c7c93d1705868d8e46fa7a3fdf"
+  integrity sha512-b2EOdqujCBzMC78WhqYMXMRzWUKC8cXuPAgt6UOZtU5QTHk2NpUMZDfQeMqHNDZYPZUQyZdHtZqQgq43lBCoIg==
   dependencies:
-    pure-rand "^1.6.2"
-    tslib "^1.9.3"
+    pure-rand "^1.7.0"
+    tslib "^1.10.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -171,15 +173,15 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-pure-rand@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-1.6.2.tgz#90b3ae78efe36f7e6e27bfffedf934f77382e6e6"
-  integrity sha512-HNwHOH63m7kCxe0kWEe5jSLwJiL2N83RUUN8POniFuZS+OsbFcMWlvXgxIU2nwKy2zYG2bQan40WBNK4biYPRg==
+pure-rand@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-1.7.0.tgz#8b119d05f5f83c409efbede897f1386c4df32313"
+  integrity sha512-Mpghwu8LvQUpr8NRFmGTgX8mFi8WHqor9oE0cCj2Sk5XjA10lBx880qUXtXQPYzrUL8NVQ87nqZvV7LI6gVdOw==
 
 source-map-support@^0.5.6:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -210,7 +212,7 @@ ts-node@^6.1.0:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-tslib@^1.9.3:
+tslib@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
## Why is this PR for?

In order to make it possible to run tests defined within example/ directory directly in codesandbox, we first have to make them use a published version of fast-check and change it during our tests to test the code against the on-going version.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *tests within example/*

(✔️: yes, ❌: no)

## Potential impacts

None.
