### PR TITLE
⚡️ Re-use the context of integer during the shrink of an array

### DIFF
--- a/src/check/arbitrary/ArrayArbitrary.ts
+++ b/src/check/arbitrary/ArrayArbitrary.ts
@@ -48,7 +48,7 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
     }
     return true;
   }
-  private wrapper(itemsRaw: Shrinkable<T>[], shrunkOnce: boolean): Shrinkable<T[]> {
+  private wrapper(itemsRaw: Shrinkable<T>[], shrunkOnce: boolean, itemsRawLengthContext: unknown): Shrinkable<T[]> {
     // We need to explicitly apply filtering on shrink items
     // has they might have duplicates (on non shrunk it is not the case by construct)
     const items = shrunkOnce ? this.preFilter(itemsRaw) : itemsRaw;
@@ -62,7 +62,17 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
     if (cloneable) {
       ArrayArbitrary.makeItCloneable(vs, items);
     }
-    return new Shrinkable(vs, () => this.shrinkImpl(items, shrunkOnce).map((v) => this.wrapper(v, true)));
+    const itemsLengthContext =
+      itemsRaw.length === items.length && itemsRawLengthContext !== undefined
+        ? itemsRawLengthContext // items and itemsRaw have the same length context is applicable
+        : shrunkOnce // otherwise we fallback to default contexts
+        ? this.lengthArb.shrunkOnceContext() // in case we shrunk once we use a dedicated context that should reduce shrink size
+        : undefined;
+    return new Shrinkable(vs, () =>
+      this.shrinkImpl(items, itemsLengthContext).map((contextualValue) =>
+        this.wrapper(contextualValue[0], true, contextualValue[1])
+      )
+    );
   }
   generate(mrng: Random): Shrinkable<T[]> {
     const targetSizeShrinkable = this.lengthArb.generate(mrng);
@@ -84,32 +94,42 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
         numSkippedInRow += 1;
       }
     }
-    return this.wrapper(items, false);
+    return this.wrapper(items, false, undefined);
   }
