### PR TITLE
✅ Check that fast-check's users can run properties with cjs+esm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "pure-rand": "^2.0.0"
+    "pure-rand": "3.0.0-alpha.2.0.0.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.8",

--- a/test/esm/node-with-import/main.js
+++ b/test/esm/node-with-import/main.js
@@ -1,3 +1,5 @@
 import fc from 'fast-check';
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/test/esm/node-with-require/main.js
+++ b/test/esm/node-with-require/main.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line
 const fc = require('fast-check');
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/test/esm/rollup-with-import/main.js
+++ b/test/esm/rollup-with-import/main.js
@@ -1,3 +1,5 @@
 import fc from 'fast-check';
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/test/esm/rollup-with-require/main.js
+++ b/test/esm/rollup-with-require/main.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line
 const fc = require('fast-check');
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/test/esm/webpack-with-import/main.js
+++ b/test/esm/webpack-with-import/main.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line
 import fc from 'fast-check';
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/test/esm/webpack-with-require/main.js
+++ b/test/esm/webpack-with-require/main.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line
 const fc = require('fast-check');
+
 // eslint-disable-next-line
 console.log(fc.__type);
+fc.assert(fc.property(fc.nat(), fc.nat(), (a, b) => a + b === b + a));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,10 +3245,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pure-rand@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-2.0.0.tgz#3324633545207907fe964c2f0ebf05d8e9a7f129"
-  integrity sha512-mk98aayyd00xbfHgE3uEmAUGzz3jCdm8Mkf5DUXUhc7egmOaGG2D7qhVlynGenNe9VaNJZvzO9hkc8myuTkDgw==
+pure-rand@3.0.0-alpha.2.0.0.0:
+  version "3.0.0-alpha.2.0.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-3.0.0-alpha.2.0.0.0.tgz#1fa9a3f4e3d8e00645036bf9154965461fc2e039"
+  integrity sha512-itTDyUn20gprHALxeFFZBfFoLKdDGCZvQsWClgbm1igShB7/a4QctZL0MNVsbuMxbD/2BelFFQQH5qu9Rl6cTQ==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
## Why is this PR for?

Current checks on cjs+esm build do not confirm that fats-check can be used properly.
They only confirm that the resulting bundle can be opened and that basic metadata exposed by fast-check are accessible.

The current PR adds checks to confirm that user can run basic properties. It mostly checks that fast-check uses correct dependencies (compatible with the settings of the user).

It may actually require to bump pure-rand. So that can be considered as 'fix an issue'.

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.
