### PR TITLE
✨ Add constraints-based signature for json/jsonObject

### DIFF
--- a/codemods/unify-signatures/snippet-5.js
+++ b/codemods/unify-signatures/snippet-5.js
@@ -41,6 +41,6 @@ fc.shuffledSubarray(computeArray(), 1, 2);
 // json
 
 fc.json();
-fc.json(5);
+fc.json(2);
 fc.json(10);
 fc.json({ maxDepth: 10 });

--- a/codemods/unify-signatures/snippet-5.js
+++ b/codemods/unify-signatures/snippet-5.js
@@ -37,3 +37,10 @@ fc.shuffledSubarray([1, 2, 3]);
 fc.shuffledSubarray([1, 2, 3], 1, 2);
 fc.shuffledSubarray(myArray, 1, 2);
 fc.shuffledSubarray(computeArray(), 1, 2);
+
+// json
+
+fc.json();
+fc.json(5);
+fc.json(10);
+fc.json({ maxDepth: 10 });

--- a/codemods/unify-signatures/transform.cjs
+++ b/codemods/unify-signatures/transform.cjs
@@ -280,6 +280,20 @@ module.exports = function (file, api, options) {
           }
           break;
         }
+        case 'json':
+        case 'unicodeJson':
+        case 'jsonObject':
+        case 'unicodeJsonObject': {
+          if (p.value.arguments.length === 1 && p.value.arguments[0].type !== 'ObjectExpression') {
+            // fc.json(10) -> fc.json({maxDepth})
+            const simplifyMax = options.simplifyMax && isNumericValue(p.value.arguments[0], 5);
+            p.value.arguments = computeNewArguments(
+              [],
+              [!simplifyMax && j.property('init', j.identifier('maxDepth'), p.value.arguments[0])]
+            );
+          }
+          break;
+        }
       }
       return p;
     })

