### PR TITLE
✨ Move to explicit `minLength`/`maxLength` constraints on `subarray`

### DIFF
--- a/codemods/2.4.0_explicit-min-max-length/snippet-5.js
+++ b/codemods/2.4.0_explicit-min-max-length/snippet-5.js
@@ -25,3 +25,15 @@ fc.stringOf(fc.char());
 fc.stringOf(fc.char(), 5);
 fc.stringOf(fc.char(), 1, 5);
 fc.stringOf(fc.char(), {});
+
+// subarray
+
+fc.subarray([1, 2, 3]);
+fc.subarray([1, 2, 3], 1, 2);
+
+// shuffledSubarray
+
+fc.shuffledSubarray([1, 2, 3]);
+fc.shuffledSubarray([1, 2, 3], 1, 2);
+fc.shuffledSubarray(myArray, 1, 2);
+fc.shuffledSubarray(computeArray(), 1, 2);

--- a/codemods/2.4.0_explicit-min-max-length/snippet-6.js
+++ b/codemods/2.4.0_explicit-min-max-length/snippet-6.js
@@ -1,0 +1,7 @@
+import fc from 'fast-check';
+
+fc.subarray([1, 2, 3, 4, 5], 0, 3); // can simplify minLength
+fc.subarray([1, 2, 3, 4, 5], 1, 3); // nothing to simplify
+fc.subarray([1, 2, 3, 4, 5], 1, 5); // can simplify maxLength
+fc.subarray([1, 2, 3, 4, 5], 0, 5); // can simplify minLength and maxLength
+fc.subarray(myArray, 0, 3); // can simplify minLength, maxLength status is unknown

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -1908,13 +1908,14 @@ fc.set(fc.hexaString(), {minLength: 5, maxLength: 10, compare: (s1, s2) => s1.le
 *&#8195;Signatures*
 
 - `fc.subarray(originalArray)`
-- `fc.subarray(originalArray, minLength, maxLength)`
+- `fc.subarray(originalArray, {minLength?, maxLength?})`
+- _`fc.subarray(originalArray, minLength, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
 - `originalArray` — _the array from which we want to extract sub-arrays_
 - `minLength?` — default: `0` — _minimal length (included)_
-- `maxLength?` — default: `maxLength=originalArray.length` — _maximal length (included)_
+- `maxLength?` — default: `originalArray.length` — _maximal length (included)_
 
 *&#8195;Usages*
 
@@ -1922,11 +1923,14 @@ fc.set(fc.hexaString(), {minLength: 5, maxLength: 10, compare: (s1, s2) => s1.le
 fc.subarray([1, 42, 48, 69, 75, 92])
 // Examples of generated values: [48,69,75,92], [75,92], [], [48,75], [1,42,48,75,92]…
 
-fc.subarray([1, 42, 48, 69, 75, 92], 5, 6)
-// Examples of generated values: [1,48,69,75,92], [1,42,48,69,75], [1,42,48,69,92], [42,48,69,75,92], [1,42,48,69,75,92]…
+fc.subarray([1, 42, 48, 69, 75, 92], {minLength: 5})
+// Examples of generated values: [1,42,69,75,92], [1,42,48,69,75], [1,42,48,69,92], [1,42,48,69,75,92], [42,48,69,75,92]…
 
-fc.subarray([1, 42, 48, 69, 75, 92], 2, 3)
-// Examples of generated values: [48,92], [42,69], [48,69], [1,48], [48,75]…
+fc.subarray([1, 42, 48, 69, 75, 92], {maxLength: 5})
+// Examples of generated values: [1,69,75,92], [42,48,69,75], [42], [69], [42,48,92]…
+
+fc.subarray([1, 42, 48, 69, 75, 92], {minLength: 2, maxLength: 3})
+// Examples of generated values: [42,75], [42,69], [1,75,92], [48,92], [42,48,92]…
 ```
 </details>
 
@@ -1942,13 +1946,14 @@ fc.subarray([1, 42, 48, 69, 75, 92], 2, 3)
 *&#8195;Signatures*
 
 - `fc.shuffledSubarray(originalArray)`
-- `fc.shuffledSubarray(originalArray, minLength, maxLength)`
+- `fc.shuffledSubarray(originalArray, {minLength?, maxLength?})`
+- _`fc.shuffledSubarray(originalArray, minLength, maxLength)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
 - `originalArray` — _the array from which we want to extract sub-arrays_
 - `minLength?` — default: `0` — _minimal length (included)_
-- `maxLength?` — default: `maxLength=originalArray.length` — _maximal length (included)_
+- `maxLength?` — default: `originalArray.length` — _maximal length (included)_
 
 *&#8195;Usages*
 
@@ -1956,11 +1961,14 @@ fc.subarray([1, 42, 48, 69, 75, 92], 2, 3)
 fc.shuffledSubarray([1, 42, 48, 69, 75, 92])
 // Examples of generated values: [75], [75,48], [92], [75,92], [1,75]…
 
-fc.shuffledSubarray([1, 42, 48, 69, 75, 92], 5, 6)
-// Examples of generated values: [69,48,1,92,75,42], [75,69,1,48,92], [48,1,92,42,69], [69,92,48,42,1], [69,42,1,92,75]…
+fc.shuffledSubarray([1, 42, 48, 69, 75, 92], {minLength: 5})
+// Examples of generated values: [42,92,1,69,48], [48,1,42,75,69,92], [92,1,75,42,48,69], [92,1,42,48,69], [92,1,69,42,75,48]…
 
-fc.shuffledSubarray([1, 42, 48, 69, 75, 92], 2, 3)
-// Examples of generated values: [69,48,1], [75,69], [48,1], [69,92], [69,42]…
+fc.shuffledSubarray([1, 42, 48, 69, 75, 92], {maxLength: 5})
+// Examples of generated values: [], [48,1,42], [92,1,75], [92], [92,1,69,42,75]…
+
+fc.shuffledSubarray([1, 42, 48, 69, 75, 92], {minLength: 2, maxLength: 3})
+// Examples of generated values: [69,1], [92,1], [69,92], [69,42,1], [75,1]…
 ```
 </details>
 

--- a/src/check/arbitrary/SubarrayArbitrary.ts
+++ b/src/check/arbitrary/SubarrayArbitrary.ts
@@ -83,6 +83,23 @@ class SubarrayArbitrary<T> extends Arbitrary<T[]> {
 }
 
 /**
+ * Constraints to be applied on {@link subarray} and {@link shuffledSubarray}
+ * @public
+ */
+export interface SubarrayConstraints {
+  /**
+   * Lower bound of the generated subarray size (included)
+   * @defaultValue 0
+   */
+  minLength?: number;
+  /**
+   * Upper bound of the generated subarray size (included)
+   * @defaultValue The length of the original array itself
+   */
+  maxLength?: number;
+}
+
+/**
  * For subarrays of `originalArray` (keeps ordering)
  *
  * @param originalArray - Original array
@@ -97,12 +114,30 @@ function subarray<T>(originalArray: T[]): Arbitrary<T[]>;
  * @param minLength - Lower bound of the generated array size
  * @param maxLength - Upper bound of the generated array size
  *
+ * @remarks
+ * Superceded by `fc.subarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function subarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-function subarray<T>(originalArray: T[], minLength?: number, maxLength?: number): Arbitrary<T[]> {
-  if (minLength != null && maxLength != null) return new SubarrayArbitrary(originalArray, true, minLength, maxLength);
-  return new SubarrayArbitrary(originalArray, true, 0, originalArray.length);
+/**
+ * For subarrays of `originalArray` (keeps ordering)
+ *
+ * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances
+ *
+ * @public
+ */
+function subarray<T>(originalArray: T[], constraints: SubarrayConstraints): Arbitrary<T[]>;
+function subarray<T>(originalArray: T[], ...args: [] | [number, number] | [SubarrayConstraints]): Arbitrary<T[]> {
+  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
+    return new SubarrayArbitrary(originalArray, true, args[0], args[1]);
+  }
+  const ct = args[0] as SubarrayConstraints | undefined;
+  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
+  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+  return new SubarrayArbitrary(originalArray, true, minLength, maxLength);
 }
 
 /**
@@ -120,12 +155,33 @@ function shuffledSubarray<T>(originalArray: T[]): Arbitrary<T[]>;
  * @param minLength - Lower bound of the generated array size
  * @param maxLength - Upper bound of the generated array size
  *
+ * @remarks
+ * Superceded by `fc.shuffledSubarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
+ * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/master/codemods/2.4.0_explicit-min-max-length | our codemod script}.
+ *
  * @public
  */
 function shuffledSubarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-function shuffledSubarray<T>(originalArray: T[], minLength?: number, maxLength?: number): Arbitrary<T[]> {
-  if (minLength != null && maxLength != null) return new SubarrayArbitrary(originalArray, false, minLength, maxLength);
-  return new SubarrayArbitrary(originalArray, false, 0, originalArray.length);
+/**
+ * For subarrays of `originalArray`
+ *
+ * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances
+ *
+ * @public
+ */
+function shuffledSubarray<T>(originalArray: T[], constraints: SubarrayConstraints): Arbitrary<T[]>;
+function shuffledSubarray<T>(
+  originalArray: T[],
+  ...args: [] | [number, number] | [SubarrayConstraints]
+): Arbitrary<T[]> {
+  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
+    return new SubarrayArbitrary(originalArray, false, args[0], args[1]);
+  }
+  const ct = args[0] as SubarrayConstraints | undefined;
+  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
+  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+  return new SubarrayArbitrary(originalArray, false, minLength, maxLength);
 }
 
 export { subarray, shuffledSubarray };

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -68,7 +68,7 @@ import {
   StringSharedConstraints,
   unicodeString,
 } from './check/arbitrary/StringArbitrary';
-import { shuffledSubarray, subarray } from './check/arbitrary/SubarrayArbitrary';
+import { shuffledSubarray, subarray, SubarrayConstraints } from './check/arbitrary/SubarrayArbitrary';
 import { genericTuple, tuple } from './check/arbitrary/TupleArbitrary';
 import { uuid, uuidV } from './check/arbitrary/UuidArbitrary';
 import {
@@ -287,6 +287,7 @@ export {
   SchedulerConstraints,
   SetConstraints,
   StringSharedConstraints,
+  SubarrayConstraints,
   WebAuthorityConstraints,
   WebUrlConstraints,
   WeightedArbitrary,

--- a/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
@@ -44,10 +44,13 @@ describe('SubarrayArbitrary', () => {
         fc.property(
           fc.array(fc.integer()),
           fc.nat(),
-          fc.nat(),
-          (originalArray: number[], length: number, otherLength: number) => {
+          fc.option(fc.nat(), { nil: undefined }),
+          (originalArray: number[], length: number, otherLength: number | undefined) => {
             expect(() => {
-              subarray(originalArray, -length - 1, otherLength % (originalArray.length + 1));
+              subarray(originalArray, {
+                minLength: -length - 1,
+                maxLength: otherLength !== undefined ? otherLength % (originalArray.length + 1) : undefined,
+              });
             }).toThrowError(/minimal length to be between 0/);
           }
         )
@@ -57,10 +60,13 @@ describe('SubarrayArbitrary', () => {
         fc.property(
           fc.array(fc.integer()),
           fc.nat(),
-          fc.nat(),
-          (originalArray: number[], offset: number, otherLength: number) => {
+          fc.option(fc.nat(), { nil: undefined }),
+          (originalArray: number[], offset: number, otherLength: number | undefined) => {
             expect(() => {
-              subarray(originalArray, originalArray.length + offset + 1, otherLength % (originalArray.length + 1));
+              subarray(originalArray, {
+                minLength: originalArray.length + offset + 1,
+                maxLength: otherLength !== undefined ? otherLength % (originalArray.length + 1) : undefined,
+              });
             }).toThrowError(/minimal length to be between 0/);
           }
         )
@@ -70,10 +76,13 @@ describe('SubarrayArbitrary', () => {
         fc.property(
           fc.array(fc.integer()),
           fc.nat(),
-          fc.nat(),
-          (originalArray: number[], length: number, otherLength: number) => {
+          fc.option(fc.nat(), { nil: undefined }),
+          (originalArray: number[], length: number, otherLength: number | undefined) => {
             expect(() => {
-              subarray(originalArray, otherLength % (originalArray.length + 1), -length - 1);
+              subarray(originalArray, {
+                minLength: otherLength !== undefined ? otherLength % (originalArray.length + 1) : undefined,
+                maxLength: -length - 1,
+              });
             }).toThrowError(/maximal length to be between 0/);
           }
         )
@@ -83,10 +92,13 @@ describe('SubarrayArbitrary', () => {
         fc.property(
           fc.array(fc.integer()),
           fc.nat(),
-          fc.nat(),
-          (originalArray: number[], offset: number, otherLength: number) => {
+          fc.option(fc.nat(), { nil: undefined }),
+          (originalArray: number[], offset: number, otherLength: number | undefined) => {
             expect(() => {
-              subarray(originalArray, otherLength % (originalArray.length + 1), originalArray.length + offset + 1);
+              subarray(originalArray, {
+                minLength: otherLength !== undefined ? otherLength % (originalArray.length + 1) : undefined,
+                maxLength: originalArray.length + offset + 1,
+              });
             }).toThrowError(/maximal length to be between 0/);
           }
         )
@@ -100,8 +112,10 @@ describe('SubarrayArbitrary', () => {
             expect(() => {
               subarray(
                 [...Array(minMax.max + offset)].map((_) => 0),
-                minMax.max,
-                minMax.min
+                {
+                  minLength: minMax.max,
+                  maxLength: minMax.min,
+                }
               );
             }).toThrowError(/minimal length to be inferior or equal to the maximal length/);
           }
@@ -119,7 +133,10 @@ describe('SubarrayArbitrary', () => {
       genericHelper.isValidArbitrary(
         (constraints: SubarrayMinMaxConstraits) => {
           const dims = computeMinMaxFor(constraints);
-          return subarray(constraints.src, dims.min, dims.max);
+          return subarray(constraints.src, {
+            minLength: dims.min,
+            maxLength: dims.max,
+          });
         },
         {
           seedGenerator: fc.record({ src: fc.array(fc.integer()), a: fc.nat(), b: fc.nat() }),
@@ -147,7 +164,10 @@ describe('SubarrayArbitrary', () => {
       genericHelper.isValidArbitrary(
         (constraints: SubarrayMinMaxConstraits) => {
           const dims = computeMinMaxFor(constraints);
-          return shuffledSubarray(constraints.src, dims.min, dims.max);
+          return shuffledSubarray(constraints.src, {
+            minLength: dims.min,
+            maxLength: dims.max,
+          });
         },
         {
           seedGenerator: fc.record({ src: fc.array(fc.integer()), a: fc.nat(), b: fc.nat() }),


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

Add support for the unified new signatures of arbitraries on subarray-based arbitraries.

Related to #89 and #992

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None.