### PR TITLE
📦 Remove all *.tsbuildinfo files from the bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
+.codesandbox
+.github
 .nyc_output/
 coverage/
 docs/
@@ -8,4 +10,4 @@ prebuild/
 src/
 test/
 buildTypes.js
-tsconfig.tsbuildinfo
+*.tsbuildinfo


### PR DESCRIPTION
## Why is this PR for?

📦 Remove all *.tsbuildinfo files from the bundle

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *decrease bundle size*

(✔️: yes, ❌: no)

## Potential impacts

None.
