### PR TITLE
Fix broken links in documentation

### DIFF
--- a/documentation/1-Guides/AdvancedArbitraries.md
+++ b/documentation/1-Guides/AdvancedArbitraries.md
@@ -90,7 +90,7 @@ const intNoShrink = fc.integer().noShrink();
 
 ## Build your own
 
-**NOTE:** Before writing your own arbitrary from scratch you should have a look to the [examples](https://github.com/dubzzz/fast-check/tree/master/example) provided in the repository. There are examples for: [recursive structures](https://github.com/dubzzz/fast-check/tree/master/example/binary-trees), [properties for automata or state machine](https://github.com/dubzzz/fast-check/tree/master/example/model-based-testing) and others.
+**NOTE:** Before writing your own arbitrary from scratch you should have a look to the [examples](https://github.com/dubzzz/fast-check/tree/master/example) provided in the repository. There are examples for: [recursive structures](https://github.com/dubzzz/fast-check/tree/master/example/002-recursive/isSearchTree), [properties for automata or state machine](https://github.com/dubzzz/fast-check/tree/master/example/004-stateMachine/musicPlayer) and others.
 
 You can also fully customize your arbitrary: not derive it from any of the buit-in arbitraries. What you have to do is to extend [Arbitrary](https://github.com/dubzzz/fast-check/blob/master/src/check/arbitrary/definition/Arbitrary.ts) and implement `generate(mrng: Random): Shrinkable<T>`.
 

--- a/documentation/1-Guides/Tips.md
+++ b/documentation/1-Guides/Tips.md
@@ -56,7 +56,7 @@ Model based testing approach have been introduced into fast-check to ease UI tes
 
 The idea of the approach is to define commands that could be applied to your system. The framework then picks zero, one or more commands and run them sequentially if they can be executed on the current state.
 
-A full example is available [here](https://github.com/dubzzz/fast-check/tree/master/example/model-based-testing).
+A full example is available [here](https://github.com/dubzzz/fast-check/tree/master/example/004-stateMachine/musicPlayer).
 
 Let's take the case of a list class with `pop`, `push`, `size` methods as an example.
 


### PR DESCRIPTION
A few of the links in the documentation to example custom arbitraries were broken by ffa7dac. This PR updates those links to the new location of the examples.

## In a nutshell

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

No potential negative impacts are foreseen.