### PR TITLE
🔧 Clean warnings related to ts-jest

### DIFF
--- a/documentation/HandsOnPropertyBased.md
+++ b/documentation/HandsOnPropertyBased.md
@@ -87,7 +87,7 @@ Edit `package.json` to configure the test framework:
 // --
 "jest": {
   "moduleFileExtensions": ["ts", "tsx", "js"],
-  "globals": {"ts-jest": {"tsConfig": "tsconfig.json"}},
+  "globals": {"ts-jest": {"tsconfig": "tsconfig.json"}},
   "transform": {"^.+\\.(ts|tsx)$": "ts-jest"},
   "testMatch": ["**/specs/*.+(ts|tsx|js)"]
 },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,11 +5,11 @@ module.exports = {
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
-    }
+      tsconfig: 'tsconfig.json',
+    },
   },
   testMatch: ['<rootDir>/test/**/*.spec.ts'],
   setupFiles: [],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  preset: 'ts-jest'
+  preset: 'ts-jest',
 };


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

```txt
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
```

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *config*

(✔️: yes, ❌: no)

## Potential impacts

None