### PR TITLE
🐛 `add64` is not supposed to produce negative zeros

### DIFF
--- a/src/check/arbitrary/helpers/ArrayInt64.ts
+++ b/src/check/arbitrary/helpers/ArrayInt64.ts
@@ -114,6 +114,9 @@ export function negative64(arrayIntA: ArrayInt64): ArrayInt64 {
  */
 export function add64(arrayIntA: ArrayInt64, arrayIntB: ArrayInt64): ArrayInt64 {
   if (isZero64(arrayIntB)) {
+    if (isZero64(arrayIntA)) {
+      return clone64(Zero64);
+    }
     return clone64(arrayIntA);
   }
   return substract64(arrayIntA, negative64(arrayIntB));

--- a/test/unit/check/arbitrary/helpers/ArrayInt64.spec.ts
+++ b/test/unit/check/arbitrary/helpers/ArrayInt64.spec.ts
@@ -9,7 +9,6 @@ import {
   logLike64,
   negative64,
   substract64,
-  Zero64,
 } from '../../../../../src/check/arbitrary/helpers/ArrayInt64';
 
 function toArrayInt64(b: bigint, withNegativeZero: boolean): ArrayInt64 {
@@ -116,23 +115,33 @@ describe('ArrayInt64', () => {
           }
         )
       ));
-    it('Should correspond to first term if second one is zero', () =>
+    it('Should equal to first term if second one is zero', () =>
       fc.assert(
-        fc.property(fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }), (a) => {
-          const result64 = substract64(toArrayInt64(a, false), Zero64);
-          expectValidArrayInt(result64);
-          expectValidZeroIfAny(result64);
-          expect(result64).toEqual(toArrayInt64(a, false));
-        })
+        fc.property(
+          fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }),
+          fc.boolean(),
+          fc.boolean(),
+          (a, na, nb) => {
+            const result64 = substract64(toArrayInt64(a, na), toArrayInt64(BigInt(0), nb));
+            expectValidArrayInt(result64);
+            expectValidZeroIfAny(result64);
+            expect(result64).toEqual(toArrayInt64(a, false)); // toArrayInt64(a, false): sign must be + for 0
+          }
+        )
       ));
-    it('Should correspond to minus second term if first one is zero', () =>
+    it('Should equal to minus second term if first one is zero', () =>
       fc.assert(
-        fc.property(fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }), (a) => {
-          const result64 = substract64(Zero64, toArrayInt64(a, false));
-          expectValidArrayInt(result64);
-          expectValidZeroIfAny(result64);
-          expect(result64).toEqual(toArrayInt64(-a, false));
-        })
+        fc.property(
+          fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }),
+          fc.boolean(),
+          fc.boolean(),
+          (a, na, nb) => {
+            const result64 = substract64(toArrayInt64(BigInt(0), nb), toArrayInt64(a, na));
+            expectValidArrayInt(result64);
+            expectValidZeroIfAny(result64);
+            expect(result64).toEqual(toArrayInt64(-a, false)); // toArrayInt64(-a, false): sign must be + for 0
+          }
+        )
       ));
   });
 
@@ -167,23 +176,33 @@ describe('ArrayInt64', () => {
           }
         )
       ));
-    it('Should correspond to first term if second one is zero', () =>
+    it('Should equal to first term if second one is zero', () =>
       fc.assert(
-        fc.property(fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }), (a) => {
-          const result64 = add64(toArrayInt64(a, false), Zero64);
-          expectValidArrayInt(result64);
-          expectValidZeroIfAny(result64);
-          expect(result64).toEqual(toArrayInt64(a, false));
-        })
+        fc.property(
+          fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }),
+          fc.boolean(),
+          fc.boolean(),
+          (a, na, nb) => {
+            const result64 = add64(toArrayInt64(a, na), toArrayInt64(BigInt(0), nb));
+            expectValidArrayInt(result64);
+            expectValidZeroIfAny(result64);
+            expect(result64).toEqual(toArrayInt64(a, false)); // toArrayInt64(a, false): sign must be + for 0
+          }
+        )
       ));
-    it('Should correspond to second term if first one is zero', () =>
+    it('Should equal to second term if first one is zero', () =>
       fc.assert(
-        fc.property(fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }), (a) => {
-          const result64 = add64(Zero64, toArrayInt64(a, false));
-          expectValidArrayInt(result64);
-          expectValidZeroIfAny(result64);
-          expect(result64).toEqual(toArrayInt64(a, false));
-        })
+        fc.property(
+          fc.bigInt({ min: -MaxArrayIntValue, max: MaxArrayIntValue }),
+          fc.boolean(),
+          fc.boolean(),
+          (a, na, nb) => {
+            const result64 = add64(toArrayInt64(BigInt(0), nb), toArrayInt64(a, na));
+            expectValidArrayInt(result64);
+            expectValidZeroIfAny(result64);
+            expect(result64).toEqual(toArrayInt64(a, false)); // toArrayInt64(a, false): sign must be + for 0
+          }
+        )
       ));
   });
 


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Fixes #1491

No visible impact/fix from an user point of view (internal API whose bug never surfaces). We are just ensuring that internals do what they say to do.

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
