### PR TITLE
Fix markdown section

### DIFF
--- a/documentation/1-Guides/Tips.md
+++ b/documentation/1-Guides/Tips.md
@@ -235,7 +235,6 @@ test('should run with custom scheduler then generated ones', () =>
     }
   ));
 ```
-```
 
 ## Opt for verbose failures
 


### PR DESCRIPTION
A section was treated as a code block due to a duplicate closing marker.

## Why is this PR for?
This PR fixes a simple markdown problem.

## In a nutshell

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts
Suitably rendered documentation ;)
