### PR TITLE
👷 Use the latest version of node for STEP=HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,13 @@ jobs:
         - yarn test:rollup-iife
         - yarn test:type
         - nvm install 0.12 ;
+          node --version ;
           node test/legacy/main.js
     - stage: test
       env: STEP=HEAD
       script:
+        - nvm install node
+        - node --version
         - yarn prebuild
         - yarn build
         - yarn test --maxWorkers=4


### PR DESCRIPTION
## Why is this PR for?

Run the CI STEP=HEAD against the latest node

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *run the CI STEP=HEAD against the latest node*

(✔️: yes, ❌: no)

## Potential impacts

None.