### PR TITLE
👷 Stop sending e2e coverage into codecov

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -98,13 +98,6 @@ jobs:
             export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
             echo "DEFAULT_SEED is: ${DEFAULT_SEED}"
             yarn e2e
-      - name: Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          name: e2e-tests-${{matrix.node-version}}-${{runner.os}}
-          flags: e2e-tests, e2e-tests-${{matrix.node-version}}-${{runner.os}}
-          fail_ci_if_error: false # default: false
-          verbose: false # default: false
   test_package_quality:
     name: 'Test package quality'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Property based testing framework for JavaScript/TypeScript
   <a href="https://dubzzz.github.io/fast-check/"><img src="https://img.shields.io/badge/-API Reference-%23282ea9.svg" title="API Reference" /></a>
 </p>
 <p align="center">
-  <a href="https://app.codecov.io/gh/dubzzz/fast-check/branch/master"><img src="https://codecov.io/gh/dubzzz/fast-check/branch/master/graph/badge.svg?flag=unit-tests&precision=0" alt="Coverage Status (unit tests)" /></a>
+  <a href="https://app.codecov.io/gh/dubzzz/fast-check/branch/master"><img src="https://codecov.io/gh/dubzzz/fast-check/branch/master/graph/badge.svg" alt="Coverage Status (unit tests)" /></a>
   <a href="https://packagequality.com/#?package=fast-check"><img src="https://packagequality.com/shield/fast-check.svg" alt="Package quality" /></a>
   <a href="https://snyk.io/advisor/npm-package/fast-check"><img src="https://snyk.io/advisor/npm-package/fast-check/badge.svg" alt="Snyk Package quality" /></a>
   <a href="https://dependabot.com/compatibility-score/?dependency-name=fast-check&package-manager=npm_and_yarn&version-scheme=semver"><img src="https://img.shields.io/dependabot/semver/npm_and_yarn/fast-check" alt="Semver stability" /></a>


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

For the moment the support for flags is not perfect and lead to red builds first, then green as soon as unit-tests come back.

Additionally badge does not report the right coverage when filtered on flags.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *ci*

(✔️: yes, ❌: no)

## Potential impacts

None
