### PR TITLE
✨ Stringify should distinguish `{}` from `Object.create(null)`

### DIFF
--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -55,14 +55,15 @@ export function stringifyInternal<Ts>(value: Ts, previousValues: any[]): string 
     case '[object Number]':
       return typeof value === 'number' ? stringifyNumber(value) : `new Number(${stringifyNumber(Number(value))})`;
     case '[object Object]': {
-      if (typeof (value as any).toString === 'function' && (value as any).toString !== Object.prototype.toString) {
-        // Instance (or one of its parent prototypes) overrides the default toString of Object
-        try {
-          return (value as any).toString();
-        } catch (err) {
-          // Only return what would have been the default toString on Object
-          return '[object Object]';
+      try {
+        const toStringAccessor = (value as any).toString; // <-- Can throw
+        if (typeof toStringAccessor === 'function' && toStringAccessor !== Object.prototype.toString) {
+          // Instance (or one of its parent prototypes) overrides the default toString of Object
+          return (value as any).toString(); // <-- Can throw
         }
+      } catch (err) {
+        // Only return what would have been the default toString on Object
+        return '[object Object]';
       }
       const rawRepr =
         '{' +

--- a/test/unit/utils/stringify.spec.ts
+++ b/test/unit/utils/stringify.spec.ts
@@ -14,16 +14,16 @@ const checkEqual = (a: any, b: any): boolean => {
 };
 
 class ThrowingToString {
-  toString = () => {
+  toString() {
     throw new Error('No toString');
-  };
+  }
 }
 
 class CustomTagThrowingToString {
   [Symbol.toStringTag] = 'CustomTagThrowingToString';
-  toString = () => {
+  toString() {
     throw new Error('No toString');
-  };
+  }
 }
 
 describe('stringify', () => {
@@ -144,5 +144,13 @@ describe('stringify', () => {
   it('Should be only produce toStringTag for failing toString', () => {
     expect(stringify(new ThrowingToString())).toEqual('[object Object]');
     expect(stringify(new CustomTagThrowingToString())).toEqual('[object CustomTagThrowingToString]');
+    // TODO Move to getter-based implementation instead - es5 required
+    const instance = Object.create(null);
+    Object.defineProperty(instance, 'toString', {
+      get: () => {
+        throw new Error('No such accessor');
+      }
+    });
+    expect(stringify(instance)).toEqual('[object Object]');
   });
 });

--- a/test/unit/utils/stringify.spec.ts
+++ b/test/unit/utils/stringify.spec.ts
@@ -129,6 +129,18 @@ describe('stringify', () => {
     expect(stringify(Symbol('fc'))).toEqual('Symbol("fc")');
     expect(stringify(Symbol.for('fc'))).toEqual('Symbol.for("fc")');
   });
+  it('Should be able to stringify Object without prototype', () => {
+    expect(stringify(Object.create(null))).toEqual('Object.create(null)');
+    expect(stringify(Object.assign(Object.create(null), { a: 1 }))).toEqual(
+      'Object.assign(Object.create(null),{"a":1})'
+    );
+  });
+  it('Should be able to stringify Object with custom __proto__ value', () => {
+    // TODO Remove eval(...) - ts-jest seems not to properly transpile { ['__proto__']: 1 } when targeting es3
+    // expect(stringify({ ['__proto__']: 1 })).toEqual('{["__proto__"]:1}');
+    expect(stringify(eval("({ ['__proto__']: 1 })"))).toEqual('{["__proto__"]:1}');
+    // NOTE: {__proto__: 1} and {'__proto__': 1} are not the same as {['__proto__']: 1}
+  });
   it('Should be only produce toStringTag for failing toString', () => {
     expect(stringify(new ThrowingToString())).toEqual('[object Object]');
     expect(stringify(new CustomTagThrowingToString())).toEqual('[object CustomTagThrowingToString]');


### PR DESCRIPTION
## Why is this PR for?

Fixes #507

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Might impact the value produced by `fc.stringify`, helper used internally to get stringified value of any object