### PR TITLE
🔧 Add missing `"private": true` on package.json used for tests

### DIFF
--- a/test/esm/node-extension-cjs/package.json
+++ b/test/esm/node-extension-cjs/package.json
@@ -7,5 +7,6 @@
   "dependencies": {
     "fast-check": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/node-extension-mjs/package.json
+++ b/test/esm/node-extension-mjs/package.json
@@ -7,5 +7,6 @@
   "dependencies": {
     "fast-check": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/node-with-import/package.json
+++ b/test/esm/node-with-import/package.json
@@ -7,5 +7,6 @@
   "dependencies": {
     "fast-check": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/node-with-require/package.json
+++ b/test/esm/node-with-require/package.json
@@ -7,5 +7,6 @@
   "dependencies": {
     "fast-check": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/rollup-with-import/package.json
+++ b/test/esm/rollup-with-import/package.json
@@ -15,5 +15,6 @@
     "rollup": "^2.10.0",
     "rollup-plugin-node-builtins": "^2.1.2"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/rollup-with-require/package.json
+++ b/test/esm/rollup-with-require/package.json
@@ -15,5 +15,6 @@
     "rollup": "^2.10.0",
     "rollup-plugin-node-builtins": "^2.1.2"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/webpack-with-import/package.json
+++ b/test/esm/webpack-with-import/package.json
@@ -13,5 +13,6 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/test/esm/webpack-with-require/package.json
+++ b/test/esm/webpack-with-require/package.json
@@ -13,5 +13,6 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }


### PR DESCRIPTION
## Why is this PR for?

Add missing `"private": true` on package.json used for tests

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *package.json with private:true*

(✔️: yes, ❌: no)

## Potential impacts

None.