### PR TITLE
🏷️ Better typings for `fc.object` and `fc.dictionnary`

### DIFF
--- a/src/check/arbitrary/DictionaryArbitrary.ts
+++ b/src/check/arbitrary/DictionaryArbitrary.ts
@@ -17,7 +17,7 @@ function toObject<T>(items: [string, T][]): { [key: string]: T } {
  * @param keyArb Arbitrary used to generate the keys of the object
  * @param valueArb Arbitrary used to generate the values of the object
  */
-function dictionary<T>(keyArb: Arbitrary<string>, valueArb: Arbitrary<T>): Arbitrary<{ [key: string]: T }> {
+function dictionary<T>(keyArb: Arbitrary<string>, valueArb: Arbitrary<T>): Arbitrary<Record<string, T>> {
   return set(tuple(keyArb, valueArb), (t1, t2) => t1[0] === t2[0]).map(toObject);
 }
 

--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -206,8 +206,7 @@ const anythingInternal = (constraints: ObjectConstraints): Arbitrary<unknown> =>
 };
 
 /** @hidden */
-// eslint-disable-next-line @typescript-eslint/ban-types
-const objectInternal = (constraints: ObjectConstraints): Arbitrary<object> => {
+const objectInternal = (constraints: ObjectConstraints): Arbitrary<Record<string, unknown>> => {
   return dictionary(constraints.key, anythingInternal(constraints));
 };
 
@@ -258,8 +257,7 @@ function anything(settings?: ObjectConstraints.Settings): Arbitrary<unknown> {
  * @example
  * ```{} or {k: [{}, 1, 2]}```
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function object(): Arbitrary<object>;
+function object(): Arbitrary<Record<string, unknown>>;
 /**
  * For any objects following the constraints defined by `settings`
  *
@@ -270,10 +268,8 @@ function object(): Arbitrary<object>;
  *
  * @param settings Constraints to apply when building instances
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function object(settings: ObjectConstraints.Settings): Arbitrary<object>;
-// eslint-disable-next-line @typescript-eslint/ban-types
-function object(settings?: ObjectConstraints.Settings): Arbitrary<object> {
+function object(settings: ObjectConstraints.Settings): Arbitrary<Record<string, unknown>>;
+function object(settings?: ObjectConstraints.Settings): Arbitrary<Record<string, unknown>> {
   return objectInternal(ObjectConstraints.from(settings));
 }
 


### PR DESCRIPTION
## Why is this PR for?

Better typings for `fc.object` and `fc.dictionnary`

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

- Typings impact: risk minor - no regression expected neither for object nor for dictionary
