### PR TITLE
🐛 Constraints on `fc.date` might be wrongly applied

### DIFF
--- a/src/check/arbitrary/DateArbitrary.ts
+++ b/src/check/arbitrary/DateArbitrary.ts
@@ -10,8 +10,8 @@ import { integer } from './IntegerArbitrary';
  */
 export function date(constraints?: { min?: Date; max?: Date }): Arbitrary<Date> {
   // Date min and max in ECMAScript specification : https://stackoverflow.com/a/11526569/3707828
-  const intMin = constraints && constraints.min ? constraints.min.getTime() : -8640000000000000;
-  const intMax = constraints && constraints.max ? constraints.max.getTime() : 8640000000000000;
+  const intMin = constraints && constraints.min !== undefined ? constraints.min.getTime() : -8640000000000000;
+  const intMax = constraints && constraints.max !== undefined ? constraints.max.getTime() : 8640000000000000;
   if (Number.isNaN(intMin)) throw new Error('fc.date min must be valid instance of Date');
   if (Number.isNaN(intMax)) throw new Error('fc.date max must be valid instance of Date');
   if (intMin > intMax) throw new Error('fc.date max must be greater or equal to min');


### PR DESCRIPTION
## In a nutshell

Related to #1109

It might not fix the problem reported by the issue but the approach to apply constraints will be safer. 

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
