### PR TITLE
👷 Remove useless CI stage (HEAD)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,15 +99,6 @@ jobs:
         - yarn build
         - yarn test --maxWorkers=4
         - yarn e2e --maxWorkers=4
-    - stage: test
-      env: STEP=HEAD
-      script:
-        - nvm install node
-        - node --version
-        - yarn prebuild
-        - yarn build
-        - yarn test --maxWorkers=4
-        - yarn e2e --maxWorkers=4
     - stage: publish documentation
       if: branch = master AND type = push
       script:


### PR DESCRIPTION
## Why is this PR for?

HEAD was initially responsible to check for future regressions introduced by libraries.
Now that dependabot bumps libraries for us, this is needed anymore.

The only thing we will lose if that it was also checking that fast-check will still work with latest revisions of node. Actually it should not be a real issue...
## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *ci*

(✔️: yes, ❌: no)

## Potential impacts

None