### PR TITLE
🐛 Calling `shrinkableFor` should never apply contextual shrinker

### DIFF
--- a/src/check/arbitrary/definition/ArbitraryWithContextualShrink.ts
+++ b/src/check/arbitrary/definition/ArbitraryWithContextualShrink.ts
@@ -87,7 +87,7 @@ abstract class ArbitraryWithContextualShrink<T> extends Arbitrary<T> {
     return new Shrinkable(value, () => {
       const context = shrunkOnce === true ? this.shrunkOnceContext() : undefined;
       return this.contextualShrink(value, context).map((contextualValue) =>
-        this.contextualShrinkableFor(contextualValue[0], contextualValue[1])
+        this.shrinkableFor(contextualValue[0], true)
       );
     });
   }

--- a/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
@@ -7,28 +7,12 @@ import * as genericHelper from './generic/GenericArbitraryHelper';
 
 import * as stubRng from '../../stubs/generators';
 import { generateOneValue } from './generic/GenerateOneValue';
-import { ArbitraryWithShrink } from '../../../../src/check/arbitrary/definition/ArbitraryWithShrink';
 
 const isStrictlySmallerInteger = (v1: number, v2: number) => Math.abs(v1) < Math.abs(v2);
 
 type ShrinkTree<T> = [T, ShrinkTree<T>[]];
 function buildShrinkTree(s: Shrinkable<number, number>): ShrinkTree<number> {
   return [s.value_, [...s.shrink().map((ss) => buildShrinkTree(ss))]];
-}
-function buildShrinkTreeWithShrunkOnce(
-  arb: ArbitraryWithShrink<number>,
-  value: number,
-  shrunkOnce = false
-): ShrinkTree<number> {
-  return [
-    value,
-    [
-      ...arb
-        .shrinkableFor(value, shrunkOnce)
-        .shrink()
-        .map((ss) => buildShrinkTreeWithShrunkOnce(arb, ss.value_, true)),
-    ],
-  ];
 }
 function renderTree(tree: ShrinkTree<number>): string[] {
   const [current, subTrees] = tree;
@@ -340,7 +324,7 @@ describe('IntegerArbitrary', () => {
       it('Should shrink strictly positive value for positive range including zero', () => {
         const arb = integer({ min: 0, max: 7 });
 
-        const tree = buildShrinkTreeWithShrunkOnce(arb, 6);
+        const tree = buildShrinkTree(arb.shrinkableFor(6));
 
         // prettier-ignore
         expect(renderTree(tree).join('\n')).toBe(
@@ -365,7 +349,7 @@ describe('IntegerArbitrary', () => {
       it('Should shrink strictly positive value for range not included zero', () => {
         const arb = integer({ min: 2, max: 9 });
 
-        const tree = buildShrinkTreeWithShrunkOnce(arb, 8);
+        const tree = buildShrinkTree(arb.shrinkableFor(8));
 
         // prettier-ignore
         expect(renderTree(tree).join('\n')).toBe(
@@ -390,7 +374,7 @@ describe('IntegerArbitrary', () => {
       it('Should shrink strictly negative value for negative range including zero', () => {
         const arb = integer({ min: -7, max: 0 });
 
-        const tree = buildShrinkTreeWithShrunkOnce(arb, -6);
+        const tree = buildShrinkTree(arb.shrinkableFor(-6));
 
         // prettier-ignore
         expect(renderTree(tree).join('\n')).toBe(


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

This potential regression has been introduced by #1355.
For the moment, we want to limit the impact on user still relying on legacy version of the shrinkers.

❌ New feature
✔️ Fix an issue: introduced by #1355 and not yet released
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Avoid a potential regression for users relying on `shrinkableFor`.