### PR TITLE
🐛 Stack overflows while shrinking large arrays of commands

### DIFF
--- a/src/check/model/commands/CommandsArbitrary.ts
+++ b/src/check/model/commands/CommandsArbitrary.ts
@@ -12,6 +12,7 @@ import { ReplayPath } from '../ReplayPath';
 import { CommandsIterable } from './CommandsIterable';
 import { CommandsSettings } from './CommandsSettings';
 import { CommandWrapper } from './CommandWrapper';
+import { makeLazy } from '../../../stream/LazyIterableIterator';
 
 /** @hidden */
 class CommandsArbitrary<Model extends object, Real, RunResult, CheckAsync extends boolean> extends Arbitrary<
@@ -101,20 +102,22 @@ class CommandsArbitrary<Model extends object, Real, RunResult, CheckAsync extend
       ? Stream.nil<Shrinkable<CommandWrapper<Model, Real, RunResult, CheckAsync>>[]>()
       : new Stream([[]][Symbol.iterator]());
 
-    // keep fixed number commands at the beginnign
+    // keep fixed number commands at the beginning
     // remove items in remaining part except the last one
     for (let numToKeep = 0; numToKeep !== items.length; ++numToKeep) {
-      const size = this.lengthArb.shrinkableFor(items.length - 1 - numToKeep, false);
-      const fixedStart = items.slice(0, numToKeep);
       allShrinks = allShrinks.join(
-        size.shrink().map(l => fixedStart.concat(items.slice(items.length - (l.value + 1))))
+        makeLazy(() => {
+          const size = this.lengthArb.shrinkableFor(items.length - 1 - numToKeep, false);
+          const fixedStart = items.slice(0, numToKeep);
+          return size.shrink().map(l => fixedStart.concat(items.slice(items.length - (l.value + 1))));
+        })
       );
     }
 
     // shrink one by one
     for (let itemAt = 0; itemAt !== items.length; ++itemAt) {
       allShrinks = allShrinks.join(
-        items[itemAt].shrink().map(v => items.slice(0, itemAt).concat([v], items.slice(itemAt + 1)))
+        makeLazy(() => items[itemAt].shrink().map(v => items.slice(0, itemAt).concat([v], items.slice(itemAt + 1))))
       );
     }
 

--- a/test/e2e/NoStackOverflowOnShrink.spec.ts
+++ b/test/e2e/NoStackOverflowOnShrink.spec.ts
@@ -1,6 +1,5 @@
 import * as fc from '../../src/fast-check';
 import * as prand from 'pure-rand';
