### PR TITLE
✨ Add commit hash into the generated package

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Build production package
-        run: yarn build:prod
+        run: yarn build:prod-ci
       - name: Create bundle
         run: |
           yarn pack

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:publish-cjs": "tsc -p tsconfig.publish.json",
     "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm && cp package.esm-template.json lib/esm/package.json",
     "build:prod": "yarn prebuild && yarn build:publish-cjs && yarn build:publish-esm && yarn build:publish-types && node postbuild/main.cjs",
+    "build:prod-ci": "cross-env EXPECT_GITHUB_SHA=true yarn build:prod",
     "watch": "tsc -w",
     "test": "jest --config jest.unit.config.cjs --coverage",
     "test:watch": "jest --config jest.unit.config.cjs --watch",

--- a/postbuild/main.cjs
+++ b/postbuild/main.cjs
@@ -1,7 +1,11 @@
 // eslint-disable-next-line
+const { execSync } = require('child_process');
+// eslint-disable-next-line
 const fs = require('fs');
 // eslint-disable-next-line
 const path = require('path');
+// eslint-disable-next-line
+const process = require('process');
 // eslint-disable-next-line
 const replace = require('replace-in-file');
 
@@ -10,7 +14,7 @@ const replace = require('replace-in-file');
 const options = {
   files: 'lib/**/*.js',
   from: [/from '\.(.*)(?<!\.js)'/g, /from "\.(.*)(?<!\.js)"/g],
-  to: ["from '.$1.js'", 'from ".$1.js"']
+  to: ["from '.$1.js'", 'from ".$1.js"'],
 };
 
 const results = replace.sync(options);
@@ -24,19 +28,22 @@ for (const { file, hasChanged } of results) {
 // Fill metas related to the package
 
 // eslint-disable-next-line
+const commitHash = getCommitHash();
+
+// eslint-disable-next-line
 fs.readFile(path.join(__dirname, '../package.json'), (err, data) => {
   if (err) {
     // eslint-disable-next-line
     console.error(err.message);
-    return;
+    process.exit(2);
   }
 
   const packageVersion = JSON.parse(data.toString()).version;
 
   const commonJsReplacement = replace.sync({
     files: 'lib/fast-check-default.js',
-    from: [/__PACKAGE_TYPE__/g, /__PACKAGE_VERSION__/g],
-    to: ['commonjs', packageVersion]
+    from: [/__PACKAGE_TYPE__/g, /__PACKAGE_VERSION__/g, /__COMMIT_HASH__/g],
+    to: ['commonjs', packageVersion, commitHash],
   });
   if (commonJsReplacement.length === 1 && commonJsReplacement[0].hasChanged) {
     // eslint-disable-next-line
@@ -45,8 +52,8 @@ fs.readFile(path.join(__dirname, '../package.json'), (err, data) => {
 
   const moduleReplacement = replace.sync({
     files: 'lib/esm/fast-check-default.js',
-    from: [/__PACKAGE_TYPE__/g, /__PACKAGE_VERSION__/g],
-    to: ['module', packageVersion]
+    from: [/__PACKAGE_TYPE__/g, /__PACKAGE_VERSION__/g, /__COMMIT_HASH__/g],
+    to: ['module', packageVersion, commitHash],
   });
   if (moduleReplacement.length === 1 && moduleReplacement[0].hasChanged) {
     // eslint-disable-next-line
@@ -55,11 +62,30 @@ fs.readFile(path.join(__dirname, '../package.json'), (err, data) => {
 
   const dTsReplacement = replace.sync({
     files: 'lib/types/fast-check-default.d.ts',
-    from: [/__PACKAGE_VERSION__/g],
-    to: [packageVersion],
+    from: [/__PACKAGE_VERSION__/g, /__COMMIT_HASH__/g],
+    to: [packageVersion, commitHash],
   });
   if (dTsReplacement.length === 1 && dTsReplacement[0].hasChanged) {
     // eslint-disable-next-line
     console.info(`Package details added onto d.ts version`);
   }
 });
+
+// Helpers
+function getCommitHash() {
+  const gitHubCommitHash = process.env.GITHUB_SHA && process.env.GITHUB_SHA.split('\n')[0];
+  if (gitHubCommitHash) {
+    // eslint-disable-next-line
+    console.info(`Using env variable GITHUB_SHA for the commit hash, got: ${gitHubCommitHash}`);
+    return gitHubCommitHash;
+  }
+  if (process.env.EXPECT_GITHUB_SHA) {
+    if (!gitHubCommitHash) {
+      // eslint-disable-next-line
+      console.error('No GITHUB_SHA specified');
+      process.exit(1);
+    }
+  }
+  const out = execSync('git rev-parse HEAD');
+  return out.toString().split('\n')[0];
+}

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -151,6 +151,11 @@ const __type = '__PACKAGE_TYPE__' as string;
  * @public
  */
 const __version = '__PACKAGE_VERSION__' as string;
+/**
+ * Commit hash of the current code (eg.: __COMMIT_HASH__)
+ * @public
+ */
+const __commitHash = '__COMMIT_HASH__' as string;
 
 /**
  * @deprecated Switch to {@link ContextValue} instead
@@ -175,6 +180,7 @@ export {
   // meta
   __type,
   __version,
+  __commitHash,
   // assess the property
   sample,
   statistics,


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Commit hash related to the package can be accessed with: `fc.__commitHash`

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None