### PR TITLE
📝 Prefer interfaces and functions for exported entities

### DIFF
--- a/src/check/arbitrary/AsyncSchedulerArbitrary.ts
+++ b/src/check/arbitrary/AsyncSchedulerArbitrary.ts
@@ -21,7 +21,7 @@ export type SchedulerSequenceItem<TMetaData = unknown> =
  * Describe a task for the report produced by the scheduler
  * @public
  */
-export type SchedulerReportItem<TMetaData = unknown> = {
+export interface SchedulerReportItem<TMetaData = unknown> {
   /**
    * Execution status for this task
    * - resolved: task released by the scheduler and successful
@@ -44,7 +44,7 @@ export type SchedulerReportItem<TMetaData = unknown> = {
   metadata?: TMetaData;
   /** Stringified version of the output or error computed using fc.stringify */
   outputValue?: string;
-};
+}
 
 /** @public */
 export interface SchedulerConstraints {

--- a/src/check/arbitrary/ContextArbitrary.ts
+++ b/src/check/arbitrary/ContextArbitrary.ts
@@ -43,4 +43,6 @@ class ContextImplem implements ContextValue {
  * Produce a {@link fast-check#ContextValue} instance
  * @public
  */
-export const context = () => clonedConstant(new ContextImplem()) as Arbitrary<ContextValue>;
+export function context(): Arbitrary<ContextValue> {
+  return clonedConstant(new ContextImplem());
+}

--- a/src/check/arbitrary/MemoArbitrary.ts
+++ b/src/check/arbitrary/MemoArbitrary.ts
@@ -48,7 +48,7 @@ let contextRemainingDepth = 10;
  *
  * @public
  */
-export const memo = <T>(builder: (maxDepth: number) => Arbitrary<T>): Memo<T> => {
+export function memo<T>(builder: (maxDepth: number) => Arbitrary<T>): Memo<T> {
   const previous: { [depth: number]: Arbitrary<T> } = {};
   return ((maxDepth?: number): Arbitrary<T> => {
     const n = maxDepth !== undefined ? maxDepth : contextRemainingDepth;
@@ -60,4 +60,4 @@ export const memo = <T>(builder: (maxDepth: number) => Arbitrary<T>): Memo<T> =>
     }
     return previous[n];
   }) as Memo<T>;
-};
+}

--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -19,7 +19,7 @@ import { bigInt } from './BigIntArbitrary';
  * Constraints for `fc.anything` and `fc.object`
  * @public
  */
-export type ObjectConstraints = {
+export interface ObjectConstraints {
   /** Maximal depth allowed */
   maxDepth?: number;
   /** Maximal number of keys */
@@ -65,7 +65,7 @@ export type ObjectConstraints = {
   withNullPrototype?: boolean;
   /** Also generate BigInt */
   withBigInt?: boolean;
-};
+}
 
 /** @internal */
 class QualifiedObjectConstraints {

--- a/src/check/model/ModelRunner.ts
+++ b/src/check/model/ModelRunner.ts
@@ -111,12 +111,12 @@ const internalAsyncModelRun = async <Model extends object, Real, CheckAsync exte
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const modelRun = <Model extends object, Real, InitialModel extends Model>(
+export function modelRun<Model extends object, Real, InitialModel extends Model>(
   s: ModelRunSetup<InitialModel, Real>,
   cmds: Iterable<Command<Model, Real>>
-): void => {
+): void {
   internalModelRun(s, cmds);
-};
+}
 
 /**
  * Run asynchronous commands over a `Model` and the `Real` system
@@ -129,12 +129,12 @@ export const modelRun = <Model extends object, Real, InitialModel extends Model>
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export const asyncModelRun = async <Model extends object, Real, CheckAsync extends boolean, InitialModel extends Model>(
+export async function asyncModelRun<Model extends object, Real, CheckAsync extends boolean, InitialModel extends Model>(
   s: ModelRunSetup<InitialModel, Real> | ModelRunAsyncSetup<InitialModel, Real>,
   cmds: Iterable<AsyncCommand<Model, Real, CheckAsync>>
-): Promise<void> => {
+): Promise<void> {
   await internalAsyncModelRun(s, cmds);
-};
+}
 
 /**
  * Run asynchronous and scheduled commands over a `Model` and the `Real` system
@@ -147,7 +147,7 @@ export const asyncModelRun = async <Model extends object, Real, CheckAsync exten
  *
  * @public
  */
-export const scheduledModelRun = async <
+export async function scheduledModelRun<
   // eslint-disable-next-line @typescript-eslint/ban-types
   Model extends object,
   Real,
@@ -157,9 +157,9 @@ export const scheduledModelRun = async <
   scheduler: Scheduler,
   s: ModelRunSetup<InitialModel, Real> | ModelRunAsyncSetup<InitialModel, Real>,
   cmds: Iterable<AsyncCommand<Model, Real, CheckAsync>>
-): Promise<void> => {
+): Promise<void> {
   const scheduledCommands = scheduleCommands(scheduler, cmds);
   const out = internalAsyncModelRun(s, scheduledCommands, scheduler.schedule(Promise.resolve(), 'startModel'));
   await scheduler.waitAll();
   await out;
-};
+}

--- a/src/check/precondition/Pre.ts
+++ b/src/check/precondition/Pre.ts
@@ -5,8 +5,8 @@ import { PreconditionFailure } from './PreconditionFailure';
  * @param expectTruthy - cancel the run whenever this value is falsy
  * @public
  */
-export const pre = (expectTruthy: boolean): void => {
+export function pre(expectTruthy: boolean): void {
   if (!expectTruthy) {
     throw new PreconditionFailure();
   }
-};
+}

--- a/src/check/runner/configuration/GlobalParameters.ts
+++ b/src/check/runner/configuration/GlobalParameters.ts
@@ -25,22 +25,22 @@ export type GlobalParameters = Pick<Parameters<unknown>, Exclude<keyof Parameter
  *
  * @public
  */
-export const configureGlobal = (parameters: GlobalParameters): void => {
+export function configureGlobal(parameters: GlobalParameters): void {
   getGlobal()[globalParametersSymbol] = parameters;
-};
+}
 
 /**
  * Read global parameters that will be used by runners
  * @public
  */
-export const readConfigureGlobal = (): GlobalParameters | undefined => {
+export function readConfigureGlobal(): GlobalParameters | undefined {
   return getGlobal()[globalParametersSymbol];
-};
+}
 
 /**
  * Reset global parameters
  * @public
  */
-export const resetConfigureGlobal = (): void => {
+export function resetConfigureGlobal(): void {
   delete getGlobal()[globalParametersSymbol];
-};
+}

--- a/src/check/runner/reporter/RunDetails.ts
+++ b/src/check/runner/reporter/RunDetails.ts
@@ -19,61 +19,70 @@ export type RunDetails<Ts> =
  * Run reported as failed because
  * the property failed
  *
+ * Refer to {@link RunDetailsCommon} for more details
+ *
  * @public
  */
-export type RunDetailsFailureProperty<Ts> = RunDetailsCommon<Ts> & {
+export interface RunDetailsFailureProperty<Ts> extends RunDetailsCommon<Ts> {
   failed: true;
   interrupted: boolean;
   counterexample: Ts;
   counterexamplePath: string;
   error: string;
-};
+}
 
 /**
  * Run reported as failed because
  * too many retries have been attempted to generate valid values
  *
+ * Refer to {@link RunDetailsCommon} for more details
+ *
  * @public
  */
-export type RunDetailsFailureTooManySkips<Ts> = RunDetailsCommon<Ts> & {
+export interface RunDetailsFailureTooManySkips<Ts> extends RunDetailsCommon<Ts> {
   failed: true;
   interrupted: false;
   counterexample: null;
   counterexamplePath: null;
   error: null;
-};
+}
 
 /**
  * Run reported as failed because
  * it took too long and thus has been interrupted
  *
+ * Refer to {@link RunDetailsCommon} for more details
+ *
  * @public
  */
-export type RunDetailsFailureInterrupted<Ts> = RunDetailsCommon<Ts> & {
+export interface RunDetailsFailureInterrupted<Ts> extends RunDetailsCommon<Ts> {
   failed: true;
   interrupted: true;
   counterexample: null;
   counterexamplePath: null;
   error: null;
-};
+}
 
 /**
  * Run reported as success
+ *
+ * Refer to {@link RunDetailsCommon} for more details
+ *
  * @public
  */
-export type RunDetailsSuccess<Ts> = RunDetailsCommon<Ts> & {
+export interface RunDetailsSuccess<Ts> extends RunDetailsCommon<Ts> {
   failed: false;
   interrupted: boolean;
   counterexample: null;
   counterexamplePath: null;
   error: null;
-};
+}
 
 /**
  * Shared part between variants of RunDetails
  * @public
  */
-export type RunDetailsCommon<Ts> = {
+export interface RunDetailsCommon<Ts> {
   /**
    * Does the property failed during the execution of {@link fast-check#(check:1)}?
    */
@@ -150,4 +159,4 @@ export type RunDetailsCommon<Ts> = {
    * and global ones specified using `fc.configureGlobal`
    */
   runConfiguration: Parameters<Ts>;
-};
+}

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -173,6 +173,8 @@ export {
   IPropertyWithHooks,
   IAsyncProperty,
   IAsyncPropertyWithHooks,
+  AsyncPropertyHookFunction,
+  PropertyHookFunction,
   // pre-built arbitraries
   boolean,
   falsy,
@@ -299,8 +301,6 @@ export {
   configureGlobal,
   readConfigureGlobal,
   resetConfigureGlobal,
-  AsyncPropertyHookFunction,
-  PropertyHookFunction,
   // run output
   ExecutionStatus,
   ExecutionTree,


### PR DESCRIPTION
In the context of the documentation extracted by api-extractor, it is better to have:

```ts
interface MyType {
  /** What does my attribute */
  attribute: any;
}
```

Over:
```ts
type MyType = {
  /** What does my attribute */
  attribute: any;
};
```

As the documentation related to the attribute will be ignored.

Same for functions versus variables.

Declaring a function as follow:
```ts
function abc() {}
```

Will produce a better extracted api than this one:
```ts
const abc = () => {}
```

<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
