### PR TITLE
🏷️ Mark fc.pre as an asserts function in typings

### DIFF
--- a/src/check/precondition/Pre.ts
+++ b/src/check/precondition/Pre.ts
@@ -5,7 +5,7 @@ import { PreconditionFailure } from './PreconditionFailure';
  * @param expectTruthy - cancel the run whenever this value is falsy
  * @public
  */
-export function pre(expectTruthy: boolean): asserts expectTruthy {
+export function pre(expectTruthy: boolean): asserts expectTruthy is true {
   if (!expectTruthy) {
     throw new PreconditionFailure();
   }

--- a/src/check/precondition/Pre.ts
+++ b/src/check/precondition/Pre.ts
@@ -5,7 +5,7 @@ import { PreconditionFailure } from './PreconditionFailure';
  * @param expectTruthy - cancel the run whenever this value is falsy
  * @public
  */
-export function pre(expectTruthy: boolean): void {
+export function pre(expectTruthy: boolean): asserts expectTruthy {
   if (!expectTruthy) {
     throw new PreconditionFailure();
   }


### PR DESCRIPTION
Fixes #558

<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact: fc.pre is now properly flagged as asserts