### PR TITLE
💚 FIX Wrongly defined `isStrictlySmallerValue` for `floatNext`

### DIFF
--- a/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
@@ -104,9 +104,9 @@ describe('FloatNextArbitrary', () => {
         isStrictlySmallerValue: (fa, fb, ct?: FloatNextConstraints) =>
           Math.abs(fa) < Math.abs(fb) || //              Case 1: abs(a) < abs(b)
           (Object.is(fa, -0) && Object.is(fb, +0)) || // Case 2: -0 < +0
-          (ct !== undefined && ct.max !== undefined && isStrictlySmaller(ct.max, +0))
+          (ct !== undefined && ct.max !== undefined && isStrictlySmaller(ct.max, +0)
             ? Number.isNaN(fa) && !Number.isNaN(fb) //   Case 3: notNaN > NaN when max <  +0
-            : !Number.isNaN(fa) && Number.isNaN(fb), //          notNaN < NaN when max >= +0
+            : !Number.isNaN(fa) && Number.isNaN(fb)), //         notNaN < NaN when max >= +0
         isValidValue: (g: number, ct?: FloatNextConstraints) => {
           if (typeof g !== 'number') return false; // should always produce numbers
           if (!is32bits(g)) return false; // should always produce 32-bit floats

--- a/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
@@ -101,10 +101,12 @@ describe('FloatNextArbitrary', () => {
     });
     describe('Is valid arbitrary?', () => {
       genericHelper.isValidArbitrary((ct?: FloatNextConstraints) => floatNext(ct), {
-        isStrictlySmallerValue: (fa, fb) =>
+        isStrictlySmallerValue: (fa, fb, ct?: FloatNextConstraints) =>
           Math.abs(fa) < Math.abs(fb) || //              Case 1: abs(a) < abs(b)
           (Object.is(fa, -0) && Object.is(fb, +0)) || // Case 2: -0 < +0
-          (!Number.isNaN(fa) && Number.isNaN(fb)), //    Case 3: notNaN < NaN
+          (ct !== undefined && ct.max !== undefined && isStrictlySmaller(ct.max, +0))
+            ? Number.isNaN(fa) && !Number.isNaN(fb) //   Case 3: notNaN > NaN when max <  +0
+            : !Number.isNaN(fa) && Number.isNaN(fb), //          notNaN < NaN when max >= +0
         isValidValue: (g: number, ct?: FloatNextConstraints) => {
           if (typeof g !== 'number') return false; // should always produce numbers
           if (!is32bits(g)) return false; // should always produce 32-bit floats

--- a/test/unit/check/arbitrary/generic/GenericArbitraryHelper.ts
+++ b/test/unit/check/arbitrary/generic/GenericArbitraryHelper.ts
@@ -165,8 +165,9 @@ export const isValidArbitrary = function <U, T>(
   testSameSeedSameValues(biasedSeedGenerator, biasedArbitraryBuilder, assertEquality, parameters);
   testSameSeedSameShrinks(biasedSeedGenerator, biasedArbitraryBuilder, assertEquality, parameters);
   if (settings.isStrictlySmallerValue != null) {
+    const isStrictlySmallerValue = settings.isStrictlySmallerValue;
     const biasedIsStrictlySmallerValue = (g1: T, g2: T, [_biasedFactor, u]: [number | null, U]) => {
-      return settings.isStrictlySmallerValue(g1, g2, u);
+      return isStrictlySmallerValue(g1, g2, u);
     };
     testShrinkPathStrictlyDecreasing(
       biasedSeedGenerator,


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *wrong test*

(✔️: yes, ❌: no)

## Potential impacts

None