--- a/codemods/unify-signatures/transform.cjs
+++ b/codemods/unify-signatures/transform.cjs
@@ -286,7 +286,7 @@ module.exports = function (file, api, options) {
         case 'unicodeJsonObject': {
           if (p.value.arguments.length === 1 && p.value.arguments[0].type !== 'ObjectExpression') {
             // fc.json(10) -> fc.json({maxDepth})
-            const simplifyMax = options.simplifyMax && isNumericValue(p.value.arguments[0], 5);
+            const simplifyMax = options.simplifyMax && isNumericValue(p.value.arguments[0], 2);
             p.value.arguments = computeNewArguments(
               [],
               [!simplifyMax && j.property('init', j.identifier('maxDepth'), p.value.arguments[0])]

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -903,7 +903,8 @@ fc.stringOf(fc.constantFrom('Hello', 'World'), {minLength: 1, maxLength: 3})
 *&#8195;Signatures*
 
 - `fc.json()`
-- `fc.json(maxDepth)`
+- `fc.json({maxDepth?})`
+- _`fc.json(maxDepth)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -921,11 +922,17 @@ fc.json()
 // • "{}"
 // • …
 
-fc.json(0)
-// Examples of generated values: "-618939220", "null", "-21", "\"'M\"", "-1336128433"…
+fc.json({maxDepth: 0})
+// Examples of generated values: "0.18608385079037526", "false", "null", "0.25584162771702035", "true"…
 
-fc.json(1)
-// Examples of generated values: "[null,null]", "null", "[false]", "[]", "\"'M\""…
+fc.json({maxDepth: 1})
+// Examples of generated values:
+// • "{\"mTZw9f!~2\":null,\"W\":null,\"N'!U6\":null,\"x\":null,\"=l]l\":null}"
+// • "{\"#\":3.494583413754526e-7,\"CyPnYYJ\\\\N\":0.9551698971333347,\"&%J\":null,\"HSz2u=t6J\":null}"
+// • "{\" !t! #.V\":null,\"%#!kPE&?6\":6.253999207395111e-8}"
+// • "{\"|\":false,\"*I\":0.8821854617928871,\"r(>uO\":\"I$2`I_6@\",\"N'q\":null}"
+// • "[0.7470952319262365,0.7422909334763742,0.0069430153745627665]"
+// • …
 ```
 </details>
 
@@ -942,7 +949,8 @@ fc.json(1)
 *&#8195;Signatures*
 
 - `fc.unicodeJson()`
-- `fc.unicodeJson(maxDepth)`
+- `fc.unicodeJson({maxDepth?})`
+- _`fc.unicodeJson(maxDepth)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -960,17 +968,11 @@ fc.unicodeJson()
 // • "{\"迵끀꧋좡ꏶ塣퐼띞\":{\"䧎﹥ï\":null},\"ቈ保婠꠨旞荫㹢ފ\":{\"콆쳑Ｈ᜞紽ѳ㑓\":false},\"\":{\"ꉶ瀞뿱끮筡팹᧊\":0.9470328025826398},\"끨\":1001562014}"
 // • …
 
-fc.unicodeJson(0)
-// Examples of generated values: "3.126712444512236e-8", "null", "\"㚗᭏µƖ簛或㝠ꗳ欛\"", "\"썤\"", "true"…
+fc.unicodeJson({maxDepth: 0})
+// Examples of generated values: "10", "1898171291", "null", "0.22572752833366638", "0.026702941895505816"…
 
-fc.unicodeJson(1)
-// Examples of generated values:
-// • "[true]"
-// • "{\"ٻ騈ᄸ\":-19}"
-// • "\"㚗᭏µƖ簛或㝠ꗳ欛\""
-// • "\"썤\""
-// • "{\"ᨫ㽹\":\"⢓Ｊ紛锆\",\"跺袁嚆⶯잨ꋿǵ蔵\":\"\",\"샘嬩\":\"烻ࡎ⑸嬗䠻\",\"\":\"값֏젴恝츏\",\"遊緃៚\":\"縧뜻箝雁債㠠\"}"
-// • …
+fc.unicodeJson({maxDepth: 1})
+// Examples of generated values: "10", "1898171291", "null", "[]", "0.026702941895505816"…
 ```
 </details>
 
@@ -2211,7 +2213,8 @@ fc.object({
 *&#8195;Signatures*
 
 - `fc.jsonObject()`
-- `fc.jsonObject(maxDepth)`
+- `fc.jsonObject({maxDepth?})`
+- _`fc.jsonObject(maxDepth)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -2229,11 +2232,11 @@ fc.jsonObject()
 // • [[-31,-1747504894]]
 // • …
 
-fc.jsonObject(0)
-// Examples of generated values: null, ".", "Sd41(w1z", "n", "'=Q"…
+fc.jsonObject({maxDepth: 0})
+// Examples of generated values: -312267957, "C{X%3]Q$U", "M}7xc\" _", true, null…
 
-fc.jsonObject(1)
-// Examples of generated values: {"/iET":-482578189,"POwJz":null,"*K1J":"R*;x,(-}","+IIwgC?":null}, [null], [0.7618818962743513], {"Kq/]OM":"81@","":null}, "'=Q"…
+fc.jsonObject({maxDepth: 1})
+// Examples of generated values: -312267957, {"{":true,"Q$":null}, "M}7xc\" _", {".b?^O.":"","D1$L":"zDJWs","j*s 9%":"",".":"0N|^?8"}, {}…
 ```
 </details>
 
@@ -2247,7 +2250,8 @@ fc.jsonObject(1)
 *&#8195;Signatures*
 
 - `fc.unicodeJsonObject()`
-- `fc.unicodeJsonObject(maxDepth)`
+- `fc.unicodeJsonObject({maxDepth?})`
+- _`fc.unicodeJsonObject(maxDepth)`_ — _not recommended ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -2259,16 +2263,16 @@ fc.jsonObject(1)
 fc.unicodeJsonObject()
 // Examples of generated values: false, [[-1517505516,-480082521]], "⠵䟵谉ꏊ㓰捛멮켜", null, [null,null,null,null]…
 
-fc.unicodeJsonObject(0)
-// Examples of generated values: "-㫴", "꺫蒬娃Ė븥", null, 0.6968476056387718, 0.7140081822872186…
+fc.unicodeJsonObject({maxDepth: 0})
+// Examples of generated values: 4.4703486135055925e-8, 1.7994014667177538e-7, true, -13, 2.451586696983199e-7…
 
-fc.unicodeJsonObject(1)
+fc.unicodeJsonObject({maxDepth: 1})
 // Examples of generated values:
-// • "-㫴"
-// • {"蒬娃Ė븥㏣퐷㮯౅":null,"枕ꞡ繍ᚶᩏ蜸Ꮪ":0.17484163030123312,"⋽߬㦕㌮ᮌ䤳䙒":false,"憊翀䔽薦䯛睂䷡醥긴":"얒쒏"}
-// • null
-// • 0.6968476056387718
-// • [0.35169129693363876,0.22590550057532044]
+// • 4.4703486135055925e-8
+// • {"减":null,"鲊ਉ뉄":null,"罧癤鷢൜牶":null,"횆쐌淪燀쯠蝒熹཯":null,"":null}
+// • {"ꁺ척蜱젿됻⫄":true,"㠰䵤᧳ꊺ蹀":true,"劸웤鯁냠漼ⳍ㧞ﰗἭ∎":false}
+// • []
+// • ["疘쥱"]
 // • …
 ```
 </details>

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -46,6 +46,7 @@ import { mixedCase, MixedCaseConstraints } from './check/arbitrary/MixedCaseArbi
 import {
   anything,
   json,
+  JsonSharedConstraints,
   jsonObject,
   object,
   ObjectConstraints,
@@ -280,6 +281,7 @@ export {
   ArrayConstraints,
   CommandsContraints,
   FalsyContraints,
+  JsonSharedConstraints,
   MixedCaseConstraints,
   ObjectConstraints,
   OptionConstraints,


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Unify signatures on arbitraries: fc.json, fc.jsonObject, fc.unicodeJson, fc.unicodeJsonObject (see [#992](https://github.com/dubzzz/fast-check/issues/992))

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None