### PR TITLE
💚 Reduce flakiness of array e2e

### DIFF
--- a/test/e2e/arbitraries/ArrayArbitrary.spec.ts
+++ b/test/e2e/arbitraries/ArrayArbitrary.spec.ts
@@ -64,7 +64,7 @@ function biasIts<T>(label: string, arb: fc.Arbitrary<T>) {
         const filtered = removeDuplicates(arr);
         expect(filtered).toHaveLength(new Set(filtered).size); // expect no duplicates (but will find some)
       }),
-      { seed, numRuns: 5000 } // increased numRuns to remove flakiness
+      { seed, numRuns: 10000 } // increased numRuns to remove flakiness
     );
     expect(out.failed).toBe(true);
     expect(out.counterexample![0]).toHaveLength(2);


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Increasing the number of runs from 5k to 10k is supposed to reduce the number of red runs. Actually the red runs are quite rare but as we run e2e 6 times per PR, it is better to have it greener. 

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *tests*

(✔️: yes, ❌: no)

## Potential impacts

If you expect some noticeable impacts with your change please explain.

Here are some examples of impacts that might be reported into this section:
- Generated values impact,
- Shrink values impact,
- Performance impact,
- Typings impact
