### PR TITLE
👷 Slow down dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/example"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "⬆️"
 
   - package-ecosystem: "npm"
     directory: "/test/type"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -33,7 +33,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/node-extension-cjs"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -44,7 +44,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/node-extension-mjs"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/node-with-import"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -66,7 +66,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/node-with-require"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -77,7 +77,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/rollup-with-import"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -88,7 +88,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/rollup-with-require"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -99,7 +99,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/webpack-with-import"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:
@@ -110,7 +110,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/test/esm/webpack-with-require"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "⬆️"
     ignore:


### PR DESCRIPTION
## Why is this PR for?

Slow down dependabot frequency.

Dependabot was opening several commits per day related to changes occuring in react-testing-library most of the time (or rollup). As it create unnecessary changes, I prefer stacking those changes once a month for the example/ directory and once a week for all the projects defined in test/.

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *ci*

(✔️: yes, ❌: no)

## Potential impacts

None
