### PR TITLE
Fix NaN passed to max in fc.date()

### DIFF
--- a/src/check/arbitrary/DateArbitrary.ts
+++ b/src/check/arbitrary/DateArbitrary.ts
@@ -13,7 +13,7 @@ export function date(constraints?: { min?: Date; max?: Date }): Arbitrary<Date> 
   const intMin = constraints && constraints.min ? constraints.min.getTime() : -8640000000000000;
   const intMax = constraints && constraints.max ? constraints.max.getTime() : 8640000000000000;
   if (Number.isNaN(intMin)) throw new Error('fc.date min must be valid instance of Date');
-  if (Number.isNaN(intMin)) throw new Error('fc.date max must be valid instance of Date');
+  if (Number.isNaN(intMax)) throw new Error('fc.date max must be valid instance of Date');
   if (intMin > intMax) throw new Error('fc.date max must be greater or equal to min');
   return integer(intMin, intMax).map((a) => new Date(a));
 }


### PR DESCRIPTION
<!-- Why is this PR for? -->
Quick fix where using `fc.date({ max: new Date('asdf') })` would hang.

Side question: why does it hang? Should `fc.integer()` check if the bounds are `NaN` and error accordingly?

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

If you expect some noticeable impacts with your change please explain.

Here are some examples of impacts that might be reported into this section:
- Generated values impact,
- Shrink values impact,
- Performance impact,
- Typings impact
