### PR TITLE
✅ E2E for AsyncScheduler were relying on changing data

### DIFF
--- a/test/e2e/AsyncScheduler.spec.ts
+++ b/test/e2e/AsyncScheduler.spec.ts
@@ -172,7 +172,10 @@ describe(`AsyncScheduler (seed: ${seed})`, () => {
     expect(outRetry.failed).toBe(true);
     expect(outRetry.numRuns).toBe(1);
 
-    expect(outRetry.error).toBe(out.error);
+    const cleanError = (error: string) => {
+      return error.replace(/AsyncScheduler\.spec\.ts:\d+:\d+/g, 'AsyncScheduler.spec.ts:*:*');
+    };
+    expect(cleanError(outRetry.error!)).toBe(cleanError(out.error!));
     expect(String(outRetry.counterexample![0])).toBe(String(out.counterexample![0]));
   });
 });


### PR DESCRIPTION
## Why is this PR for?

The E2E tests written for `AsyncScheduler` were relying on changing data. They failed as soon as we updated the targeted versions of node, ts... (see [branch next-1_25_1](https://github.com/dubzzz/fast-check/tree/next-1_25_1))

See:
```
      Received: 1
          at propertyValidator (C:\dev\fast-check\test\e2e\AsyncScheduler.spec.ts:152:21)
          at processTicksAndRejections (internal/process/task_queues.js:93:5)
          at AsyncProperty.run (C:\dev\fast-check\src\check\property\AsyncProperty.generic.ts:31:22)
          at asyncRunIt (C:\dev\fast-check\src\check\runner\Runner.ts:44:17)
    -     at Object.<anonymous> (C:\dev\fast-check\test\e2e\AsyncScheduler.spec.ts:155:17)
    +     at Object.<anonymous> (C:\dev\fast-check\test\e2e\AsyncScheduler.spec.ts:169:22)
```

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
