### PR TITLE
Check no stack overflow on shrink

### DIFF
--- a/test/e2e/NoStackOverflowOnShrink.spec.ts
+++ b/test/e2e/NoStackOverflowOnShrink.spec.ts
@@ -1,24 +1,26 @@
 import * as fc from '../../src/fast-check';
 import { Shrinkable } from '../../src/fast-check';
 
+const computeMaximalDepth = () => {
+  // Compute the maximal call stack size
+  let depth = 0;
+  const f = () => {
+    ++depth;
+    f();
+  };
+  try {
+    f();
+  } catch (_err) {
+    // throws 'RangeError: Maximum call stack size exceeded'
+  }
+  return depth;
+};
+
+const maximalDepth = computeMaximalDepth();
 const seed = Date.now();
-describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
+describe(`NoStackOverflowOnShrink (depth: ${maximalDepth}) (seed: ${seed})`, () => {
   it('should not run into stack overflow during very deep shrink tasks', () => {
-    const computeMaximalDepth = () => {
-      // Compute the maximal call stack size
-      let depth = 0;
-      const f = () => {
-        ++depth;
-        f();
-      };
-      try {
-        f();
-      } catch (_err) {
-        // throws 'RangeError: Maximum call stack size exceeded'
-      }
-      return depth;
-    };
-    const stopAtShrinkDepth = computeMaximalDepth() + 10000; // More than maximal call stack size
+    const stopAtShrinkDepth = maximalDepth + 10000; // More than maximal call stack size
     class InfiniteShrinkingDepth extends fc.Arbitrary<number> {
       private static buildInfiniteShrinkable(n: number): fc.Shrinkable<number> {
         function* g() {

--- a/test/e2e/NoStackOverflowOnShrink.spec.ts
+++ b/test/e2e/NoStackOverflowOnShrink.spec.ts
@@ -1,0 +1,41 @@
+import * as fc from '../../src/fast-check';
+import { Shrinkable } from '../../src/fast-check';
+
+const seed = Date.now();
+describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
+  it('should not run into stack overflow during very deep shrink tasks', () => {
+    const computeMaximalDepth = () => {
+      // Compute the maximal call stack size
+      let depth = 0;
+      const f = () => {
+        ++depth;
+        f();
+      };
+      try {
+        f();
+      } catch (_err) {
+        // throws 'RangeError: Maximum call stack size exceeded'
+      }
+      return depth;
+    };
+    const stopAtShrinkDepth = computeMaximalDepth() + 10000; // More than maximal call stack size
+    class InfiniteShrinkingDepth extends fc.Arbitrary<number> {
+      private static buildInfiniteShrinkable(n: number): fc.Shrinkable<number> {
+        function* g() {
+          yield n - 1;
+        }
+        if (n <= -stopAtShrinkDepth) {
+          return new Shrinkable(n);
+        }
+        return new Shrinkable(n, () => fc.stream(g()).map(InfiniteShrinkingDepth.buildInfiniteShrinkable));
+      }
+      generate(_mrng: fc.Random): fc.Shrinkable<number> {
+        return InfiniteShrinkingDepth.buildInfiniteShrinkable(0);
+      }
+    }
+
+    const out = fc.check(fc.property(new InfiniteShrinkingDepth(), _n => false), { seed });
+    expect(out.failed).toBe(true);
+    expect(out.counterexamplePath).toBe([...Array(stopAtShrinkDepth + 1)].map(() => '0').join(':'));
+  });
+});


### PR DESCRIPTION
## Why is this PR for?

Related to #499

This commit confirms that a well-defined shrinker should never run into stack overflows during shrinking process. Meanwhile some shrinking algorithms like the one for arrays seem to be broken and will need some updates.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *tests*

(✔️: yes, ❌: no)

## Potential impacts

None.