### PR TITLE
🔨 Add script to serve the generated documentation locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:rollup-esm": "rollup --config test/rollup/esm/rollup.config.js && node test/rollup/esm/dist/main.js",
     "coverage": "cat ./coverage/lcov.info | coveralls",
     "docs": "mkdirp docs/2-API && docsify-init --editDir documentation && cp -R documentation/* docs/ && api-extractor run --local && generate-ts-docs markdown -i docs/2-API -o docs/2-API && cat README.md | sed 's/https:\\/\\/github.com\\/dubzzz\\/fast-check\\/blob\\/master\\/documentation//g' > docs/README.md && markdownbars -i docs/_sidebar.md -o docs/_sidebar.md",
+    "docs:serve": "npx serve docs/",
     "format": "prettier --write \"**/*.{js,ts}\"",
     "format:check": "prettier --list-different \"**/*.{js,ts}\"",
     "lint": "eslint \"**/*.{js,ts}\" --fix",


### PR DESCRIPTION
```sh
yarn docs
yarn docs:serve  # <-- new script that makes devs able to check the generated doc locally
```

<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *add script*

(✔️: yes, ❌: no)

## Potential impacts

None