### PR TITLE
👷 Remove unused flags in coverage

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -62,7 +62,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: unit-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: unit-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: unit-tests, unit-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
       - name: Coveralls
@@ -100,7 +100,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: e2e-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: e2e-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: e2e-tests, e2e-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
   publish_coverage:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -62,7 +62,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: unit-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: unit-tests, node-${{matrix.node-version}}, ${{runner.os}}, unit-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: unit-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
       - name: Coveralls
@@ -100,7 +100,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: e2e-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: e2e-tests, node-${{matrix.node-version}}, ${{runner.os}}, e2e-tests-${{matrix.node-version}}-${{runner.os}}
+          flags: e2e-tests-${{matrix.node-version}}-${{runner.os}}
           fail_ci_if_error: false # default: false
           verbose: false # default: false
   publish_coverage:


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

For the moment, we don't use flags so much. So we limit them to the name of the job. We might add them back in the future of needed.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *code coverage*

(✔️: yes, ❌: no)

## Potential impacts

None
