### PR TITLE
⏪ Do not depreciate overloads for array-like (yet)

### DIFF
--- a/codemods/2.4.0_explicit-min-max-length/README.md
+++ b/codemods/2.4.0_explicit-min-max-length/README.md
@@ -7,30 +7,38 @@ Before version `2.4.0`, defining constraints on the size of an array required to
 - `fc.array(arb, maxLength)`
 - `fc.array(arb, minLength, maxLength)`
 
-Version 2.4.0 depreciated those signatures for another one `fc.array(arb, {minLength, maxLength})` which is more explicit.
+Same for `fc.set` and other array-like arbitraries.
 
+Version 2.4.0 introduced more explicit and more powerful signatures for array-like arbitaries.
+For instance: `fc.array(arb, {minLength, maxLength})`.
 
-The reasons behind this change are:
+The reasons behind this change are (more details on rfc [#992](https://github.com/dubzzz/fast-check/issues/992)):
 1. when seeing a call like `fc.array(arb, 10)` it was difficult to understand the meaning of the second argument: is is for the max? for the min?
 2. no signature to only specify a min length, specifying a min required the user to also specify a max
 3. difficult to use this kind of signature with `fc.set`, `fc.uint32array`... or even worst `fc.object`
 
-This codemod converts implicit `minLength` and `maxLength` to the newly added object expression syntax.
+This codemod converts implicit `minLength` and `maxLength` to the newly added object expression syntax for:
+- `fc.array`
+- `fc.set`
 
 ---
 
 Running the codemod on your code:
 
 ```sh
-// JavaScript code
+# JavaScript code
 npx jscodeshift -t https://raw.githubusercontent.com/dubzzz/fast-check/master/codemods/2.4.0_explicit-min-max-length/transform.cjs <path_to_code>
-// TypeScript code
+# TypeScript code
 npx jscodeshift --parser=ts --extensions=ts -t https://raw.githubusercontent.com/dubzzz/fast-check/master/codemods/2.4.0_explicit-min-max-length/transform.cjs <path_to_code>
 ```
 
 You may need one of the following additional options:
 - `--simplifyMin=true` - _do not use `minLength` if it corresponds to the default_
 - `--simplifyMax=true` - _do not use `maxLength` if it corresponds to the default_
+
+And some others that you might not need:
+- `--debug=true` - _enable debug mode for the codemod_
+- `--local=true` - _mostly when lauching the codemod against the codebase of fast-check, it considers that local imports are imports of fast-check_
 
 ---
 

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -1762,8 +1762,8 @@ fc.genericTuple([fc.nat(), fc.string()])
 
 - `fc.array(arb)`
 - `fc.array(arb, {minLength?, maxLength?})`
-- ~~`fc.array(arb, maxLength)`~~ — _deprecated_
-- ~~`fc.array(arb, minLength, maxLength)`~~ — _deprecated_
+- _`fc.array(arb, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- _`fc.array(arb, minLength, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -1819,11 +1819,11 @@ fc.array(fc.nat(), {minLength: 5, maxLength: 7})
 
 - `fc.set(arb)`
 - `fc.set(arb, {minLength?, maxLength?, compare?})`
-- ~~`fc.set(arb, maxLength)`~~ — _deprecated_
-- ~~`fc.set(arb, minLength, maxLength)`~~ — _deprecated_
-- ~~`fc.set(arb, compare)`~~ — _deprecated_
-- ~~`fc.set(arb, maxLength, compare)`~~ — _deprecated_
-- ~~`fc.set(arb, minLength, maxLength, compare)`~~ — _deprecated_
+- _`fc.set(arb, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- _`fc.set(arb, minLength, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- _`fc.set(arb, compare)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- _`fc.set(arb, maxLength, compare)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- _`fc.set(arb, minLength, maxLength, compare)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/check/arbitrary/ArrayArbitrary.ts
+++ b/src/check/arbitrary/ArrayArbitrary.ts
@@ -128,18 +128,28 @@ export interface ArrayConstraints {
 function array<T>(arb: Arbitrary<T>): Arbitrary<T[]>;
 /**
  * For arrays of values coming from `arb` having an upper bound size
+ *
  * @param arb - Arbitrary used to generate the values inside the array
  * @param maxLength - Upper bound of the generated array size
- * @deprecated Superceded by `fc.array(arb, {maxLength})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ *
+ * @remarks
+ * Superceded by `fc.array(arb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function array<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
 /**
  * For arrays of values coming from `arb` having lower and upper bound size
+ *
  * @param arb - Arbitrary used to generate the values inside the array
  * @param minLength - Lower bound of the generated array size
  * @param maxLength - Upper bound of the generated array size
- * @deprecated Superceded by `fc.array(arb, {minLength, maxLength})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ *
+ * @remarks
+ * Superceded by `fc.array(arb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function array<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>;

--- a/src/check/arbitrary/SetArbitrary.ts
+++ b/src/check/arbitrary/SetArbitrary.ts
@@ -98,7 +98,10 @@ function set<T>(arb: Arbitrary<T>): Arbitrary<T[]>;
  * @param arb - Arbitrary used to generate the values inside the array
  * @param maxLength - Upper bound of the generated array size
  *
- * @deprecated Superceded by `fc.set(arb, {maxLength})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ * @remarks
+ * Superceded by `fc.set(arb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function set<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
@@ -109,7 +112,10 @@ function set<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
  * @param minLength - Lower bound of the generated array size
  * @param maxLength - Upper bound of the generated array size
  *
- * @deprecated Superceded by `fc.set(arb, {minLength, maxLength})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ * @remarks
+ * Superceded by `fc.set(arb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function set<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>;
@@ -119,7 +125,10 @@ function set<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitr
  * @param arb - Arbitrary used to generate the values inside the array
  * @param compare - Return true when the two values are equals
  *
- * @deprecated Superceded by `fc.set(arb, {compare})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ * @remarks
+ * Superceded by `fc.set(arb, {compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function set<T>(arb: Arbitrary<T>, compare: (a: T, b: T) => boolean): Arbitrary<T[]>;
@@ -130,7 +139,10 @@ function set<T>(arb: Arbitrary<T>, compare: (a: T, b: T) => boolean): Arbitrary<
  * @param maxLength - Upper bound of the generated array size
  * @param compare - Return true when the two values are equals
  *
- * @deprecated Superceded by `fc.array(arb, {maxLength, compare})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ * @remarks
+ * Superceded by `fc.array(arb, {maxLength, compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function set<T>(arb: Arbitrary<T>, maxLength: number, compare: (a: T, b: T) => boolean): Arbitrary<T[]>;
@@ -142,7 +154,10 @@ function set<T>(arb: Arbitrary<T>, maxLength: number, compare: (a: T, b: T) => b
  * @param maxLength - Upper bound of the generated array size
  * @param compare - Return true when the two values are equals
  *
- * @deprecated Superceded by `fc.array(arb, {minLength, maxLength, compare})`. Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}
+ * @remarks
+ * Superceded by `fc.array(arb, {minLength, maxLength, compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function set<T>(


### PR DESCRIPTION
For the moment, instead of explicitely depreciating the overloads for `fc.array`, `fc.set` and more to come. We only mark them as non-recommended.

Two subjects still need to be discussed before going for depreciated flag, see #992 for more details.
## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None, not released yet