### PR TITLE
✨ Introduce new helper ArbitraryWithContextualShrink

### DIFF
--- a/src/check/arbitrary/definition/ArbitraryWithContextualShrink.ts
+++ b/src/check/arbitrary/definition/ArbitraryWithContextualShrink.ts
@@ -1,0 +1,96 @@
+import { Random } from '../../../random/generator/Random';
+import { Stream } from '../../../stream/Stream';
+import { Arbitrary } from './Arbitrary';
+import { Shrinkable } from './Shrinkable';
+
+/**
+ * Extract value from tuple [value, context]
+ * @internal
+ */
+function removeContextFromContextualValue<T>(contextualValue: [T, unknown]): T {
+  return contextualValue[0];
+}
+
+/**
+ * Abstract class able to generate and shrink values on type `T`
+ *
+ * It can shrink a value that it has not produced through `generate` (contrary to {@link Arbitrary}).
+ * In the case of classical {@link Arbitrary} there is no `contextualShrink`, `contextualShrinkableFor` methods directly on the {@link Arbitrary},
+ * the users have to call `shrink` on the instance of {@link Shrinkable} produced by `generate`.
+ *
+ * @public
+ */
+abstract class ArbitraryWithContextualShrink<T> extends Arbitrary<T> {
+  /**
+   * Generate a value of type `T` along with its shrink method
+   * based on the provided random number generator
+   *
+   * @param mrng - Random number generator
+   * @returns Random value of type `T` and its shrinker
+   */
+  abstract generate(mrng: Random): Shrinkable<T>;
+
+  /**
+   * Produce a stream of shrinks of value
+   *
+   * @param value - Value to shrink
+   * @param context -
+   * @returns Stream of shrinks associated to value
+   */
+  abstract contextualShrink(value: T, context?: unknown): Stream<[T, unknown]>;
+
+  /**
+   * Build the Shrinkable associated to value
+   *
+   * @param value - Value to shrink
+   * @param shrunkOnce - Indicate whether its the first shrink
+   * @returns Shrinkable associated to value
+   */
+  contextualShrinkableFor(value: T, context?: unknown): Shrinkable<T> {
+    return new Shrinkable(value, () =>
+      this.contextualShrink(value, context).map((contextualValue) =>
+        this.contextualShrinkableFor(contextualValue[0], contextualValue[1])
+      )
+    );
+  }
+
+  /**
+   * Produce a context for shrunkOnce case
+   * @deprecated Prefer context based variants of shrink and shrinkableFor
+   */
+  abstract shrunkOnceContext(): unknown;
+
+  /**
+   * Produce a stream of shrinks of value
+   *
+   * @deprecated Prefer contextualShrink
+   *
+   * @param value - Value to shrink
+   * @param shrunkOnce - Indicate whether its the first shrink (default: false)
+   * @returns Stream of shrinks associated to value
+   */
+  shrink(value: T, shrunkOnce?: boolean): Stream<T> {
+    const context = shrunkOnce === true ? this.shrunkOnceContext() : undefined;
+    return this.contextualShrink(value, context).map(removeContextFromContextualValue);
+  }
+
+  /**
+   * Build the Shrinkable associated to value
+   *
+   * @deprecated Prefer contextualShrinkableFor
+   *
+   * @param value - Value to shrink
+   * @param shrunkOnce - Indicate whether its the first shrink
+   * @returns Shrinkable associated to value
+   */
+  shrinkableFor(value: T, shrunkOnce?: boolean): Shrinkable<T> {
+    return new Shrinkable(value, () => {
+      const context = shrunkOnce === true ? this.shrunkOnceContext() : undefined;
+      return this.contextualShrink(value, context).map((contextualValue) =>
+        this.contextualShrinkableFor(contextualValue[0], contextualValue[1])
+      );
+    });
+  }
+}
+
+export { ArbitraryWithContextualShrink };

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -136,6 +136,7 @@ import {
 } from './check/arbitrary/AsyncSchedulerArbitrary';
 import { defaultReportMessage } from './check/runner/utils/RunDetailsFormatter';
 import { ArbitraryWithShrink } from './check/arbitrary/definition/ArbitraryWithShrink';
+import { ArbitraryWithContextualShrink } from './check/arbitrary/definition/ArbitraryWithContextualShrink';
 import { CommandsContraints } from './check/model/commands/CommandsContraints';
 import { PreconditionFailure } from './check/precondition/PreconditionFailure';
 import { RandomType } from './check/runner/configuration/RandomType';
@@ -317,6 +318,7 @@ export {
   // extend the framework
   Arbitrary,
   ArbitraryWithShrink,
+  ArbitraryWithContextualShrink,
   Shrinkable,
   cloneMethod,
   // print values


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Why?

ArbitraryWithShrink do not provide enough details to the shrinker. Thus it leads to slow shrink scenarios as the only useful information we got on shrinker side is whether or not we already shrunk one.

The problem is that knowing whether we already shrunk or not is useful, but not enough to shrink in an efficient way. Thus we will introduce a new generation of shrinkers based on this more powerful helper.

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
