### PR TITLE
Add findOrUndefined function.

### DIFF
--- a/src/check/arbitrary/ConstantArbitrary.ts
+++ b/src/check/arbitrary/ConstantArbitrary.ts
@@ -3,6 +3,7 @@ import { stream } from '../../stream/Stream';
 import { cloneMethod, hasCloneMethod } from '../symbols';
 import { Arbitrary } from './definition/Arbitrary';
 import { Shrinkable } from './definition/Shrinkable';
+import { findOrUndefined } from './helpers/ArrayHelper';
 
 /** @hidden */
 class ConstantArbitrary<T> extends Arbitrary<T> {
@@ -56,7 +57,7 @@ function constantFrom<T>(...values: T[]): Arbitrary<T> {
   if (values.length === 0) {
     throw new Error('fc.constantFrom expects at least one parameter');
   }
-  if (values.find(v => hasCloneMethod(v)) != null) {
+  if (findOrUndefined(values, v => hasCloneMethod(v)) != undefined) {
     throw new Error('fc.constantFrom does not accept cloneable values, not supported for the moment');
   }
   return new ConstantArbitrary<T>([...values]);

--- a/src/check/arbitrary/helpers/ArrayHelper.ts
+++ b/src/check/arbitrary/helpers/ArrayHelper.ts
@@ -1,0 +1,12 @@
+/**
+ * @hidden
+ * Find first element matching the predicate in the array, or null if none match
+ * Equivalent to Array.prototype.find, but works on Internet Explorer 11.
+ */
+export function findOrUndefined<T> (ts: ArrayLike<T>, f: (t: T) => boolean): T | undefined {
+  for (let i = 0; i < ts.length; i++) {
+    const t = ts[i];
+    if (f(t)) return t;
+  }
+  return undefined;
+}

--- a/src/check/arbitrary/helpers/ArrayHelper.ts
+++ b/src/check/arbitrary/helpers/ArrayHelper.ts
@@ -3,7 +3,7 @@
  * Find first element matching the predicate in the array, or null if none match
  * Equivalent to Array.prototype.find, but works on Internet Explorer 11.
  */
-export function findOrUndefined<T> (ts: ArrayLike<T>, f: (t: T) => boolean): T | undefined {
+export function findOrUndefined<T>(ts: ArrayLike<T>, f: (t: T) => boolean): T | undefined {
   for (let i = 0; i < ts.length; i++) {
     const t = ts[i];
     if (f(t)) return t;

--- a/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
+++ b/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
@@ -4,30 +4,43 @@ import { findOrUndefined } from '../../../../../src/check/arbitrary/helpers/Arra
 describe('ArrayHelper', () => {
   describe('findOrNull', () => {
     it('should return null for empty array', () => {
-      expect(findOrUndefined<number>([], () => {
-        throw new Error('⊥')
-      })).toBe(undefined);
+      expect(
+        findOrUndefined<number>([], () => {
+          throw new Error('⊥');
+        })
+      ).toBe(undefined);
     });
     it('should return a matching element', () => {
-      fc.assert(fc.property(fc.array(fc.integer()), fc.integer(), fc.array(fc.integer()), (prefix, e, suffix) => {
-        expect(findOrUndefined<number>([...prefix, e, ...suffix], (x) => x === e)).toBe(e);
-      }))
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.integer(), fc.array(fc.integer()), (prefix, e, suffix) => {
+          expect(findOrUndefined<number>([...prefix, e, ...suffix], x => x === e)).toBe(e);
+        })
+      );
     });
     it('should return null when not present', () => {
-      fc.assert(fc.property(fc.array(fc.integer(0, 100)), fc.integer(-100, -1), fc.array(fc.integer(0, 100)), (prefix, e, suffix) => {
-        expect(findOrUndefined<number>([...prefix, ...suffix], (x) => x === e)).toBe(undefined);
-      }));
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(0, 100)),
+          fc.integer(-100, -1),
+          fc.array(fc.integer(0, 100)),
+          (prefix, e, suffix) => {
+            expect(findOrUndefined<number>([...prefix, ...suffix], x => x === e)).toBe(undefined);
+          }
+        )
+      );
     });
     it('should pass some simple examples', () => {
-      expect(findOrUndefined<number>([7, 8, 2, 1], (x) => x < 3)).toBe(2);
-      expect(findOrUndefined<number>([12, 8, -1], (x) => x < 3)).toBe(-1);
-      expect(findOrUndefined<number>([3], (x) => x > 10)).toBe(undefined);
-      expect(findOrUndefined<number>([], (x) => x > 10)).toBe(undefined);
+      expect(findOrUndefined<number>([7, 8, 2, 1], x => x < 3)).toBe(2);
+      expect(findOrUndefined<number>([12, 8, -1], x => x < 3)).toBe(-1);
+      expect(findOrUndefined<number>([3], x => x > 10)).toBe(undefined);
+      expect(findOrUndefined<number>([], x => x > 10)).toBe(undefined);
     });
     it('should be consistent with Array.prototype.indexOf', () => {
-      fc.assert(fc.property(fc.array(fc.integer(1, 200)), fc.integer(1, 200), (xs, x) => {
-        expect(findOrUndefined<number>(xs, (a) => a === x) === undefined).toBe(xs.indexOf(x) === -1);
-      }));
+      fc.assert(
+        fc.property(fc.array(fc.integer(1, 200)), fc.integer(1, 200), (xs, x) => {
+          expect(findOrUndefined<number>(xs, a => a === x) === undefined).toBe(xs.indexOf(x) === -1);
+        })
+      );
     });
   });
 });

--- a/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
+++ b/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
@@ -1,0 +1,33 @@
+import * as fc from '../../../../../lib/fast-check';
+import { findOrUndefined } from '../../../../../src/check/arbitrary/helpers/ArrayHelper';
+
+describe('ArrayHelper', () => {
+  describe('findOrNull', () => {
+    it('should return null for empty array', () => {
+      expect(findOrUndefined<number>([], () => {
+        throw new Error('⊥')
+      })).toBe(undefined);
+    });
+    it('should return a matching element', () => {
+      fc.assert(fc.property(fc.array(fc.integer()), fc.integer(), fc.array(fc.integer()), (prefix, e, suffix) => {
+        expect(findOrUndefined<number>([...prefix, e, ...suffix], (x) => x === e)).toBe(e);
+      }))
+    });
+    it('should return null when not present', () => {
+      fc.assert(fc.property(fc.array(fc.integer(0, 100)), fc.integer(-100, -1), fc.array(fc.integer(0, 100)), (prefix, e, suffix) => {
+        expect(findOrUndefined<number>([...prefix, ...suffix], (x) => x === e)).toBe(undefined);
+      }));
+    });
+    it('should pass some simple examples', () => {
+      expect(findOrUndefined<number>([7, 8, 2, 1], (x) => x < 3)).toBe(2);
+      expect(findOrUndefined<number>([12, 8, -1], (x) => x < 3)).toBe(-1);
+      expect(findOrUndefined<number>([3], (x) => x > 10)).toBe(undefined);
+      expect(findOrUndefined<number>([], (x) => x > 10)).toBe(undefined);
+    });
+    it('should be consistent with Array.prototype.indexOf', () => {
+      fc.assert(fc.property(fc.array(fc.integer(1, 200)), fc.integer(1, 200), (xs, x) => {
+        expect(findOrUndefined<number>(xs, (a) => a === x) === undefined).toBe(xs.indexOf(x) === -1);
+      }));
+    });
+  });
+});

--- a/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
+++ b/test/unit/check/arbitrary/helpers/ArrayHelper.spec.ts
@@ -2,8 +2,8 @@ import * as fc from '../../../../../lib/fast-check';
 import { findOrUndefined } from '../../../../../src/check/arbitrary/helpers/ArrayHelper';
 
 describe('ArrayHelper', () => {
-  describe('findOrNull', () => {
-    it('should return null for empty array', () => {
+  describe('findOrUndefined', () => {
+    it('should return undefined for empty array', () => {
       expect(
         findOrUndefined<number>([], () => {
           throw new Error('⊥');
@@ -17,7 +17,7 @@ describe('ArrayHelper', () => {
         })
       );
     });
-    it('should return null when not present', () => {
+    it('should return undefined when not present', () => {
       fc.assert(
         fc.property(
           fc.array(fc.integer(0, 100)),


### PR DESCRIPTION
This allows us to avoid using Array.prototype.find,
which is not available on Internet Explorer 11.

## Why is this PR for?

Addresses issue #582

## In a nutshell

❌ New feature
✔️/❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Slightly larger code size, slightly longer testing time. 
