### PR TITLE
✨ Move NaN as an extreme value for floatNext

### DIFF
--- a/src/check/arbitrary/FloatNextArbitrary.ts
+++ b/src/check/arbitrary/FloatNextArbitrary.ts
@@ -198,8 +198,15 @@ export function floatNext(constraints: FloatNextConstraints = {}): Arbitrary<num
   if (noNaN) {
     return integer(minIndex, maxIndex).map(indexToFloat);
   }
-  return integer(minIndex, maxIndex + 1).map((index) => {
-    if (index > maxIndex) return Number.NaN;
+  // In case maxIndex > 0 or in other words max > 0,
+  //   values will be [min, ..., +0, ..., max, NaN]
+  //               or [min, ..., max, NaN] if min > +0
+  // Otherwise,
+  //   values will be [NaN, min, ..., max] with max <= +0
+  const minIndexWithNaN = maxIndex > 0 ? minIndex : minIndex - 1;
+  const maxIndexWithNaN = maxIndex > 0 ? maxIndex + 1 : maxIndex;
+  return integer(minIndexWithNaN, maxIndexWithNaN).map((index) => {
+    if (index > maxIndex || index < minIndex) return Number.NaN;
     else return indexToFloat(index);
   });
 }

--- a/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
@@ -104,9 +104,9 @@ describe('FloatNextArbitrary', () => {
         isStrictlySmallerValue: (fa, fb, ct?: FloatNextConstraints) =>
           Math.abs(fa) < Math.abs(fb) || //              Case 1: abs(a) < abs(b)
           (Object.is(fa, -0) && Object.is(fb, +0)) || // Case 2: -0 < +0
-          (ct !== undefined && ct.max !== undefined && isStrictlySmaller(ct.max, +0)
-            ? Number.isNaN(fa) && !Number.isNaN(fb) //   Case 3: notNaN > NaN when max <  +0
-            : !Number.isNaN(fa) && Number.isNaN(fb)), //         notNaN < NaN when max >= +0
+          (ct !== undefined && ct.max !== undefined && ct.max <= 0
+            ? Number.isNaN(fa) && !Number.isNaN(fb) //   Case 3: notNaN > NaN, when max <= 0 NaN is the minimal value
+            : !Number.isNaN(fa) && Number.isNaN(fb)), //         notNaN < NaN, when max >  0 NaN is the maximal value
         isValidValue: (g: number, ct?: FloatNextConstraints) => {
           if (typeof g !== 'number') return false; // should always produce numbers
           if (!is32bits(g)) return false; // should always produce 32-bit floats


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Before that change shrinking a value generated by floatNext could have produced NaN.
In reality NaN should be considered as one of the extreme values (after the max or after the min but never the closer from zero).

It is more an enhancement than a new feature.

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None, the feature has not been released yet.