### PR TITLE
💚 Reduce flakiness of tests regarding coverage

### DIFF
--- a/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ObjectArbitrary.spec.ts
@@ -166,6 +166,7 @@ describe('ObjectArbitrary', () => {
     it('Should be able to produce unboxed Boolean', () => checkProduceUnboxed(true));
     it('Should be able to produce unboxed Number', () => checkProduceUnboxed(1));
     it('Should be able to produce unboxed String', () => checkProduceUnboxed(''));
+    it('Should be able to produce "unboxed" anything', () => checkProduceUnboxed({}));
     it('Should be able to produce Set', () =>
       checkProduce({ values: [constant(0)], maxDepth: 1, withSet: true }, (v) => v instanceof Set));
     it('Should be able to produce Map', () =>


### PR DESCRIPTION
## Why is this PR for?

Coverage reported by the CI was flaky due to one line of code that was not always covered*

![image](https://user-images.githubusercontent.com/5300235/88956248-64bc9380-d29d-11ea-8b30-a377d5f310c5.png)

*Our test suite is using PBT as a consequence tests may vary from one run to another. But ideally we should still cover the same set of lines.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *CI builds were flaky*

(✔️: yes, ❌: no)

## Potential impacts

None
