### PR TITLE
(💥)⬆️ Bump pure-rand to its latest major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "pure-rand": "^2.0.0"
+    "pure-rand": "^3.0.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4101,10 +4101,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pure-rand@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-2.0.0.tgz#3324633545207907fe964c2f0ebf05d8e9a7f129"
-  integrity sha512-mk98aayyd00xbfHgE3uEmAUGzz3jCdm8Mkf5DUXUhc7egmOaGG2D7qhVlynGenNe9VaNJZvzO9hkc8myuTkDgw==
+pure-rand@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-3.0.0.tgz#9dd90685e0c6ff98871f656a5e37fe90d2bfe0e4"
+  integrity sha512-7/U3rk8elhZPagxdheW1UHEhRr0IF8wCs3qyYVVswSxLoRrrrCMyaTKtAYIrCfuTeUoX/O3rN1piY/pX8JEcEA==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
## Why is this PR for?

Bumping pure-rand to its latest major. This major is compatible with both commonjs and es modules.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *dependencies*

(✔️: yes, ❌: no)

## Potential impacts

Starting at version 3.0.0, pure-rand publishes an hybrid version of the package that should be compatible with both commonjs and es module. Nonetheless as the change might have unseen side-effects, it can still be considered as potentially dangerous.