### PR TITLE
🐛🏷️ Fix wrongly typed fc.record(recordModel)

### DIFF
--- a/src/check/arbitrary/RecordArbitrary.ts
+++ b/src/check/arbitrary/RecordArbitrary.ts
@@ -17,7 +17,8 @@ export interface RecordConstraints {
  * given the type of the source arbitrary and constraints to be applied
  * @public
  */
-export type RecordValue<T, Constraints = undefined> = Constraints extends {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type RecordValue<T, Constraints = {}> = Constraints extends {
   withDeletedKeys: true;
 }
   ? Partial<T>

--- a/test/type/index.test-d.ts
+++ b/test/type/index.test-d.ts
@@ -70,6 +70,10 @@ expectType<fc.Arbitrary<1 | 2 | 'hello'>>(fc.constantFrom(...([1, 2, 'hello'] as
 
 // record arbitrary
 expectType<fc.Arbitrary<{ a: number; b: string }>>(fc.record({ a: fc.nat(), b: fc.string() }));
+expectType<fc.Arbitrary<{ a: number; b: string }>>(fc.record({ a: fc.nat(), b: fc.string() }, {}));
+expectType<fc.Arbitrary<{ a: number; b: string }>>(
+  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: false })
+);
 expectType<fc.Arbitrary<{ a?: number; b?: string }>>(
   fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: true })
 );


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Fixes #1141

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact on `fc.record`