### PR TITLE
💚 Increase numRuns for bias e2e to limit flakiness

### DIFF
--- a/test/e2e/arbitraries/Arbitrary.spec.ts
+++ b/test/e2e/arbitraries/Arbitrary.spec.ts
@@ -39,7 +39,9 @@ describe(`Arbitrary (seed: ${seed})`, () => {
           fc.nat().chain((c) => fc.tuple(fc.constant(c), fc.nat())),
           (v: [number, number]) => !(v[0] <= 100 && v[1] <= 100)
         ),
-        { seed: seed }
+        // Number of runs has been artificially increased to reduce the flakiness of this test
+        // The default (100) was not so bad, but from time to time it led to red runs in the CI
+        { seed: seed, numRuns: 500 }
       );
       expect(out.failed).toBe(true);
     });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *flaky ci*

(✔️: yes, ❌: no)

## Potential impacts

None