-import { Shrinkable } from '../../src/fast-check';
 
 const computeMaximalStackSize = () => {
   // Compute the maximal call stack size
@@ -30,7 +29,7 @@ const maxShrinksToAsk = 100;
 
 const seed = Date.now();
 describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
-  const iterateOverShrunkValues = <T>(s: Shrinkable<T>) => {
+  const iterateOverShrunkValues = <T>(s: fc.Shrinkable<T>) => {
     const it = s
       .shrink()
       .take(maxShrinksToAsk)
@@ -52,9 +51,9 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
           yield n - 1;
         }
         if (n <= -maxDepthForArrays) {
-          return new Shrinkable(n);
+          return new fc.Shrinkable(n);
         }
-        return new Shrinkable(n, () => fc.stream(g()).map(InfiniteShrinkingDepth.buildInfiniteShrinkable));
+        return new fc.Shrinkable(n, () => fc.stream(g()).map(InfiniteShrinkingDepth.buildInfiniteShrinkable));
       }
       generate(_mrng: fc.Random): fc.Shrinkable<number> {
         return InfiniteShrinkingDepth.buildInfiniteShrinkable(0);
@@ -73,7 +72,7 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
     const arb = fc.array(fc.boolean(), maxDepthForArrays);
-    let s: Shrinkable<boolean[]> | null = null;
+    let s: fc.Shrinkable<boolean[]> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
       if (tempShrinkable.value.length >= callStackSize) {
@@ -90,7 +89,7 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
     const arb = fc.shuffledSubarray([...Array(maxDepthForArrays)].map((_, i) => i));
-    let s: Shrinkable<number[]> | null = null;
+    let s: fc.Shrinkable<number[]> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
       if (tempShrinkable.value.length >= callStackSize) {
@@ -113,7 +112,7 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
     const arb = fc.commands([fc.boolean().map(b => new AnyCommand(b))], { maxCommands: maxDepthForArrays });
-    let s: Shrinkable<Iterable<fc.Command<{}, {}>>> | null = null;
+    let s: fc.Shrinkable<Iterable<fc.Command<{}, {}>>> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
       const cmds = [...tempShrinkable.value];

--- a/test/e2e/NoStackOverflowOnShrink.spec.ts
+++ b/test/e2e/NoStackOverflowOnShrink.spec.ts
@@ -19,20 +19,39 @@ const computeMaximalStackSize = () => {
 
 const callStackSize = computeMaximalStackSize();
 const callStackSizeWithMargin = 2 * callStackSize;
-const stopAtShrinkDepth = 40000;
+
+// Configure arbitraries and provide them with a maximal length much greater than the default one
+// This value is hardcoded in order to avoid variations from one env to another and ease replays in case of problem
+const maxDepthForArrays = 40000;
+
+// Not all the shrunk values of a given generated value will be asked
+// The aim is to check if asking for the first maxShrinksToAsk might trigger unwanted stack overflows
+const maxShrinksToAsk = 100;
+
 const seed = Date.now();
 describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
+  const iterateOverShrunkValues = <T>(s: Shrinkable<T>) => {
+    const it = s
+      .shrink()
+      .take(maxShrinksToAsk)
+      [Symbol.iterator]();
+    let cur = it.next();
+    while (!cur.done) {
+      cur = it.next();
+    }
+  };
+
   it('should not run into stack overflow during very deep shrink tasks', () => {
     // We expect the depth used by this test to be greater than
     // the maximal depth we computed before reaching a stack overflow
-    expect(stopAtShrinkDepth).toBeGreaterThan(callStackSizeWithMargin);
+    expect(maxDepthForArrays).toBeGreaterThan(callStackSizeWithMargin);
 
     class InfiniteShrinkingDepth extends fc.Arbitrary<number> {
       private static buildInfiniteShrinkable(n: number): fc.Shrinkable<number> {
         function* g() {
           yield n - 1;
         }
-        if (n <= -stopAtShrinkDepth) {
+        if (n <= -maxDepthForArrays) {
           return new Shrinkable(n);
         }
         return new Shrinkable(n, () => fc.stream(g()).map(InfiniteShrinkingDepth.buildInfiniteShrinkable));
@@ -44,16 +63,16 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
 
     const out = fc.check(fc.property(new InfiniteShrinkingDepth(), _n => false), { seed });
     expect(out.failed).toBe(true);
-    expect(out.counterexamplePath).toBe([...Array(stopAtShrinkDepth + 1)].map(() => '0').join(':'));
+    expect(out.counterexamplePath).toBe([...Array(maxDepthForArrays + 1)].map(() => '0').join(':'));
   });
 
   it('should not run into stack overflow while calling shrink on very large arrays', () => {
     // We expect the depth used by this test to be greater than
     // the maximal depth we computed before reaching a stack overflow
-    expect(stopAtShrinkDepth).toBeGreaterThan(callStackSizeWithMargin);
+    expect(maxDepthForArrays).toBeGreaterThan(callStackSizeWithMargin);
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
-    const arb = fc.array(fc.boolean(), stopAtShrinkDepth);
+    const arb = fc.array(fc.boolean(), maxDepthForArrays);
     let s: Shrinkable<boolean[]> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
@@ -61,16 +80,16 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
         s = tempShrinkable;
       }
     }
-    expect(() => s!.shrink()).not.toThrow();
+    expect(() => iterateOverShrunkValues(s!)).not.toThrow();
   });
 
   it('should not run into stack overflow while calling shrink on very large shuffled sub-arrays', () => {
     // We expect the depth used by this test to be greater than
     // the maximal depth we computed before reaching a stack overflow
-    expect(stopAtShrinkDepth).toBeGreaterThan(callStackSizeWithMargin);
+    expect(maxDepthForArrays).toBeGreaterThan(callStackSizeWithMargin);
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
-    const arb = fc.shuffledSubarray([...Array(stopAtShrinkDepth)].map((_, i) => i));
+    const arb = fc.shuffledSubarray([...Array(maxDepthForArrays)].map((_, i) => i));
     let s: Shrinkable<number[]> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
@@ -78,13 +97,13 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
         s = tempShrinkable;
       }
     }
-    expect(() => s!.shrink()).not.toThrow();
+    expect(() => iterateOverShrunkValues(s!)).not.toThrow();
   });
 
   it('should not run into stack overflow while calling shrink on very large arrays of commands', () => {
     // We expect the depth used by this test to be greater than
     // the maximal depth we computed before reaching a stack overflow
-    expect(stopAtShrinkDepth).toBeGreaterThan(callStackSizeWithMargin);
+    expect(maxDepthForArrays).toBeGreaterThan(callStackSizeWithMargin);
 
     class AnyCommand implements fc.Command<{}, {}> {
       constructor(readonly b: boolean) {}
@@ -93,7 +112,7 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
     }
 
     const mrng = new fc.Random(prand.xorshift128plus(seed));
-    const arb = fc.commands([fc.boolean().map(b => new AnyCommand(b))], { maxCommands: stopAtShrinkDepth });
+    const arb = fc.commands([fc.boolean().map(b => new AnyCommand(b))], { maxCommands: maxDepthForArrays });
     let s: Shrinkable<Iterable<fc.Command<{}, {}>>> | null = null;
     while (s === null) {
       const tempShrinkable = arb.generate(mrng);
@@ -103,6 +122,6 @@ describe(`NoStackOverflowOnShrink (seed: ${seed})`, () => {
         s = tempShrinkable;
       }
     }
-    expect(() => s!.shrink()).not.toThrow();
+    expect(() => iterateOverShrunkValues(s!)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Why is this PR for?

Shrink of large arrays of commands was causing crashes of fast-check.

As we did for `array` and `shuffledSubarray` in #505, we fixed the shrinker of `commands` so that it can be executed on large arrays of commands without running into stack overflows or other crashes.

Related to #499

Fixes #508

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.

Shrinker keeps shrinking towards the same values. We just tend to limit the stack size required to do it, and limit as much as possible every unneeded computations.
