### PR TITLE
💥 Remove support for `with_deleted_keys` on `fc.record`

### DIFF
--- a/src/check/arbitrary/RecordArbitrary.ts
+++ b/src/check/arbitrary/RecordArbitrary.ts
@@ -6,22 +6,13 @@ import { genericTuple } from './TupleArbitrary';
 export interface RecordConstraints {
   /** Allow to remove keys from the generated record */
   withDeletedKeys?: boolean;
-
-  /** @depreciated Prefer withDeletedKeys */
-  with_deleted_keys?: boolean;
 }
 
 interface DeletedKeys {
   withDeletedKeys: true;
 }
 
-interface DeletedKeysDepreciated {
-  with_deleted_keys: true;
-}
-
-type ConstrainedArbitrary<T, Constraints> = Constraints extends DeletedKeys | DeletedKeysDepreciated
-  ? Arbitrary<Partial<T>>
-  : Arbitrary<T>;
+type ConstrainedArbitrary<T, Constraints> = Constraints extends DeletedKeys ? Arbitrary<Partial<T>> : Arbitrary<T>;
 
 /** @internal */
 function rawRecord<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<{ [K in keyof T]: T[K] }> {
@@ -63,8 +54,9 @@ function record<T, Constraints extends RecordConstraints>(
   constraints: Constraints
 ): ConstrainedArbitrary<{ [K in keyof T]: T[K] }, Constraints>;
 function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }, constraints?: RecordConstraints) {
-  if (constraints == null || (constraints.withDeletedKeys !== true && constraints.with_deleted_keys !== true))
+  if (constraints == null || constraints.withDeletedKeys !== true) {
     return rawRecord(recordModel);
+  }
 
   const updatedRecordModel: {
     [key: string]: Arbitrary<{ value: T } | null>;


### PR DESCRIPTION
## Why is this PR for?

Remove support for previously depreciated parameter in fc.record.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove depreciated feature*

(✔️: yes, ❌: no)

## Potential impacts

Remove depreciated feature.
All references to `with_deleted_keys` should changed into `withDeletedKeys`.