### PR TITLE
🐛 Fix `fc.object()` with withNullPrototype

### DIFF
--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -193,7 +193,7 @@ const anythingInternal = (constraints: ObjectConstraints): Arbitrary<unknown> =>
       ...(constraints.withMap ? [mapArb()] : []),
       ...(constraints.withSet ? [setArb()] : []),
       ...(constraints.withObjectString ? [anythingArb().map(o => stringify(o))] : []),
-      ...(constraints.withNullPrototype ? objectArb().map(o => Object.assign(Object.create(null), o)) : [])
+      ...(constraints.withNullPrototype ? [objectArb().map(o => Object.assign(Object.create(null), o))] : [])
     );
   });
 


### PR DESCRIPTION
## Why is this PR for?

The code of `fc.object()` was trying to spread an `Arbitrary`, which is a totally illegal operation. Transpilation may have covered the bug...

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None. Fixes a potential bug :)