### PR TITLE
Avoid using unsafe-eval in implementation of getGlobal

### DIFF
--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -1,3 +1,5 @@
+// tslint:disable
+
 // See https://github.com/paulmillr/es6-shim/commit/2367e0953edd01ae9a5628e1f47cf14b0377a7d6
 // and https://github.com/tc39/proposal-global/blob/269dd7c646451e72e3e3edc573b57ce766aac86a/README.md#rationale
 

--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -1,5 +1,9 @@
 // tslint:disable
 
+declare const self: any
+declare const window: any
+declare const global: any
+
 // See https://github.com/paulmillr/es6-shim/commit/2367e0953edd01ae9a5628e1f47cf14b0377a7d6
 // and https://github.com/tc39/proposal-global/blob/269dd7c646451e72e3e3edc573b57ce766aac86a/README.md#rationale
 

--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -10,23 +10,25 @@ declare const global: any;
  * Internal polyfill for `globalThis`
  * @internal
  */
-export let getGlobal = () => {
-  const globalThis = (function () {
-    // the only reliable means to get the global object is
-    // `Function('return this')()`
-    // However, this causes CSP violations in Chrome apps.
-    if (typeof self !== 'undefined') {
-      return self;
-    }
-    if (typeof window !== 'undefined') {
-      return window;
-    }
-    if (typeof global !== 'undefined') {
-      return global;
-    }
-    throw new Error('unable to locate global object');
-  })();
+/** @internal */
+const internalGlobalThis: any = (function () {
+  // the only reliable means to get the global object is
+  // `Function('return this')()`
+  // However, this causes CSP violations in Chrome apps.
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw new Error('unable to locate global object');
+})();
 
-  getGlobal = () => globalThis;
-  return globalThis;
-};
+/**
+ * Internal polyfill for `globalThis`
+ * @internal
+ */
+export const getGlobal = () => internalGlobalThis;

--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -1,13 +1,21 @@
-// Implementation of globalThis derived from https://github.com/tc39/proposal-global/blob/master/polyfill.js
-
-/** @internal */
-// tslint:disable
-const internalGlobalThis: any = (function (global) {
-  return global.globalThis ? global.globalThis : global;
-})(typeof this === 'object' ? this : Function('return this')());
+// See https://github.com/paulmillr/es6-shim/commit/2367e0953edd01ae9a5628e1f47cf14b0377a7d6
+// and https://github.com/tc39/proposal-global/blob/269dd7c646451e72e3e3edc573b57ce766aac86a/README.md#rationale
 
 /**
  * Internal polyfill for `globalThis`
  * @internal
  */
-export const getGlobal = () => internalGlobalThis;
+export let getGlobal = () => {
+  const globalThis = (function () {
+    // the only reliable means to get the global object is
+    // `Function('return this')()`
+    // However, this causes CSP violations in Chrome apps.
+    if (typeof self !== 'undefined') { return self; }
+    if (typeof window !== 'undefined') { return window; }
+    if (typeof global !== 'undefined') { return global; }
+    throw new Error('unable to locate global object');
+  })();
+  
+  getGlobal = () => globalThis
+  return globalThis;
+};

--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -1,11 +1,10 @@
-// tslint:disable
-
-declare const self: any
-declare const window: any
-declare const global: any
-
 // See https://github.com/paulmillr/es6-shim/commit/2367e0953edd01ae9a5628e1f47cf14b0377a7d6
 // and https://github.com/tc39/proposal-global/blob/269dd7c646451e72e3e3edc573b57ce766aac86a/README.md#rationale
+
+// tslint:disable
+declare const self: any;
+declare const window: any;
+declare const global: any;
 
 /**
  * Internal polyfill for `globalThis`
@@ -16,12 +15,18 @@ export let getGlobal = () => {
     // the only reliable means to get the global object is
     // `Function('return this')()`
     // However, this causes CSP violations in Chrome apps.
-    if (typeof self !== 'undefined') { return self; }
-    if (typeof window !== 'undefined') { return window; }
-    if (typeof global !== 'undefined') { return global; }
+    if (typeof self !== 'undefined') {
+      return self;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    if (typeof global !== 'undefined') {
+      return global;
+    }
     throw new Error('unable to locate global object');
   })();
-  
-  getGlobal = () => globalThis
+
+  getGlobal = () => globalThis;
   return globalThis;
 };

--- a/src/utils/globalThis.ts
+++ b/src/utils/globalThis.ts
@@ -10,7 +10,6 @@ declare const global: any;
  * Internal polyfill for `globalThis`
  * @internal
  */
-/** @internal */
 const internalGlobalThis: any = (function () {
   // the only reliable means to get the global object is
   // `Function('return this')()`
@@ -31,4 +30,4 @@ const internalGlobalThis: any = (function () {
  * Internal polyfill for `globalThis`
  * @internal
  */
-export const getGlobal = () => internalGlobalThis;
+export const getGlobal = (): any => internalGlobalThis;

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,14 +730,6 @@
     "@typescript-eslint/typescript-estree" "4.14.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.0.tgz#55a4743095d684e1f7b7180c4bac2a0a3727f517"
-  integrity sha512-/J+LlRMdbPh4RdL4hfP1eCwHN5bAhFAGOTsvE6SxsrM/47XQiPSgF5MDgLyp/i9kbZV9Lx80DW0OpPkzL+uf8Q==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
-
 "@typescript-eslint/scope-manager@4.14.1":
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz#8444534254c6f370e9aa974f035ced7fe713ce02"
@@ -746,29 +738,10 @@
     "@typescript-eslint/types" "4.14.1"
     "@typescript-eslint/visitor-keys" "4.14.1"
 
-"@typescript-eslint/types@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.0.tgz#d8a8202d9b58831d6fd9cee2ba12f8a5a5dd44b6"
-  integrity sha512-VsQE4VvpldHrTFuVPY1ZnHn/Txw6cZGjL48e+iBxTi2ksa9DmebKjAeFmTVAYoSkTk7gjA7UqJ7pIsyifTsI4A==
-
 "@typescript-eslint/types@4.14.1":
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.1.tgz#b3d2eb91dafd0fd8b3fce7c61512ac66bd0364aa"
   integrity sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==
-
-"@typescript-eslint/typescript-estree@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.0.tgz#4bcd67486e9acafc3d0c982b23a9ab8ac8911ed7"
-  integrity sha512-wRjZ5qLao+bvS2F7pX4qi2oLcOONIB+ru8RGBieDptq/SudYwshveORwCVU4/yMAd4GK7Fsf8Uq1tjV838erag==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.14.1":
   version "4.14.1"
@@ -783,14 +756,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.0.tgz#b1090d9d2955b044b2ea2904a22496849acbdf54"
-  integrity sha512-MeHHzUyRI50DuiPgV9+LxcM52FCJFYjJiWHtXlbyC27b80mfOwKeiKI+MHOTEpcpfmoPFm/vvQS88bYIx6PZTA==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.14.1":
   version "4.14.1"


### PR DESCRIPTION
The current implementation of getGlobal is not compatible with CSP (due to its use of `Function('return this')`).

## In a nutshell

✔️ Fix an issue
