### PR TITLE
👷 Basic setup for codecov

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:
+          name: unit-tests-node-${{matrix.node-version}}-${{runner.os}}
           flags: unit-tests, node-${{matrix.node-version}}, ${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: true # default: false

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -58,6 +58,12 @@ jobs:
             yarn build
       - name: Unit tests
         run: yarn test
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unit-tests, node-${{matrix.node-version}}, ${{runner.os}}
+          fail_ci_if_error: false # default: false
+          verbose: true # default: false
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:
-          name: unit-tests-node-${{matrix.node-version}}-${{runner.os}}
-          flags: unit-tests, node-${{matrix.node-version}}, ${{runner.os}}
+          name: unit-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: unit-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
-          verbose: true # default: false
+          verbose: false # default: false
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -62,7 +62,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: unit-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: unit-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: unit-tests, node-${{matrix.node-version}}, ${{runner.os}}, unit-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
       - name: Coveralls
@@ -100,7 +100,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: e2e-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: e2e-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: e2e-tests, node-${{matrix.node-version}}, ${{runner.os}}, e2e-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
   publish_coverage:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -96,6 +96,13 @@ jobs:
             yarn build
       - name: End-to-end tests
         run: yarn e2e
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          name: e2e-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: e2e-tests-${{matrix.node-version}}-${{runner.os}}
+          fail_ci_if_error: false # default: false
+          verbose: false # default: false
   publish_coverage:
     name: 'Publish coverage'
     needs: test

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -w",
     "test": "jest --config jest.unit.config.cjs --coverage",
     "test:watch": "jest --config jest.unit.config.cjs --watch",
-    "e2e": "jest --config jest.e2e.config.cjs",
+    "e2e": "jest --config jest.e2e.config.cjs --coverage",
     "e2e:watch": "jest --config jest.e2e.config.cjs --watch",
     "update:examples": "cross-env UPDATE_CODE_SNIPPETS=true jest --config jest.examples.config.cjs",
     "docs": "api-extractor run --local && rm docs/fast-check.api.json && typedoc --out docs src && node postbuild/main.cjs",


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Reports provided by coveralls are difficult to diagnose when some paths are randomly executed. They are said to be red while when we open the detailed view of the job everything appear to be green.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *coverage tooling*

(✔️: yes, ❌: no)

## Potential impacts

None