### PR TITLE
💚 Check compatibility with node 12.x and >= 12.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,16 +59,20 @@ jobs:
         - yarn build:prod
         - yarn link
         - cd test/esm
+        # Node >=13.2.0 enables support for ES modules by default
+        # Our default version of node is above 13.2.0
+        - node --version
+        - sh run.sh
+        # Node 12.x and >=12.18 enables support for ES modules by default
+        - nvm install 12.18
+        - node --version
+        - sh run.sh
+        # Node <12.18 requires a flag to support ES modules but can understand them
+        - nvm install 12.17
+        - node --version
+        - sh run.sh
         # Node 10 does not understand ES modules
         - nvm install 10
-        - node --version
-        - sh run.sh
-        # Node 12 requires a flag to support ES modules but can understand them
-        - nvm install 12
-        - node --version
-        - sh run.sh
-        # Node >=13.2.0 enables support for ES modules by default
-        - nvm install 14
         - node --version
         - sh run.sh
     - stage: test

--- a/test/esm/run.sh
+++ b/test/esm/run.sh
@@ -7,10 +7,11 @@ set -x
 set -e
 
 ## Versions of node >=13.2.0 support es modules without any flag
+## Versions 12.x of node >=12.18.0 support es modules without any flag
 #NODE_MAJOR=$(node --version | cut -d. -f 1 | cut -dv -f 2)
 #NODE_MINOR=$(node --version | cut -d. -f 2)
 #
-#if [ $NODE_MAJOR -gt 13 ] || [ $NODE_MAJOR -eq 13 ] && [ $NODE_MINOR -ge 2 ]; then
+#if [ $NODE_MAJOR -gt 13 ] || [ $NODE_MAJOR -eq 13 ] && [ $NODE_MINOR -ge 2 ] || [ $NODE_MAJOR -eq 12 ] && [ $NODE_MINOR -ge 18 ]; then
 #    cd node-with-import
 #    yarn --frozen-lockfile --ignore-engines
 #    yarn link "fast-check"


### PR DESCRIPTION
## Why is this PR for?

Now that node 12 has been unflagged and support ES Modules out-of-the-box, we need to ensure it will work correctly with fast-check.

For holder releases (<12.18) and new ones (>=12.18)

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *CI for CommonJS and ESM checks*

(✔️: yes, ❌: no)

## Potential impacts

None
