### PR TITLE
💚 FIX Wrongly expressed isStrictlySmallerValue in floatNext

### DIFF
--- a/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
@@ -101,12 +101,10 @@ describe('FloatNextArbitrary', () => {
     });
     describe('Is valid arbitrary?', () => {
       genericHelper.isValidArbitrary((ct?: FloatNextConstraints) => floatNext(ct), {
-        isStrictlySmallerValue: (fa, fb, ct?: FloatNextConstraints) =>
+        isStrictlySmallerValue: (fa, fb) =>
           Math.abs(fa) < Math.abs(fb) || //              Case 1: abs(a) < abs(b)
           (Object.is(fa, -0) && Object.is(fb, +0)) || // Case 2: -0 < +0
-          (ct !== undefined && ct.max !== undefined && ct.max <= 0
-            ? Number.isNaN(fa) && !Number.isNaN(fb) //   Case 3: notNaN > NaN, when max <= 0 NaN is the minimal value
-            : !Number.isNaN(fa) && Number.isNaN(fb)), //         notNaN < NaN, when max >  0 NaN is the maximal value
+          (!Number.isNaN(fa) && Number.isNaN(fb)), //    Case 3: notNaN < NaN, NaN is one of the extreme values
         isValidValue: (g: number, ct?: FloatNextConstraints) => {
           if (typeof g !== 'number') return false; // should always produce numbers
           if (!is32bits(g)) return false; // should always produce 32-bit floats


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

In previous test when ct.max === 0 we were doing:
> Number.isNaN(fa) && !Number.isNaN(fb)

In such configuration we expect:
[NaN, 0] with index=-1 for NaN and index=0 for 0

Actually NaN should always be considered greater than others no matter the passed constraints. The only additional check we could do is: check that the value of fa has the right sign or is +0 but it does not bring lots of value.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *badly written test*

(✔️: yes, ❌: no)

## Potential impacts

None