### PR TITLE
doc about filter performance

### DIFF
--- a/src/check/arbitrary/definition/Arbitrary.ts
+++ b/src/check/arbitrary/definition/Arbitrary.ts
@@ -25,6 +25,8 @@ export abstract class Arbitrary<T> {
    * All the values produced by the resulting arbitrary
    * satisfy `predicate(value) == true`
    *
+   * Be aware that using filter may highly impact the time required to generate a valid entry
+   *
    * @example
    * ```typescript
    * const integerGenerator: Arbitrary<number> = ...;
@@ -41,6 +43,8 @@ export abstract class Arbitrary<T> {
    *
    * All the values produced by the resulting arbitrary
    * satisfy `predicate(value) == true`
+   *
+   * Be aware that using filter may highly impact the time required to generate a valid entry
    *
    * @example
    * ```typescript


### PR DESCRIPTION
## Description
`Arbitrary.filter` can harm the performance of generations of values, and this is shown in [the advanced doc](https://github.com/dubzzz/fast-check/blob/master/documentation/AdvancedArbitraries.md#filter-values) but not in the code doc.
This is a very important and fundamental issue when use property based testing libraries so should be written in the code doc explicitly.
The doc content is borrowed from the advanced doc description.

## In a nutshell

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*