-  private shrinkImpl(items: Shrinkable<T>[], shrunkOnce: boolean): Stream<Shrinkable<T>[]> {
+  private shrinkImpl(items: Shrinkable<T>[], itemsLengthContext: unknown): Stream<[Shrinkable<T>[], unknown]> {
     if (items.length === 0) {
-      return Stream.nil<Shrinkable<T>[]>();
+      return Stream.nil<[Shrinkable<T>[], unknown]>();
     }
-    const size = this.lengthArb.contextualShrinkableFor(
-      items.length,
-      // We cannot have more context than just: Did we shrink once?
-      // Actually the context of integer arbitrary is highly dependent on the target value,
-      // passing a context computed for a length of 5 to an array having a length of 4 will not work properly.
-      shrunkOnce ? this.lengthArb.shrunkOnceContext() : undefined
+    return (
+      this.lengthArb
+        .contextualShrink(
+          items.length,
+          // itemsLengthContext is a context returned by a previous call to the integer
+          // abitrary and the integral value items.length.
+          itemsLengthContext
+        )
+        .map((contextualValue): [Shrinkable<T>[], unknown] => {
+          return [
+            items.slice(items.length - contextualValue[0]), // array of length contextualValue[0]
+            contextualValue[1], // integer context for value contextualValue[0] (the length)
+          ];
+        })
+        // Context value will be set to undefined for remaining shrinking values
+        // as they are outside of our shrinking process focused on items.length.
+        // None of our computed contexts will apply for them.
+        .join(items[0].shrink().map((v) => [[v].concat(items.slice(1)), undefined]))
+        .join(
+          items.length > this.minLength
+            ? makeLazy(() =>
+                // We pass itemsLengthContext=undefined to next shrinker to start shrinking
+                // without any assumptions on the current state (we never explored that one)
+                this.shrinkImpl(items.slice(1), undefined)
+                  .filter((contextualValue) => this.minLength <= contextualValue[0].length + 1)
+                  .map((contextualValue) => [[items[0]].concat(contextualValue[0]), undefined])
+              )
+            : Stream.nil<[Shrinkable<T>[], unknown]>()
+        )
     );
-    return size
-      .shrink()
-      .map((l) => items.slice(items.length - l.value))
-      .join(items[0].shrink().map((v) => [v].concat(items.slice(1))))
-      .join(
-        items.length > this.minLength
-          ? makeLazy(() =>
-              this.shrinkImpl(items.slice(1), false)
-                .filter((vs) => this.minLength <= vs.length + 1)
-                .map((vs) => [items[0]].concat(vs))
-            )
-          : Stream.nil<Shrinkable<T>[]>()
-      );
   }
   withBias(freq: number): Arbitrary<T[]> {
     return biasWrapper(freq, this, (originalArbitrary: ArrayArbitrary<T>) => {

--- a/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -522,9 +522,9 @@ Execution summary:
 
 exports[`NoRegression domain 1`] = `
 "Property failed after 1 tests
-{ seed: 42, path: \\"0:0:0:2:2:2:3:3:1:0:1:1\\", endOnFailure: true }
+{ seed: 42, path: \\"0:0:0:2:0:1:3:1:0:1:1\\", endOnFailure: true }
 Counterexample: [\\"aa.af\\"]
-Shrunk 11 time(s)
+Shrunk 10 time(s)
 Got error: Property failed by returning false
 
 Execution summary:
@@ -534,28 +534,21 @@ Execution summary:
 . . . [32m√[0m [\\"aw.swiysf\\"]
 . . . [32m√[0m [\\"a2ux9i71yglw.swiysf\\"]
 . . . [31m×[0m [\\"ach99e2ux9i71yglw.swiysf\\"]
-. . . . [32m√[0m [\\"ax9i71yglw.swiysf\\"]
-. . . . [32m√[0m [\\"a9e2ux9i71yglw.swiysf\\"]
-. . . . [31m×[0m [\\"ah99e2ux9i71yglw.swiysf\\"]
-. . . . . [32m√[0m [\\"a9i71yglw.swiysf\\"]
-. . . . . [32m√[0m [\\"ae2ux9i71yglw.swiysf\\"]
-. . . . . [31m×[0m [\\"a99e2ux9i71yglw.swiysf\\"]
+. . . . [31m×[0m [\\"a99e2ux9i71yglw.swiysf\\"]
+. . . . . [32m√[0m [\\"a9e2ux9i71yglw.swiysf\\"]
+. . . . . [31m×[0m [\\"aa9e2ux9i71yglw.swiysf\\"]
 . . . . . . [32m√[0m [\\"a9i71yglw.swiysf\\"]
 . . . . . . [32m√[0m [\\"a2ux9i71yglw.swiysf\\"]
 . . . . . . [32m√[0m [\\"a9e2ux9i71yglw.swiysf\\"]
-. . . . . . [31m×[0m [\\"aa9e2ux9i71yglw.swiysf\\"]
-. . . . . . . [32m√[0m [\\"a9i71yglw.swiysf\\"]
-. . . . . . . [32m√[0m [\\"a2ux9i71yglw.swiysf\\"]
-. . . . . . . [32m√[0m [\\"a9e2ux9i71yglw.swiysf\\"]
-. . . . . . . [31m×[0m [\\"aaw.swiysf\\"]
-. . . . . . . . [32m√[0m [\\"aw.swiysf\\"]
-. . . . . . . . [31m×[0m [\\"aaa.swiysf\\"]
-. . . . . . . . . [31m×[0m [\\"aa.swiysf\\"]
-. . . . . . . . . . [32m√[0m [\\"a.swiysf\\"]
-. . . . . . . . . . [31m×[0m [\\"aa.sf\\"]
-. . . . . . . . . . . [32m√[0m [\\"a.sf\\"]
-. . . . . . . . . . . [31m×[0m [\\"aa.af\\"]
-. . . . . . . . . . . . [32m√[0m [\\"a.af\\"]"
+. . . . . . [31m×[0m [\\"aaw.swiysf\\"]
+. . . . . . . [32m√[0m [\\"aw.swiysf\\"]
+. . . . . . . [31m×[0m [\\"aaa.swiysf\\"]
+. . . . . . . . [31m×[0m [\\"aa.swiysf\\"]
+. . . . . . . . . [32m√[0m [\\"a.swiysf\\"]
+. . . . . . . . . [31m×[0m [\\"aa.sf\\"]
+. . . . . . . . . . [32m√[0m [\\"a.sf\\"]
+. . . . . . . . . . [31m×[0m [\\"aa.af\\"]
+. . . . . . . . . . . [32m√[0m [\\"a.af\\"]"
 `;
 
 exports[`NoRegression double 1`] = `
@@ -1346,7 +1339,7 @@ Execution summary:
 
 exports[`NoRegression hexaString 1`] = `
 "Property failed after 6 tests
-{ seed: 42, path: \\"5:1:1:11:1:5:0\\", endOnFailure: true }
+{ seed: 42, path: \\"5:1:1:10:1:5:0\\", endOnFailure: true }
 Counterexample: [\\"66\\"]
 Shrunk 6 time(s)
 Got error: Property failed by returning false
@@ -1362,7 +1355,6 @@ Execution summary:
 . [31m×[0m [\\"fddc6\\"]
 . . [32m√[0m [\\"dc6\\"]
 . . [31m×[0m [\\"ddc6\\"]
-. . . [32m√[0m [\\"c6\\"]
 . . . [32m√[0m [\\"dc6\\"]
 . . . [32m√[0m [\\"0dc6\\"]
 . . . [32m√[0m [\\"7dc6\\"]
@@ -3374,7 +3366,7 @@ Execution summary:
 
 exports[`NoRegression webAuthority 1`] = `
 "Property failed after 1 tests
-{ seed: 42, path: \\"0:1:3:5:6:6:2:1:2:2:2:0:1\\", endOnFailure: true }
+{ seed: 42, path: \\"0:1:3:3:2:6:2:1:2:2:2:0:1\\", endOnFailure: true }
 Counterexample: [\\"aa.aw\\"]
 Shrunk 12 time(s)
 Got error: Property failed by returning false
@@ -3388,16 +3380,10 @@ Execution summary:
 . . [32m√[0m [\\"a59ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . [31m×[0m [\\"au77b318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . [32m√[0m [\\"7edwncurnj6.lw\\"]
-. . . [32m√[0m [\\"amed0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . [32m√[0m [\\"aioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . [32m√[0m [\\"a18g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . [32m√[0m [\\"a7b318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
+. . . [32m√[0m [\\"ag1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
+. . . [32m√[0m [\\"ab318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . [31m×[0m [\\"a77b318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . . [32m√[0m [\\"7edwncurnj6.lw\\"]
-. . . . [32m√[0m [\\"aed0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . . [32m√[0m [\\"aoh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . . [32m√[0m [\\"a8g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
-. . . . [32m√[0m [\\"ab318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . . [32m√[0m [\\"a7b318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . . [31m×[0m [\\"aa7b318g1-dioh859ca5e7med0c1-5ifcbdeycpda6fla6.7edwncurnj6.lw\\"]
 . . . . . [32m√[0m [\\"7edwncurnj6.lw\\"]
@@ -3521,7 +3507,7 @@ Execution summary:
 
 exports[`NoRegression webSegment 1`] = `
 "Property failed after 3 tests
-{ seed: 42, path: \\"2:2:1:18\\", endOnFailure: true }
+{ seed: 42, path: \\"2:2:0:17\\", endOnFailure: true }
 Counterexample: [\\"::\\"]
 Shrunk 3 time(s)
 Got error: Property failed by returning false
@@ -3533,9 +3519,7 @@ Execution summary:
 . [32m√[0m [\\"\\"]
 . [32m√[0m [\\":0T\\"]
 . [31m×[0m [\\"4::0T\\"]
-. . [32m√[0m [\\":0T\\"]
 . . [31m×[0m [\\"::0T\\"]
-. . . [32m√[0m [\\"0T\\"]
 . . . [32m√[0m [\\":0T\\"]
 . . . [32m√[0m [\\"a:0T\\"]
 . . . [32m√[0m [\\"N:0T\\"]


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *faster shrinker*

(✔️: yes, ❌: no)

## Potential impacts

Impacts on the shrinker of array and any derived arbitrary (including strings).
