### PR TITLE
🏷️ Add an interface to better type (Async)Property

### DIFF
--- a/prebuild/property.cjs
+++ b/prebuild/property.cjs
@@ -20,14 +20,14 @@ const signatureFor = (num, isAsync) => {
   const className = isAsync ? 'AsyncProperty' : 'Property';
   return `
         /**
-         * Instantiate a new {@link ${className}}
+         * Instantiate a new {@link fast-check#I${className}}
          * @param predicate - Assess the success of the property. Would be considered falsy if its throws or if its output evaluates to false
          * @public
          */
         function ${functionName}<${txCommas(num)}>(
             ${commas(num, (v) => `arb${v}:Arbitrary<T${v}>`)},
             predicate: ${predicateFor(num, isAsync)}
-        ): ${className}<[${txCommas(num)}]>;`;
+        ): I${className}WithHooks<[${txCommas(num)}]>;`;
 };
 
 /**
@@ -41,7 +41,7 @@ const generateProperty = (num, isAsync) => {
     // imports
     `import { Arbitrary } from '../arbitrary/definition/Arbitrary';`,
     `import { genericTuple } from '../arbitrary/TupleArbitrary';`,
-    `import { ${className} } from './${className}.generic';`,
+    `import { ${className}, I${className}WithHooks } from './${className}.generic';`,
     // declare all signatures
     ...iota(num).map((id) => signatureFor(id + 1, isAsync)),
     // declare function

--- a/src/check/property/AsyncProperty.generic.ts
+++ b/src/check/property/AsyncProperty.generic.ts
@@ -4,20 +4,41 @@ import { Shrinkable } from '../arbitrary/definition/Shrinkable';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
 import { IRawProperty, runIdToFrequency } from './IRawProperty';
 
+/** @public */
+type HookFunction = (() => Promise<unknown>) | (() => void);
+
 /**
  * Interface for asynchronous property, see {@link IRawProperty}
  * @public
  */
 export interface IAsyncProperty<Ts> extends IRawProperty<Ts, true> {}
 
-type HookFunction = (() => Promise<unknown>) | (() => void);
+/**
+ * Interface for asynchronous property defining hooks, see {@link IAsyncProperty}
+ * @public
+ */
+export interface IAsyncPropertyWithHooks<Ts> extends IAsyncProperty<Ts> {
+  /**
+   * Define a function that should be called before all calls to the predicate
+   * @param hookFunction - Function to be called
+   */
+  beforeEach(hookFunction: HookFunction): IAsyncPropertyWithHooks<Ts>;
+
+  /**
+   * Define a function that should be called after all calls to the predicate
+   * @param hookFunction - Function to be called
+   */
+  afterEach(hookFunction: HookFunction): IAsyncPropertyWithHooks<Ts>;
+}
 
 /**
  * Asynchronous property, see {@link IAsyncProperty}
  *
  * Prefer using {@link asyncProperty} instead
+ *
+ * @internal
  */
-export class AsyncProperty<Ts> implements IAsyncProperty<Ts> {
+export class AsyncProperty<Ts> implements IAsyncPropertyWithHooks<Ts> {
   static dummyHook: HookFunction = () => {};
   private beforeEachHook: HookFunction = AsyncProperty.dummyHook;
   private afterEachHook: HookFunction = AsyncProperty.dummyHook;

--- a/src/check/property/AsyncProperty.ts
+++ b/src/check/property/AsyncProperty.ts
@@ -1,4 +1,4 @@
 import { asyncProperty } from './AsyncProperty.generated';
-import { IAsyncProperty } from './AsyncProperty.generic';
+import { IAsyncProperty, IAsyncPropertyWithHooks } from './AsyncProperty.generic';
 
-export { asyncProperty, IAsyncProperty };
+export { asyncProperty, IAsyncProperty, IAsyncPropertyWithHooks };

--- a/src/check/property/Property.generic.ts
+++ b/src/check/property/Property.generic.ts
@@ -4,20 +4,56 @@ import { Shrinkable } from '../arbitrary/definition/Shrinkable';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
 import { IRawProperty, runIdToFrequency } from './IRawProperty';
 
+/** @public */
+type HookFunction = () => void;
+
 /**
  * Interface for synchronous property, see {@link IRawProperty}
  * @public
  */
 export interface IProperty<Ts> extends IRawProperty<Ts, false> {}
 
-type HookFunction = () => void;
+/**
+ * Interface for synchronous property defining hooks, see {@link IProperty}
+ * @public
+ */
+export interface IPropertyWithHooks<Ts> extends IProperty<Ts> {
+  /**
+   * Define a function that should be called before all calls to the predicate
+   * @param invalidHookFunction - Function to be called, please provide a valid hook function
+   */
+  beforeEach(
+    invalidHookFunction: () => Promise<unknown>
+  ): 'beforeEach expects a synchronous function but was given a function returning a Promise';
+
+  /**
+   * Define a function that should be called before all calls to the predicate
+   * @param hookFunction - Function to be called
+   */
+  beforeEach(hookFunction: HookFunction): IPropertyWithHooks<Ts>;
+
+  /**
+   * Define a function that should be called after all calls to the predicate
+   * @param invalidHookFunction - Function to be called, please provide a valid hook function
+   */
+  afterEach(
+    invalidHookFunction: () => Promise<unknown>
+  ): 'afterEach expects a synchronous function but was given a function returning a Promise';
+  /**
+   * Define a function that should be called after all calls to the predicate
+   * @param hookFunction - Function to be called
+   */
+  afterEach(hookFunction: HookFunction): IPropertyWithHooks<Ts>;
+}
 
 /**
  * Property, see {@link IProperty}
  *
  * Prefer using {@link property} instead
+ *
+ * @internal
  */
-export class Property<Ts> implements IProperty<Ts> {
+export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
   static dummyHook: HookFunction = () => {};
   private beforeEachHook: HookFunction = Property.dummyHook;
   private afterEachHook: HookFunction = Property.dummyHook;
@@ -42,26 +78,15 @@ export class Property<Ts> implements IProperty<Ts> {
     }
   }
 
-  /**
-   * Define a function that should be called before all calls to the predicate
-   * @param hookFunction - Function to be called
-   */
-  beforeEach(
-    invalidHookFunction: () => Promise<unknown>
-  ): 'beforeEach expects a synchronous function but was given a function returning a Promise';
+  beforeEach(invalidHookFunction: () => Promise<unknown>): never;
   beforeEach(validHookFunction: HookFunction): Property<Ts>;
   beforeEach(hookFunction: HookFunction): unknown {
     this.beforeEachHook = hookFunction;
     return this;
   }
-  /**
-   * Define a function that should be called after all calls to the predicate
-   * @param hookFunction - Function to be called
-   */
-  afterEach(
-    invalidHookFunction: () => Promise<unknown>
-  ): 'afterEach expects a synchronous function but was given a function returning a Promise';
-  afterEach(validHookFunction: HookFunction): Property<Ts>;
+
+  afterEach(invalidHookFunction: () => Promise<unknown>): never;
+  afterEach(hookFunction: HookFunction): Property<Ts>;
   afterEach(hookFunction: HookFunction): unknown {
     this.afterEachHook = hookFunction;
     return this;

--- a/src/check/property/Property.ts
+++ b/src/check/property/Property.ts
@@ -1,4 +1,4 @@
 import { property } from './Property.generated';
-import { IProperty } from './Property.generic';
+import { IProperty, IPropertyWithHooks } from './Property.generic';
 
-export { property, IProperty };
+export { property, IProperty, IPropertyWithHooks };

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -1,6 +1,6 @@
 import { pre } from './check/precondition/Pre';
-import { asyncProperty, IAsyncProperty } from './check/property/AsyncProperty';
-import { property, IProperty } from './check/property/Property';
+import { asyncProperty, IAsyncProperty, IAsyncPropertyWithHooks } from './check/property/AsyncProperty';
+import { property, IProperty, IPropertyWithHooks } from './check/property/Property';
 import { IRawProperty } from './check/property/IRawProperty';
 import { Parameters } from './check/runner/configuration/Parameters';
 import {
@@ -140,7 +140,9 @@ export {
   asyncProperty,
   IRawProperty,
   IProperty,
+  IPropertyWithHooks,
   IAsyncProperty,
+  IAsyncPropertyWithHooks,
   // pre-built arbitraries
   boolean,
   falsy,


### PR DESCRIPTION
## Why is this PR for?

Add an interface to better type (Async)Property

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *types*

(✔️: yes, ❌: no)

## Potential impacts

No real breaking change or problem expected. `fc.property` now returns (typing) a `IPropertyWithHooks` while it used to return a `Property` (this is and was an internal class not supposed to be imported by users).