### PR TITLE
♻️ No special case for sparse arrays without trailing holes and no elements

### DIFF
--- a/src/check/arbitrary/SparseArrayArbitrary.ts
+++ b/src/check/arbitrary/SparseArrayArbitrary.ts
@@ -63,7 +63,7 @@ export function sparseArray<T>(arb: Arbitrary<T>, constraints: SparseArrayConstr
   const resultedMaxNumElements = Math.min(maxNumElements, maxLength);
 
   if (noTrailingHole) {
-    if (maxLength === 0) {
+    if (resultedMaxNumElements === 0) {
       return constant([]);
     }
     return set(tuple(nat(maxLength - 1), arb), {

--- a/src/check/arbitrary/SparseArrayArbitrary.ts
+++ b/src/check/arbitrary/SparseArrayArbitrary.ts
@@ -63,14 +63,14 @@ export function sparseArray<T>(arb: Arbitrary<T>, constraints: SparseArrayConstr
   const resultedMaxNumElements = Math.min(maxNumElements, maxLength);
 
   if (noTrailingHole) {
-    if (resultedMaxNumElements === 0) {
-      return constant([]);
-    }
-    return set(tuple(nat(maxLength - 1), arb), {
+    const maxIndexAuthorized = Math.max(maxLength - 1, 0); // just preventing special case for maxLength=0
+    return set(tuple(nat(maxIndexAuthorized), arb), {
       minLength: minNumElements,
       maxLength: resultedMaxNumElements,
       compare: (itemA, itemB) => itemA[0] === itemB[0],
     }).map((items) => {
+      // When maxLength=0 (implies resultedMaxNumElements=0) we will have items=[] leading to lastIndex=-1
+      // resulting in an empty array
       const lastIndex = extractMaxIndex(items);
       return arrayFromItems(lastIndex + 1, items);
     });

--- a/src/check/arbitrary/SparseArrayArbitrary.ts
+++ b/src/check/arbitrary/SparseArrayArbitrary.ts
@@ -1,5 +1,4 @@
 import { maxLengthFromMinLength } from './ArrayArbitrary';
-import { constant } from './ConstantArbitrary';
 import { Arbitrary } from './definition/Arbitrary';
 import { nat } from './IntegerArbitrary';
 import { set } from './SetArbitrary';

--- a/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
@@ -5,12 +5,10 @@ import { mocked } from 'ts-jest/utils';
 
 import fc from '../../../../lib/fast-check';
 
-import * as ConstantArbitraryMock from '../../../../src/check/arbitrary/ConstantArbitrary';
 import * as IntegerArbitraryMock from '../../../../src/check/arbitrary/IntegerArbitrary';
 import * as SetArbitraryMock from '../../../../src/check/arbitrary/SetArbitrary';
 import * as TupleArbitraryMock from '../../../../src/check/arbitrary/TupleArbitrary';
 import { arbitraryFor } from './generic/ArbitraryBuilder';
-jest.mock('../../../../src/check/arbitrary/ConstantArbitrary');
 jest.mock('../../../../src/check/arbitrary/IntegerArbitrary');
 jest.mock('../../../../src/check/arbitrary/SetArbitrary');
 jest.mock('../../../../src/check/arbitrary/TupleArbitrary');
@@ -162,34 +160,6 @@ describe('SparseArrayArbitrary', () => {
             expect(() => sparseArray(arb, ct)).toThrowError(/non-hole/);
           }
         )
-      );
-    });
-
-    it('Should only produce empty arrays if no trailing holes and no elements allowed', () => {
-      fc.assert(
-        fc
-          .property(fc.option(fc.nat(), { nil: undefined }), (maxLength) => {
-            // Arrange
-            const { constant } = mocked(ConstantArbitraryMock);
-            const { set } = mocked(SetArbitraryMock);
-            const { tuple } = mocked(TupleArbitraryMock);
-            const expectedArbitrary = Symbol();
-            constant.mockReturnValueOnce(expectedArbitrary as any);
-
-            const arb = new FakeArbitrary();
-            const ct: SparseArrayConstraints = { noTrailingHole: true, maxNumElements: 0, maxLength };
-
-            // Act
-            const out = sparseArray(arb, ct);
-
-            // Assert
-            expect(out).toBe(expectedArbitrary);
-            expect(constant).toHaveBeenCalledTimes(1);
-            expect(constant).toHaveBeenCalledWith([]);
-            expect(set).not.toHaveBeenCalled();
-            expect(tuple).not.toHaveBeenCalled();
-          })
-          .beforeEach(beforeEachFunction)
       );
     });
   });

--- a/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
@@ -5,10 +5,12 @@ import { mocked } from 'ts-jest/utils';
 
 import fc from '../../../../lib/fast-check';
 
+import * as ConstantArbitraryMock from '../../../../src/check/arbitrary/ConstantArbitrary';
 import * as IntegerArbitraryMock from '../../../../src/check/arbitrary/IntegerArbitrary';
 import * as SetArbitraryMock from '../../../../src/check/arbitrary/SetArbitrary';
 import * as TupleArbitraryMock from '../../../../src/check/arbitrary/TupleArbitrary';
 import { arbitraryFor } from './generic/ArbitraryBuilder';
+jest.mock('../../../../src/check/arbitrary/ConstantArbitrary');
 jest.mock('../../../../src/check/arbitrary/IntegerArbitrary');
 jest.mock('../../../../src/check/arbitrary/SetArbitrary');
 jest.mock('../../../../src/check/arbitrary/TupleArbitrary');
@@ -160,6 +162,34 @@ describe('SparseArrayArbitrary', () => {
             expect(() => sparseArray(arb, ct)).toThrowError(/non-hole/);
           }
         )
+      );
+    });
+
+    it('Should only produce empty arrays if no trailing holes and no elements allowed', () => {
+      fc.assert(
+        fc
+          .property(fc.option(fc.nat(), { nil: undefined }), (maxLength) => {
+            // Arrange
+            const { constant } = mocked(ConstantArbitraryMock);
+            const { set } = mocked(SetArbitraryMock);
+            const { tuple } = mocked(TupleArbitraryMock);
+            const expectedArbitrary = Symbol();
+            constant.mockReturnValueOnce(expectedArbitrary as any);
+
+            const arb = new FakeArbitrary();
+            const ct: SparseArrayConstraints = { noTrailingHole: true, maxNumElements: 0, maxLength };
+
+            // Act
+            const out = sparseArray(arb, ct);
+
+            // Assert
+            expect(out).toBe(expectedArbitrary);
+            expect(constant).toHaveBeenCalledTimes(1);
+            expect(constant).toHaveBeenCalledWith([]);
+            expect(set).not.toHaveBeenCalled();
+            expect(tuple).not.toHaveBeenCalled();
+          })
+          .beforeEach(beforeEachFunction)
       );
     });
   });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

When asked for:
- noTrailingHole: true
- maxNumElements: 0
- maxLength > 0

sparse arrays was producing an array of size 0 but requested it through a complex workflow passing through the generation of an empty set (sometimes and sometimes not).

We just factorize the two paths into a single one to avoid an unneeded special case.

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
