### PR TITLE
💚 Spec. for `fc.float(Next)` was not doing the right checks to compare zeros

### DIFF
--- a/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FloatNextArbitrary.spec.ts
@@ -103,7 +103,7 @@ describe('FloatNextArbitrary', () => {
       genericHelper.isValidArbitrary((ct?: FloatNextConstraints) => floatNext(ct), {
         isStrictlySmallerValue: (fa, fb) =>
           Math.abs(fa) < Math.abs(fb) || //              Case 1: abs(a) < abs(b)
-          (Object.is(fa, -0) && Object.is(fb, +0)) || // Case 2: -0 < +0
+          (Object.is(fa, +0) && Object.is(fb, -0)) || // Case 2: +0 < -0  --> we shrink from -0 to +0
           (!Number.isNaN(fa) && Number.isNaN(fb)), //    Case 3: notNaN < NaN, NaN is one of the extreme values
         isValidValue: (g: number, ct?: FloatNextConstraints) => {
           if (typeof g !== 'number') return false; // should always produce numbers


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Fixes #1198

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *green ci*

(✔️: yes, ❌: no)

## Potential impacts

None
