### PR TITLE
Fix examples leaking in to functions table

### DIFF
--- a/src/check/arbitrary/AsyncSchedulerArbitrary.ts
+++ b/src/check/arbitrary/AsyncSchedulerArbitrary.ts
@@ -370,6 +370,8 @@ function scheduler<TMetaData = unknown>(constraints?: SchedulerConstraints): Arb
  * Ordering is defined by using a template string like the one generated in case of failure of a {@link fast-check#scheduler}
  *
  * It may be something like:
+ *
+ * @example
  * ```typescript
  * fc.schedulerFor()`
  *   -> [task\${2}] promise pending

--- a/src/check/runner/configuration/GlobalParameters.ts
+++ b/src/check/runner/configuration/GlobalParameters.ts
@@ -10,6 +10,7 @@ export type GlobalParameters = Pick<Parameters<unknown>, Exclude<keyof Parameter
 /**
  * Define global parameters that will be used by all the runners
  *
+ * @example
  * ```typescript
  * fc.configureGlobal({ numRuns: 10 });
  * //...


### PR DESCRIPTION
Fix examples leaking in to functions table

Some examples weren't marked as such and were leaking in to the table of functions in the documentation.

<img width="851" alt="Screen Shot 2020-08-20 at 7 47 16 am" src="https://user-images.githubusercontent.com/475/90693102-98497700-e2b9-11ea-8118-1f43ae277936.png">


## In a nutshell

❌ New feature
✔️ Fix an issue
✔️ Documentation improvement

