### PR TITLE
✨ Add support for Symbol keys in record

### DIFF
--- a/src/check/arbitrary/RecordArbitrary.ts
+++ b/src/check/arbitrary/RecordArbitrary.ts
@@ -11,6 +11,11 @@ export type RecordConstraints<T = unknown> =
   | {
       /**
        * List keys that should never be deleted.
+       *
+       * Remark:
+       * You might need to use an explicit typing in case you need to declare symbols as required (not needed when required keys are simple strings).
+       * With something like `{ requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] }` when both `mySymbol1` and `a` are required.
+       *
        * Warning: Cannot be used in conjunction with withDeletedKeys.
        */
       requiredKeys?: T[];
@@ -39,7 +44,7 @@ export type RecordValue<T, TConstraints = {}> = TConstraints extends { withDelet
   : T;
 
 /** @internal */
-function rawRecord<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<{ [K in keyof T]: T[K] }> {
+function rawRecord<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<T> {
   const keys: Extract<keyof T, string>[] = [];
   const arbs: Arbitrary<T[keyof T]>[] = [];
   for (const k in recordModel) {
@@ -51,7 +56,7 @@ function rawRecord<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitra
     for (let idx = 0; idx !== keys.length; ++idx) {
       obj[keys[idx]] = gs[idx];
     }
-    return obj as { [K in keyof T]: T[K] };
+    return obj as T;
   });
 }
 
@@ -68,7 +73,7 @@ function rawRecord<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitra
  *
  * @public
  */
-function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<RecordValue<{ [K in keyof T]: T[K] }>>;
+function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<RecordValue<T>>;
 /**
  * For records following the `recordModel` schema
  *
@@ -86,7 +91,7 @@ function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<
 function record<T, TConstraints extends RecordConstraints<keyof T>>(
   recordModel: { [K in keyof T]: Arbitrary<T[K]> },
   constraints: TConstraints
-): Arbitrary<RecordValue<{ [K in keyof T]: T[K] }, TConstraints>>;
+): Arbitrary<RecordValue<T, TConstraints>>;
 function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }, constraints?: RecordConstraints<keyof T>) {
   if (constraints == null) {
     return rawRecord(recordModel);

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -81,15 +81,15 @@ expectType<fc.Arbitrary<{ a: number; b: string }>>()(fc.record({ a: fc.nat(), b:
 expectType<fc.Arbitrary<{ [mySymbol1]: number; [mySymbol2]: string }>>()(
   fc.record({ [mySymbol1]: fc.nat(), [mySymbol2]: fc.string() })
 );
-// Related to https://github.com/microsoft/TypeScript/issues/27525
+// Related to https://github.com/microsoft/TypeScript/issues/27525:
 //expectType<fc.Arbitrary<{ [Symbol.iterator]: number; [mySymbol2]: string }>>()(
 //  fc.record({ [Symbol.iterator]: fc.nat(), [mySymbol2]: fc.string() })
 //);
-// Workaround for known symbols not defined as unique ones
-const symbolIterator: unique symbol = Symbol.iterator as any;
-expectType<fc.Arbitrary<{ [symbolIterator]: number; [mySymbol2]: string }>>()(
-  fc.record({ [symbolIterator]: fc.nat(), [mySymbol2]: fc.string() })
-);
+// Workaround for known symbols not defined as unique ones:
+//const symbolIterator: unique symbol = Symbol.iterator as any;
+//expectType<fc.Arbitrary<{ [symbolIterator]: number; [mySymbol2]: string }>>()(
+//  fc.record({ [symbolIterator]: fc.nat(), [mySymbol2]: fc.string() })
+//);
 expectType<fc.Arbitrary<{ a: number; b: string }>>()(fc.record({ a: fc.nat(), b: fc.string() }, {}));
 expectType<fc.Arbitrary<{ a: number; b: string }>>()(
   fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: false })

--- a/test/unit/check/arbitrary/RecordArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/RecordArbitrary.spec.ts
@@ -2,21 +2,24 @@ import * as prand from 'pure-rand';
 import * as fc from '../../../../lib/fast-check';
 
 import { constant } from '../../../../src/check/arbitrary/ConstantArbitrary';
+import { Arbitrary } from '../../../../src/check/arbitrary/definition/Arbitrary';
 import { integer } from '../../../../src/check/arbitrary/IntegerArbitrary';
 import { record, RecordConstraints } from '../../../../src/check/arbitrary/RecordArbitrary';
 import { Random } from '../../../../src/random/generator/Random';
 
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
-import { Arbitrary } from '../../../../src/check/arbitrary/definition/Arbitrary';
+const keyArb: fc.Arbitrary<any> = fc
+  .tuple(fc.string(), fc.boolean())
+  .map(([name, symbol]) => (symbol ? Symbol.for(name) : name));
 
 describe('RecordArbitrary', () => {
   describe('record', () => {
     it('Should produce a record with missing keys', () =>
       fc.assert(
-        fc.property(fc.set(fc.string(), { minLength: 1 }), fc.nat(), fc.integer(), (keys, missingIdx, seed) => {
+        fc.property(fc.set(keyArb, { minLength: 1 }), fc.nat(), fc.integer(), (keys, missingIdx, seed) => {
           const mrng = new Random(prand.xorshift128plus(seed));
-          const recordModel: { [key: string]: Arbitrary<string> } = {};
+          const recordModel: Record<string | symbol, Arbitrary<string>> = {};
           for (const k of keys) recordModel[k] = constant(`_${k}_`);
 
           const arb = record(recordModel, { withDeletedKeys: true });
@@ -29,9 +32,9 @@ describe('RecordArbitrary', () => {
       ));
     it('Should produce a record with present keys', () =>
       fc.assert(
-        fc.property(fc.set(fc.string(), { minLength: 1 }), fc.nat(), fc.integer(), (keys, missingIdx, seed) => {
+        fc.property(fc.set(keyArb, { minLength: 1 }), fc.nat(), fc.integer(), (keys, missingIdx, seed) => {
           const mrng = new Random(prand.xorshift128plus(seed));
-          const recordModel: { [key: string]: Arbitrary<string> } = {};
+          const recordModel: Record<string | symbol, Arbitrary<string>> = {};
           for (const k of keys) {
             recordModel[k] = constant(`_${k}_`);
           }
@@ -46,10 +49,10 @@ describe('RecordArbitrary', () => {
       ));
     it('Should reject configurations specifying non existing keys as required', () =>
       fc.assert(
-        fc.property(fc.set(fc.string(), { minLength: 1 }), fc.string(), (keys, requiredKey) => {
+        fc.property(fc.set(keyArb, { minLength: 1 }), keyArb, (keys, requiredKey) => {
           fc.pre(!keys.includes(requiredKey));
 
-          const recordModel: { [key: string]: Arbitrary<string> } = {};
+          const recordModel: Record<string | symbol, Arbitrary<string>> = {};
           for (const k of keys) {
             recordModel[k] = constant(`_${k}_`);
           }
@@ -64,14 +67,14 @@ describe('RecordArbitrary', () => {
     it('Should reject configurations specifying both requiredKeys and withDeletedKeys (even undefined)', () =>
       fc.assert(
         fc.property(
-          fc.set(fc.record({ name: fc.string(), required: fc.boolean() }), {
+          fc.set(fc.record({ name: keyArb, required: fc.boolean() }), {
             minLength: 1,
             compare: (a, b) => a.name === b.name,
           }),
           fc.option(fc.constant(true), { nil: undefined }),
           fc.option(fc.boolean(), { nil: undefined }),
           (keys, withRequiredKeys, withDeletedKeys) => {
-            const recordModel: { [key: string]: Arbitrary<string> } = {};
+            const recordModel: Record<string | symbol, Arbitrary<string>> = {};
             for (const k of keys) {
               recordModel[k.name] = constant(`_${k.name}_`);
             }
@@ -86,10 +89,10 @@ describe('RecordArbitrary', () => {
         )
       ));
 
-    type Meta = { key: string; valueStart: number; kept: boolean };
+    type Meta = { key: any; valueStart: number; kept: boolean };
     const metaArbitrary = fc.set(
       fc.record({
-        key: fc.string(),
+        key: keyArb,
         valueStart: fc.nat(1000),
         kept: fc.boolean(),
       }),
@@ -103,7 +106,7 @@ describe('RecordArbitrary', () => {
     describe('Given a custom record configuration', () => {
       genericHelper.isValidArbitrary(
         ([metas, constraints]: [Meta[], RecordConstraints<any>]) => {
-          const recordModel: { [key: string]: Arbitrary<number> } = {};
+          const recordModel: Record<string | symbol, Arbitrary<number>> = {};
           for (const m of metas) {
             recordModel[m.key] = integer(m.valueStart, m.valueStart + 10);
           }
@@ -122,7 +125,7 @@ describe('RecordArbitrary', () => {
               return [metas, constraintsMeta] as [Meta[], RecordConstraints];
             }),
           isValidValue: (r: { [key: string]: number }, [metas, constraints]: [Meta[], RecordConstraints]) => {
-            for (const k of Object.keys(r)) {
+            for (const k of [...Object.getOwnPropertyNames(r), ...Object.getOwnPropertySymbols(r)]) {
               // generated object should not have more keys
               if (metas.findIndex((m) => m.key === k) === -1) return false;
             }
@@ -147,10 +150,6 @@ describe('RecordArbitrary', () => {
               if (typeof r[m.key] !== 'number') return false;
               if (r[m.key] < m.valueStart) return false;
               if (r[m.key] > m.valueStart + 10) return false;
-            }
-            for (const k in r) {
-              // all keys of the generated value comes from keys defined in metas
-              if (metas.find((m) => m.key === k) === undefined) return false;
             }
             return true;
           },


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Fixes #240

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

No real impact expected except that record will now accept models containing symbols as keys.
