### PR TITLE
💥✨ Improve typings for `fc.constantFrom`

### DIFF
--- a/src/check/arbitrary/ConstantArbitrary.ts
+++ b/src/check/arbitrary/ConstantArbitrary.ts
@@ -53,14 +53,14 @@ function clonedConstant<T>(value: T): Arbitrary<T> {
  *
  * @param values Constant values to be produced (all values shrink to the first one)
  */
-function constantFrom<T>(...values: T[]): Arbitrary<T> {
+function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]> {
   if (values.length === 0) {
     throw new Error('fc.constantFrom expects at least one parameter');
   }
   if (findOrUndefined(values, (v) => hasCloneMethod(v)) != undefined) {
     throw new Error('fc.constantFrom does not accept cloneable values, not supported for the moment');
   }
-  return new ConstantArbitrary<T>([...values]);
+  return new ConstantArbitrary<TArgs[number]>([...values]);
 }
 
 export { clonedConstant, constant, constantFrom };

--- a/test/type/index.test-d.ts
+++ b/test/type/index.test-d.ts
@@ -62,6 +62,12 @@ expectType<fc.Arbitrary<string[]>>(fc.nat().chain((n) => fc.array(fc.char(), 0, 
 expectType<fc.Arbitrary<number>>(fc.option(fc.nat()).filter((n): n is number => n !== null));
 expectType<fc.Arbitrary<string>>(fc.nat().map((n) => String(n)));
 
+// constantFrom arbitrary
+expectType<fc.Arbitrary<number>>(fc.constantFrom(1, 2));
+expectType<fc.Arbitrary<1 | 2>>(fc.constantFrom(...([1, 2] as const)));
+expectType<fc.Arbitrary<number | string>>(fc.constantFrom(1, 2, 'hello'));
+expectType<fc.Arbitrary<1 | 2 | 'hello'>>(fc.constantFrom(...([1, 2, 'hello'] as const)));
+
 // record arbitrary
 expectType<fc.Arbitrary<{ a: number; b: string }>>(fc.record({ a: fc.nat(), b: fc.string() }));
 expectType<fc.Arbitrary<{ a?: number; b?: string }>>(


### PR DESCRIPTION
## Why is this PR for?

**WARNING**

It introduces a breaking change in the typings:
`fc.constantFrom<T>` should be updated into `fc.constantFrom<T[]>`

## In a nutshell

✔️ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact
