### PR TITLE
🔧 Add missing references to lib-old in .*ignore configs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 example/
 node_modules/
 lib/
+lib-*/
 perf/
 test/legacy/
 test/type/

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ coverage/
 docs/
 documentation/
 example/
+lib-*/
 perf/
 prebuild/
 src/


### PR DESCRIPTION
## Why is this PR for?

Add missing references to lib-old in .*ignore configs

Directory lib-old was not ignored from some configurations.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *build config*

(✔️: yes, ❌: no)

## Potential impacts

None.
