### PR TITLE
Allow looser return types for AsyncProperty beforeEach and afterEach

### DIFF
--- a/src/check/property/AsyncProperty.generic.ts
+++ b/src/check/property/AsyncProperty.generic.ts
@@ -9,17 +9,17 @@ import { IRawProperty, runIdToFrequency } from './IRawProperty';
  */
 export interface IAsyncProperty<Ts> extends IRawProperty<Ts, true> {}
 
+type HookFunction = (() => Promise<unknown>) | (() => void);
+
 /**
  * Asynchronous property, see {@link IAsyncProperty}
  *
  * Prefer using {@link asyncProperty} instead
  */
 export class AsyncProperty<Ts> implements IAsyncProperty<Ts> {
-  static dummyHook: () => Promise<void> = async () => {
-    return;
-  };
-  private beforeEachHook: () => Promise<void> = AsyncProperty.dummyHook;
-  private afterEachHook: () => Promise<void> = AsyncProperty.dummyHook;
+  static dummyHook: HookFunction = () => {};
+  private beforeEachHook: HookFunction = AsyncProperty.dummyHook;
+  private afterEachHook: HookFunction = AsyncProperty.dummyHook;
   constructor(readonly arb: Arbitrary<Ts>, readonly predicate: (t: Ts) => Promise<boolean | void>) {}
   isAsync = () => true as const;
   generate(mrng: Random, runId?: number): Shrinkable<Ts> {
@@ -45,7 +45,7 @@ export class AsyncProperty<Ts> implements IAsyncProperty<Ts> {
    * Define a function that should be called before all calls to the predicate
    * @param hookFunction Function to be called
    */
-  beforeEach(hookFunction: () => Promise<void>): AsyncProperty<Ts> {
+  beforeEach(hookFunction: HookFunction): AsyncProperty<Ts> {
     this.beforeEachHook = hookFunction;
     return this;
   }
@@ -53,7 +53,7 @@ export class AsyncProperty<Ts> implements IAsyncProperty<Ts> {
    * Define a function that should be called after all calls to the predicate
    * @param hookFunction Function to be called
    */
-  afterEach(hookFunction: () => Promise<void>): AsyncProperty<Ts> {
+  afterEach(hookFunction: HookFunction): AsyncProperty<Ts> {
     this.afterEachHook = hookFunction;
     return this;
   }

--- a/src/check/property/Property.generic.ts
+++ b/src/check/property/Property.generic.ts
@@ -9,17 +9,17 @@ import { IRawProperty, runIdToFrequency } from './IRawProperty';
  */
 export interface IProperty<Ts> extends IRawProperty<Ts, false> {}
 
+type HookFunction = () => void;
+
 /**
  * Property, see {@link IProperty}
  *
  * Prefer using {@link property} instead
  */
 export class Property<Ts> implements IProperty<Ts> {
-  static dummyHook: () => void = () => {
-    return;
-  };
-  private beforeEachHook: () => void = Property.dummyHook;
-  private afterEachHook: () => void = Property.dummyHook;
+  static dummyHook: HookFunction = () => {};
+  private beforeEachHook: HookFunction = Property.dummyHook;
+  private afterEachHook: HookFunction = Property.dummyHook;
   constructor(readonly arb: Arbitrary<Ts>, readonly predicate: (t: Ts) => boolean | void) {}
   isAsync = () => false as const;
   generate(mrng: Random, runId?: number): Shrinkable<Ts> {
@@ -45,7 +45,11 @@ export class Property<Ts> implements IProperty<Ts> {
    * Define a function that should be called before all calls to the predicate
    * @param hookFunction Function to be called
    */
-  beforeEach(hookFunction: () => void): Property<Ts> {
+  beforeEach(
+    invalidHookFunction: () => Promise<unknown>
+  ): 'beforeEach expects a synchronous function but was given a function returning a Promise';
+  beforeEach(validHookFunction: HookFunction): Property<Ts>;
+  beforeEach(hookFunction: HookFunction): unknown {
     this.beforeEachHook = hookFunction;
     return this;
   }
@@ -53,7 +57,11 @@ export class Property<Ts> implements IProperty<Ts> {
    * Define a function that should be called after all calls to the predicate
    * @param hookFunction Function to be called
    */
-  afterEach(hookFunction: () => void): Property<Ts> {
+  afterEach(
+    invalidHookFunction: () => Promise<unknown>
+  ): 'afterEach expects a synchronous function but was given a function returning a Promise';
+  afterEach(validHookFunction: HookFunction): Property<Ts>;
+  afterEach(hookFunction: HookFunction): unknown {
     this.afterEachHook = hookFunction;
     return this;
   }

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -8,11 +8,14 @@ expectType<Promise<void>>(fc.assert(fc.asyncProperty(fc.nat(), async () => {})))
 // property
 expectType(fc.property(fc.nat(), a => {}) as fc.IProperty<[number]>);
 expectType(fc.property(fc.nat(), fc.string(), (a, b) => {}) as fc.IProperty<[number, string]>);
+expectType(fc.property(fc.nat(), () => {}).beforeEach(() => 123).afterEach(() => "anything"));
 expectError(fc.property(fc.nat(), fc.string(), (a: number, b: number) => {}));
 
 // asyncProperty
 expectType(fc.asyncProperty(fc.nat(), async a => {}) as fc.IAsyncProperty<[number]>);
 expectType(fc.asyncProperty(fc.nat(), fc.string(), async (a, b) => {}) as fc.IAsyncProperty<[number, string]>);
+expectType(fc.asyncProperty(fc.nat(), async () => {}).beforeEach(async () => 123).afterEach(async () => "anything"));
+expectType(fc.asyncProperty(fc.nat(), async () => {}).beforeEach(() => 123).afterEach(() => "anything"));
 expectError(fc.asyncProperty(fc.nat(), fc.string(), async (a: number, b: number) => {}));
 
 // record arbitrary

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -8,14 +8,33 @@ expectType<Promise<void>>(fc.assert(fc.asyncProperty(fc.nat(), async () => {})))
 // property
 expectType(fc.property(fc.nat(), a => {}) as fc.IProperty<[number]>);
 expectType(fc.property(fc.nat(), fc.string(), (a, b) => {}) as fc.IProperty<[number, string]>);
-expectType(fc.property(fc.nat(), () => {}).beforeEach(() => 123).afterEach(() => "anything"));
+expectType(
+  fc.assert(
+    fc
+      .property(fc.nat(), () => {})
+      .beforeEach(() => 123)
+      .afterEach(() => 'anything')
+  )
+);
 expectError(fc.property(fc.nat(), fc.string(), (a: number, b: number) => {}));
+expectError(fc.assert(fc.property(fc.nat(), () => {}).beforeEach(async () => {})));
+expectError(fc.assert(fc.property(fc.nat(), () => {}).afterEach(async () => {})));
 
 // asyncProperty
 expectType(fc.asyncProperty(fc.nat(), async a => {}) as fc.IAsyncProperty<[number]>);
 expectType(fc.asyncProperty(fc.nat(), fc.string(), async (a, b) => {}) as fc.IAsyncProperty<[number, string]>);
-expectType(fc.asyncProperty(fc.nat(), async () => {}).beforeEach(async () => 123).afterEach(async () => "anything"));
-expectType(fc.asyncProperty(fc.nat(), async () => {}).beforeEach(() => 123).afterEach(() => "anything"));
+expectType(
+  fc
+    .asyncProperty(fc.nat(), async () => {})
+    .beforeEach(async () => 123)
+    .afterEach(async () => 'anything')
+);
+expectType(
+  fc
+    .asyncProperty(fc.nat(), async () => {})
+    .beforeEach(() => 123)
+    .afterEach(() => 'anything')
+);
 expectError(fc.asyncProperty(fc.nat(), fc.string(), async (a: number, b: number) => {}));
 
 // record arbitrary


### PR DESCRIPTION
## Why is this PR for?

Closes #480

## In a nutshell

✔️ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Should be a non-breaking change, since the type is looser than it was before.