### PR TITLE
💥 Get rid of old namespace syntax for ObjectArbitrary

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'prettier/@typescript-eslint'
+    'prettier/@typescript-eslint',
   ],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
@@ -12,9 +12,8 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'warn',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-namespace': 'warn',
     '@typescript-eslint/no-this-alias': 'warn',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-    '@typescript-eslint/no-use-before-define': 'warn'
-  }
+    '@typescript-eslint/no-use-before-define': 'warn',
+  },
 };

--- a/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
@@ -138,7 +138,7 @@ describe('ObjectArbitrary', () => {
           assertShrinkedValue(originalValue, shrinkable.value);
         })
       ));
-    const checkProduce = (settings: ObjectConstraints.Settings, f: (v: any) => boolean) => {
+    const checkProduce = (settings: ObjectConstraints, f: (v: any) => boolean) => {
       let numRuns = 0;
       const seed = 0;
       const mrng = new Random(prand.xorshift128plus(seed));


### PR DESCRIPTION
**Merge of PR #631 to master**

---

## Why is this PR for?

Update `ObjectConstraints`

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact
