### PR TITLE
✨ Do not generate internationalized domains

### DIFF
--- a/src/check/arbitrary/WebArbitrary.ts
+++ b/src/check/arbitrary/WebArbitrary.ts
@@ -21,8 +21,6 @@ export interface WebAuthorityConstraints {
   withUserInfo?: boolean;
   /** Enable port suffix */
   withPort?: boolean;
-  /** Remove domains starting by xn-- */
-  excludeInternationalizedDomains?: boolean;
 }
 
 /**
@@ -34,7 +32,7 @@ export interface WebAuthorityConstraints {
  */
 export function webAuthority(constraints?: WebAuthorityConstraints) {
   const c = constraints || {};
-  const hostnameArbs = [domain({ excludeInternationalizedDomains: c.excludeInternationalizedDomains })]
+  const hostnameArbs = [domain()]
     .concat(c.withIPv4 === true ? [ipV4()] : [])
     .concat(c.withIPv6 === true ? [ipV6().map(ip => `[${ip}]`)] : [])
     .concat(c.withIPv4Extended === true ? [ipV4Extended()] : []);

--- a/test/e2e/arbitraries/WebArbitrary.spec.ts
+++ b/test/e2e/arbitraries/WebArbitrary.spec.ts
@@ -5,7 +5,7 @@ const seed = Date.now();
 describe(`WebArbitrary (seed: ${seed})`, () => {
   it('Should produce valid domains', () => {
     fc.assert(
-      fc.property(fc.domain({ excludeInternationalizedDomains: true }), domain => {
+      fc.property(fc.domain(), domain => {
         const p = `http://user:pass@${domain}/path/?query#fragment`;
         const u = new URL(p);
         expect(u.hostname).toEqual(domain);
@@ -20,8 +20,7 @@ describe(`WebArbitrary (seed: ${seed})`, () => {
           withIPv4: false,
           withIPv6: false,
           withUserInfo: true,
-          withPort: true,
-          excludeInternationalizedDomains: true
+          withPort: true
         }),
         authority => {
           const domain = /(^|@)([-a-z0-9.]+)(:\d+$|$)/.exec(authority)![2];
@@ -41,8 +40,7 @@ describe(`WebArbitrary (seed: ${seed})`, () => {
           withIPv6: true,
           withIPv4Extended: true,
           withUserInfo: true,
-          withPort: true,
-          excludeInternationalizedDomains: true
+          withPort: true
         }),
         fc.array(fc.webSegment()).map(p => p.map(v => `/${v}`).join('')),
         fc.webQueryParameters(),

--- a/test/unit/check/arbitrary/WebArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/WebArbitrary.spec.ts
@@ -19,38 +19,26 @@ const isValidUrl = (t: string) => {
 
 describe('WebArbitrary', () => {
   describe('webUrl', () => {
-    genericHelper.isValidArbitrary(
-      c =>
-        webUrl({
-          ...c,
-          authoritySettings: {
-            ...c.authoritySettings,
-            // some domains starting by xn-- might not be valid internationalized domains
-            // they raise an exception when encountered by 'new URL' in node
-            excludeInternationalizedDomains: true
-          }
-        }),
-      {
-        isValidValue: (g: string) => isValidUrl(g),
-        seedGenerator: fc.record(
-          {
-            validSchemes: fc.constant(['ftp']),
-            authoritySettings: fc.record(
-              {
-                withIPv4: fc.boolean(),
-                withIPv6: fc.boolean(),
-                withIPv4Extended: fc.boolean(),
-                withUserInfo: fc.boolean(),
-                withPort: fc.boolean()
-              },
-              { withDeletedKeys: true }
-            ),
-            withQueryParameters: fc.boolean(),
-            withFragments: fc.boolean()
-          },
-          { withDeletedKeys: true }
-        )
-      }
-    );
+    genericHelper.isValidArbitrary(webUrl, {
+      isValidValue: (g: string) => isValidUrl(g),
+      seedGenerator: fc.record(
+        {
+          validSchemes: fc.constant(['ftp']),
+          authoritySettings: fc.record(
+            {
+              withIPv4: fc.boolean(),
+              withIPv6: fc.boolean(),
+              withIPv4Extended: fc.boolean(),
+              withUserInfo: fc.boolean(),
+              withPort: fc.boolean()
+            },
+            { withDeletedKeys: true }
+          ),
+          withQueryParameters: fc.boolean(),
+          withFragments: fc.boolean()
+        },
+        { withDeletedKeys: true }
+      )
+    });
   });
 });


### PR DESCRIPTION
## Why is this PR for?

Another way to fix #532 

Previous way was #536 but it seems better to have not internationalized domains by default for the moment. If one day, we add the support for internationalized domains we might want to also add badly internationalized ones.

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Generated values impact might rarely be impacted.

The probability to generate one of the filtered values is:
(1 / 36) * (4 / 5) * (1 / 37) * (1 / 37) * (1 / 37) = 0.00004387 %