### PR TITLE
🎨 Stricter limits on email arbitrary

### DIFF
--- a/src/check/arbitrary/EmailArbitrary.ts
+++ b/src/check/arbitrary/EmailArbitrary.ts
@@ -8,16 +8,20 @@ import { Arbitrary } from './definition/Arbitrary';
 /**
  * For email address
  *
- * According to {@link https://www.ietf.org/rfc/rfc5322.txt | RFC 5322}
+ * According to {@link https://www.ietf.org/rfc/rfc2821.txt | RFC 2821},
+ * {@link https://www.ietf.org/rfc/rfc3696.txt | RFC 3696} and
+ * {@link https://www.ietf.org/rfc/rfc5322.txt | RFC 5322}
  *
  * @public
  */
 export function emailAddress(): Arbitrary<string> {
   const others = ['!', '#', '$', '%', '&', "'", '*', '+', '-', '/', '=', '?', '^', '_', '`', '{', '|', '}', '~'];
   const atextArb = buildLowerAlphaNumericArb(others);
-  const dotAtomArb = array(stringOf(atextArb, { minLength: 1, maxLength: 10 }), {
-    minLength: 1,
-    maxLength: 5,
-  }).map((a) => a.join('.'));
-  return tuple(dotAtomArb, domain()).map(([lp, d]) => `${lp}@${d}`);
+  const localPartArb = array(stringOf(atextArb, { minLength: 1, maxLength: 10 }), { minLength: 1, maxLength: 5 })
+    .map((a) => a.join('.'))
+    // According to RFC 2821:
+    //    The maximum total length of a user name or other local-part is 64 characters.
+    .filter((lp) => lp.length <= 64);
+
+  return tuple(localPartArb, domain()).map(([lp, d]) => `${lp}@${d}`);
 }

--- a/test/unit/check/arbitrary/EmailArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/EmailArbitrary.spec.ts
@@ -8,6 +8,13 @@ const isValidEmailRfc1123 = (t: string) => {
   return rfc1123.test(t);
 };
 
+const isValidEmailRfc2821 = (t: string) => {
+  const [localPart, domain] = t.split('@');
+  // The maximum total length of a user name or other local-part is 64 characters.
+  // The maximum total length of a domain name or number is 255 characters.
+  return localPart.length <= 64 && domain.length <= 255;
+};
+
 const isValidEmailRfc5322 = (t: string) => {
   // Taken from https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression
   const rfc5322 = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -19,6 +26,11 @@ describe('EmailArbitrary', () => {
     describe('RFC 1123', () => {
       genericHelper.isValidArbitrary(() => emailAddress(), {
         isValidValue: (g: string) => isValidEmailRfc1123(g),
+      });
+    });
+    describe('RFC 2821', () => {
+      genericHelper.isValidArbitrary(() => emailAddress(), {
+        isValidValue: (g: string) => isValidEmailRfc2821(g),
       });
     });
     describe('RFC 5322', () => {


### PR DESCRIPTION
## In a nutshell

Safer email generation: we now ensures by using a filter that the size will never be outside of the authorized range.
The previous implementation was already safe we just make it even safer in case we refactor it in the future.

Fixes #1008

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None