### PR TITLE
Update script to an nmp package for compatibility on with windows: mkdir -p --> mkdirp (#626).

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-config-prettier": "^6.11.0",
     "jest": "^25.5.4",
     "markdownbars": "^1.0.10",
+    "mkdirp": "^1.0.4",
     "prettier": "2.0.5",
     "replace-in-file": "^6.0.0",
     "rollup": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:rollup-esm": "rollup --config test/rollup/esm/rollup.config.js && node test/rollup/esm/dist/main.js",
     "test:rollup-iife": "rollup --config test/rollup/iife/rollup.config.js && node test/rollup/iife/dist/main.js",
     "coverage": "cat ./coverage/lcov.info | coveralls",
-    "docs": "mkdir -p docs/2-API && docsify-init --editDir documentation && cp -R documentation/* docs/ && api-extractor run --local && generate-ts-docs markdown -i docs/2-API -o docs/2-API && cat README.md | sed 's/https:\\/\\/github.com\\/dubzzz\\/fast-check\\/blob\\/master\\/documentation//g' > docs/README.md && markdownbars -i docs/_sidebar.md -o docs/_sidebar.md",
+    "docs": "mkdirp docs/2-API && docsify-init --editDir documentation && cp -R documentation/* docs/ && api-extractor run --local && generate-ts-docs markdown -i docs/2-API -o docs/2-API && cat README.md | sed 's/https:\\/\\/github.com\\/dubzzz\\/fast-check\\/blob\\/master\\/documentation//g' > docs/README.md && markdownbars -i docs/_sidebar.md -o docs/_sidebar.md",
     "format": "prettier --write \"**/*.{js,ts}\"",
     "format:check": "prettier --list-different \"**/*.{js,ts}\"",
     "lint": "eslint \"**/*.{js,ts}\" --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3616,6 +3616,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 module-deps@^6.0.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.2.tgz#d8a15c2265dfc119153c29bb47386987d0ee423b"


### PR DESCRIPTION
Issue #626 

## Why is this PR for?
This script, defined in the root package.json, makes use of mkdir -p which is not working on Windows. We should replace it by the npm package mkdirp

Describe the reason of this PR or give a link towards the associated issue.
https://github.com/dubzzz/fast-check/issues/626

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

If you expect some noticeable impacts with your change please explain.

Here are some examples of impacts that might be reported into this section:
- Generated values impact,
- Shrink values impact,
- Performance impact,
- Typings impact
