### PR TITLE
✨ Automatically simplify min and max in codemod for arrays

### DIFF
--- a/codemods/2.4.0_explicit-min-max-length/README.md
+++ b/codemods/2.4.0_explicit-min-max-length/README.md
@@ -28,6 +28,10 @@ npx jscodeshift -t https://raw.githubusercontent.com/dubzzz/fast-check/master/co
 npx jscodeshift --parser=ts --extensions=ts -t https://raw.githubusercontent.com/dubzzz/fast-check/master/codemods/2.4.0_explicit-min-max-length/transform.cjs <path_to_code>
 ```
 
+You may need one of the following additional options:
+- `--simplifyMin=true` - _do not use `minLength` if it corresponds to the default_
+- `--simplifyMax=true` - _do not use `maxLength` if it corresponds to the default_
+
 ---
 
 **Minimal version:** `>=2.4.0`

--- a/codemods/2.4.0_explicit-min-max-length/snippet-3.js
+++ b/codemods/2.4.0_explicit-min-max-length/snippet-3.js
@@ -6,20 +6,30 @@ import fcLocal from './path';
 import { array as localArray } from './path';
 
 test('test default import', () => {
-  fc.assert(fc.property(fc.array(fc.nat(), 7, 10), () => true));
+  fc.assert(fc.property(fc.array(fc.nat(), 7, 42), () => true));
 });
 test('test star import', () => {
-  fcStar.assert(fcStar.property(fcStar.array(fcStar.nat(), 7, 10), () => true));
+  fcStar.assert(fcStar.property(fcStar.array(fcStar.nat(), 7, 42), () => true));
 });
 test('test specific', () => {
-  assert(property(array(nat(), 7, 10), () => true));
+  assert(property(array(nat(), 7, 42), () => true));
 });
 test('test specific named', () => {
-  assert(property(fcArray(nat(), 7, 10), () => true));
+  assert(property(fcArray(nat(), 7, 42), () => true));
 });
 test('test default import (local)', () => {
-  fcLocal.assert(fcLocal.property(fcLocal.array(fcLocal.nat(), 7, 10), () => true));
+  fcLocal.assert(fcLocal.property(fcLocal.array(fcLocal.nat(), 7, 42), () => true));
 });
 test('test specific named (local)', () => {
-  assert(property(localArray(nat(), 7, 10), () => true));
+  assert(property(localArray(nat(), 7, 42), () => true));
+});
+test('test simplify unneeded min', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 0, 42), () => true));
+});
+test('test simplify unneeded max', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 10), () => true));
+  fc.assert(fc.property(fc.array(fc.nat(), 1, 10), () => true));
+});
+test('test simplify unneeded min and max', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 0, 10), () => true));
 });

--- a/codemods/2.4.0_explicit-min-max-length/snippet-4.ts
+++ b/codemods/2.4.0_explicit-min-max-length/snippet-4.ts
@@ -6,20 +6,30 @@ import fcLocal from './path';
 import { array as localArray } from './path';
 
 test('test default import', () => {
-  fc.assert(fc.property(fc.array(fc.nat(), 7, 10), () => true));
+  fc.assert(fc.property(fc.array(fc.nat(), 7, 42), () => true));
 });
 test('test star import', () => {
-  fcStar.assert(fcStar.property(fcStar.array(fcStar.nat(), 7, 10), () => true));
+  fcStar.assert(fcStar.property(fcStar.array(fcStar.nat(), 7, 42), () => true));
 });
 test('test specific', () => {
-  assert(property(array(nat(), 7, 10), () => true));
+  assert(property(array(nat(), 7, 42), () => true));
 });
 test('test specific named', () => {
-  assert(property(fcArray(nat(), 7, 10), () => true));
+  assert(property(fcArray(nat(), 7, 42), () => true));
 });
 test('test default import (local)', () => {
-  fcLocal.assert(fcLocal.property(fcLocal.array(fcLocal.nat(), 7, 10), () => true));
+  fcLocal.assert(fcLocal.property(fcLocal.array(fcLocal.nat(), 7, 42), () => true));
 });
 test('test specific named (local)', () => {
-  assert(property(localArray(nat(), 7, 10), () => true));
+  assert(property(localArray(nat(), 7, 42), () => true));
+});
+test('test simplify unneeded min', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 0, 42), () => true));
+});
+test('test simplify unneeded max', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 10), () => true));
+  fc.assert(fc.property(fc.array(fc.nat(), 1, 10), () => true));
+});
+test('test simplify unneeded min and max', () => {
+  fc.assert(fc.property(fc.array(fc.nat(), 0, 10), () => true));
 });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

Add some additional options onto the codemod used to migrate away from `fc.array(arb, maxLength)` and `fc.array(arb, minLength, maxLength)`.

It now provides two custom flags not to put `minLength` and/or `maxLength` if they do not make sense (in other words, if the value is 0 for min or 10 for max).

`fc.array(arb, 10)` -> `fc.array(arb)` when toggling that option (instead of `fc.array(arb, {maxLength: 10})`)
`fc.array(arb, 0, 10)` -> `fc.array(arb)` when toggling that option (instead of `fc.array(arb, {minLength: 0, maxLength: 10})`)

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None