### PR TITLE
💬 Prefer unique symbols over `Symbol.for`

### DIFF
--- a/src/check/precondition/PreconditionFailure.ts
+++ b/src/check/precondition/PreconditionFailure.ts
@@ -3,7 +3,7 @@
  * @public
  */
 export class PreconditionFailure extends Error {
-  private static readonly SharedFootPrint: symbol = Symbol.for('fast-check/PreconditionFailure');
+  private static readonly SharedFootPrint: symbol = Symbol('fast-check/PreconditionFailure');
   private readonly footprint: symbol;
   constructor(readonly interruptExecution: boolean = false) {
     super();

--- a/src/check/runner/configuration/GlobalParameters.ts
+++ b/src/check/runner/configuration/GlobalParameters.ts
@@ -2,7 +2,7 @@ import { getGlobal } from '../../../utils/globalThis';
 import { Parameters } from './Parameters';
 
 /** @internal */
-const globalParametersSymbol = Symbol.for('fast-check/GlobalParameters');
+const globalParametersSymbol = Symbol('fast-check/GlobalParameters');
 
 /**
  * Type of legal hook function that can be used in the global parameter `beforeEach` and/or `afterEach`

--- a/src/check/symbols.ts
+++ b/src/check/symbols.ts
@@ -10,7 +10,7 @@
  *
  * @public
  */
-export const cloneMethod = Symbol.for('fast-check/cloneMethod');
+export const cloneMethod = Symbol('fast-check/cloneMethod');
 
 /** @internal */
 export interface WithCloneMethod<T> {

--- a/test/unit/check/precondition/Pre.spec.ts
+++ b/test/unit/check/precondition/Pre.spec.ts
@@ -1,5 +1,6 @@
 import { pre } from '../../../../src/check/precondition/Pre';
 import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure';
+import * as fc from '../../../../lib/fast-check';
 
 describe('pre', () => {
   it('should not throw on thruthy condition', () => {
@@ -12,6 +13,16 @@ describe('pre', () => {
     } catch (err) {
       failed = true;
       expect(PreconditionFailure.isFailure(err)).toBe(true);
+    }
+    expect(failed).toBe(true);
+  });
+  it('should not understand PreconditionFailure thrown by other instances', () => {
+    let failed = false;
+    try {
+      fc.pre(false);
+    } catch (err) {
+      failed = true;
+      expect(PreconditionFailure.isFailure(err)).toBe(false);
     }
     expect(failed).toBe(true);
   });

--- a/test/unit/check/runner/configuration/GlobalParameters.spec.ts
+++ b/test/unit/check/runner/configuration/GlobalParameters.spec.ts
@@ -3,6 +3,7 @@ import {
   readConfigureGlobal,
   resetConfigureGlobal,
 } from '../../../../../src/check/runner/configuration/GlobalParameters';
+import * as fc from '../../../../../lib/fast-check';
 
 describe('GlobalParameters', () => {
   afterEach(() => {
@@ -19,5 +20,12 @@ describe('GlobalParameters', () => {
 
     resetConfigureGlobal();
     expect(readConfigureGlobal()).toBe(undefined);
+  });
+  it('should use distinct global configurations for distinct instances of fast-check'() => {
+    const myGlobalConfiguration = { numRuns: 123 };
+
+    configureGlobal(myGlobalConfiguration);
+    expect(readConfigureGlobal()).toBe(myGlobalConfiguration);
+    expect(fc.readConfigureGlobal()).not.toBe(myGlobalConfiguration);
   });
 });

--- a/test/unit/check/runner/configuration/GlobalParameters.spec.ts
+++ b/test/unit/check/runner/configuration/GlobalParameters.spec.ts
@@ -21,7 +21,7 @@ describe('GlobalParameters', () => {
     resetConfigureGlobal();
     expect(readConfigureGlobal()).toBe(undefined);
   });
-  it('should use distinct global configurations for distinct instances of fast-check'() => {
+  it('should use distinct global configurations for distinct instances of fast-check', () => {
     const myGlobalConfiguration = { numRuns: 123 };
 
     configureGlobal(myGlobalConfiguration);

--- a/test/unit/check/symbols.spec.ts
+++ b/test/unit/check/symbols.spec.ts
@@ -1,0 +1,8 @@
+import { cloneMethod } from '../../../src/check/symbols';
+import * as fc from '../../../lib/fast-check';
+
+describe('symbols', () => {
+  it('should declare distinct cloneMethod for distinct libraries', () => {
+    expect(cloneMethod).not.toBe(fc.cloneMethod);
+  });
+});


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *refactoring*

(✔️: yes, ❌: no)

## Potential impacts

Symbols changed but no problem expected except if you users are importing different versions of fast-check at the same time. In that case, symbols will differ between the versions. 