### PR TITLE
💚 Generated typings where causing the doc generation to crash

### DIFF
--- a/src/check/arbitrary/EmailArbitrary.ts
+++ b/src/check/arbitrary/EmailArbitrary.ts
@@ -3,13 +3,14 @@ import { buildLowerAlphaNumericArb } from './helpers/SpecificCharacterRange';
 import { domain } from './HostArbitrary';
 import { stringOf } from './StringArbitrary';
 import { tuple } from './TupleArbitrary';
+import { Arbitrary } from './definition/Arbitrary';
 
 /**
  * For email address
  *
  * According to RFC 5322 - https://www.ietf.org/rfc/rfc5322.txt
  */
-export function emailAddress() {
+export function emailAddress(): Arbitrary<string> {
   const others = ['!', '#', '$', '%', '&', "'", '*', '+', '-', '/', '=', '?', '^', '_', '`', '{', '|', '}', '~'];
   const atextArb = buildLowerAlphaNumericArb(others);
   const dotAtomArb = array(stringOf(atextArb, 1, 10), 1, 5).map((a) => a.join('.'));

--- a/src/check/arbitrary/HostArbitrary.ts
+++ b/src/check/arbitrary/HostArbitrary.ts
@@ -7,6 +7,7 @@ import {
 import { option } from './OptionArbitrary';
 import { stringOf } from './StringArbitrary';
 import { tuple } from './TupleArbitrary';
+import { Arbitrary } from './definition/Arbitrary';
 
 /** @hidden */
 function subdomain() {
@@ -33,7 +34,7 @@ function subdomain() {
  * - https://www.ietf.org/rfc/rfc1123.txt
  * - https://url.spec.whatwg.org/
  */
-export function domain() {
+export function domain(): Arbitrary<string> {
   const alphaNumericArb = buildLowerAlphaArb([]);
   const extensionArb = stringOf(alphaNumericArb, 2, 10);
   return tuple(array(subdomain(), 1, 5), extensionArb)
@@ -42,7 +43,7 @@ export function domain() {
 }
 
 /** @hidden */
-export function hostUserInfo() {
+export function hostUserInfo(): Arbitrary<string> {
   const others = ['-', '.', '_', '~', '!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=', ':'];
   return stringOf(buildAlphaNumericPercentArb(others));
 }

--- a/src/check/arbitrary/WebArbitrary.ts
+++ b/src/check/arbitrary/WebArbitrary.ts
@@ -9,6 +9,7 @@ import { oneof } from './OneOfArbitrary';
 import { option } from './OptionArbitrary';
 import { stringOf } from './StringArbitrary';
 import { tuple } from './TupleArbitrary';
+import { Arbitrary } from './definition/Arbitrary';
 
 export interface WebAuthorityConstraints {
   /** Enable IPv4 in host */
@@ -30,7 +31,7 @@ export interface WebAuthorityConstraints {
  *
  * @param constraints
  */
-export function webAuthority(constraints?: WebAuthorityConstraints) {
+export function webAuthority(constraints?: WebAuthorityConstraints): Arbitrary<string> {
   const c = constraints || {};
   const hostnameArbs = [domain()]
     .concat(c.withIPv4 === true ? [ipV4()] : [])
@@ -50,7 +51,7 @@ export function webAuthority(constraints?: WebAuthorityConstraints) {
  *
  * eg.: In the url `https://github.com/dubzzz/fast-check/`, `dubzzz` and `fast-check` are segments
  */
-export function webSegment() {
+export function webSegment(): Arbitrary<string> {
   // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
   // segment       = *pchar
   const others = ['-', '.', '_', '~', '!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=', ':', '@'];
@@ -72,7 +73,7 @@ function uriQueryOrFragment() {
  *
  * eg.: In the url `https://domain/plop/?hello=1&world=2`, `?hello=1&world=2` are query parameters
  */
-export function webQueryParameters() {
+export function webQueryParameters(): Arbitrary<string> {
   return uriQueryOrFragment();
 }
 
@@ -83,7 +84,7 @@ export function webQueryParameters() {
  *
  * eg.: In the url `https://domain/plop?page=1#hello=1&world=2`, `?hello=1&world=2` are query parameters
  */
-export function webFragments() {
+export function webFragments(): Arbitrary<string> {
   return uriQueryOrFragment();
 }
 
@@ -112,7 +113,7 @@ export function webUrl(constraints?: {
   authoritySettings?: WebAuthorityConstraints;
   withQueryParameters?: boolean;
   withFragments?: boolean;
-}) {
+}): Arbitrary<string> {
   const c = constraints || {};
   const validSchemes = c.validSchemes || ['http', 'https'];
   const schemeArb = constantFrom(...validSchemes);


### PR DESCRIPTION
## Why is this PR for?

The errors were reported by @typescript-eslint/explicit-module-boundary-types as warnings. Unfortunately enabling them would ask to add several missing typings that may not be really needed.

The rule could be added only for the real source code by adding the following into `.eslintrc.cjs` file:
```
  overrides: [
    {
      files: ['src/**/*.ts'],
      rules: {
        '@typescript-eslint/explicit-module-boundary-types': ['error', { allowArgumentsExplicitlyTypedAsAny: true }],
      },
    },
  ],
```

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *fix build issue*

(✔️: yes, ❌: no)

## Potential impacts

None.