### PR TITLE
💥 Remove pre-packaged version for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     }
   },
   "module": "lib/esm/fast-check.js",
-  "browser": "lib/esm/fast-check.js",
   "types": "lib/types/fast-check.d.ts",
   "files": [
     "lib"


### PR DESCRIPTION
## Why is this PR for?

Bundlers such as rollup or webpack are often preferred nowadays.

Otherwise some services offer mirrors with the bundles ready for use in browsers:
- pika
- bundle.run

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove browser version*

(✔️: yes, ❌: no)

## Potential impacts

No more browser version