### PR TITLE
🐛 Fix letrec bug when __proto__ set to null

### DIFF
--- a/src/check/arbitrary/LetRecArbitrary.ts
+++ b/src/check/arbitrary/LetRecArbitrary.ts
@@ -53,7 +53,7 @@ export class LazyArbitrary extends Arbitrary<any> {
 
 /** @hidden */
 function isLazyArbitrary(arb: Arbitrary<any> | undefined): arb is LazyArbitrary {
-  return arb !== undefined && Object.prototype.hasOwnProperty.call(arb, 'underlying');
+  return typeof arb === 'object' && arb !== null && Object.prototype.hasOwnProperty.call(arb, 'underlying');
 }
 
 /**


### PR DESCRIPTION
## Why is this PR for?

Fixes bug introduced in #509

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.