### PR TITLE
💥 Remove deprecated signatures of `fc.array`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2332,8 +2332,6 @@ fc.genericTuple([fc.nat(), fc.string()])
 
 - `fc.array(arb)`
 - `fc.array(arb, {minLength?, maxLength?})`
-- _`fc.array(arb, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.array(arb, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/documentation/Tips.md
+++ b/documentation/Tips.md
@@ -247,7 +247,7 @@ function UserPageProfile(props) {
 test('should not display data related to another user', () =>
   fc.assert(
     fc.asyncProperty(
-      fc.array(fc.uuid(), fc.uuid(), fc.scheduler(),
+      fc.uuid(), fc.uuid(), fc.scheduler(),
       async (uid1, uid2, s) => {
         // Arrange
         getUserProfile.mockImplementation(

--- a/example/005-race/autocomplete/main.spec.tsx
+++ b/example/005-race/autocomplete/main.spec.tsx
@@ -31,7 +31,7 @@ describe('AutocompleteField', () => {
         .asyncProperty(AllResultsArbitrary, QueriesArbitrary, fc.scheduler({ act }), async (allResults, queries, s) => {
           // Arrange
           const searchImplem: typeof search = s.scheduleFunction(function search(query, maxResults) {
-            return Promise.resolve(allResults.filter(r => r.includes(query)).slice(0, maxResults));
+            return Promise.resolve(allResults.filter((r) => r.includes(query)).slice(0, maxResults));
           });
 
           // Act
@@ -45,7 +45,7 @@ describe('AutocompleteField', () => {
 
             const autocompletionValue = input.attributes.getNamedItem('value')!.value;
             const suggestions = (screen.queryAllByRole('listitem') as HTMLElement[]).map(getNodeText);
-            if (!suggestions.every(suggestion => suggestion.includes(autocompletionValue))) {
+            if (!suggestions.every((suggestion) => suggestion.includes(autocompletionValue))) {
               throw new Error(
                 `Invalid suggestions for ${JSON.stringify(autocompletionValue)}, got: ${JSON.stringify(suggestions)}`
               );
@@ -65,7 +65,7 @@ describe('AutocompleteField', () => {
           // Arrange
           const query = queries[queries.length - 1];
           const searchImplem: typeof search = s.scheduleFunction(function search(query, maxResults) {
-            return Promise.resolve(allResults.filter(r => r.includes(query)).slice(0, maxResults));
+            return Promise.resolve(allResults.filter((r) => r.includes(query)).slice(0, maxResults));
           });
 
           // Act
@@ -90,13 +90,13 @@ describe('AutocompleteField', () => {
             if (suggestions.length < prevSuggestions.length) {
               const got = JSON.stringify({
                 prevSuggestions,
-                suggestions
+                suggestions,
               });
               throw new Error(`We expect to have more and more suggestions as we resolve queries, got: ${got}`);
             }
           }
           // At the end we expect to get results matching <query>
-          if (!suggestions.every(s => s.startsWith(query))) {
+          if (!suggestions.every((s) => s.startsWith(query))) {
             throw new Error(`Must start with ${JSON.stringify(query)}, got: ${JSON.stringify(suggestions)}`);
           }
         })
@@ -110,7 +110,7 @@ describe('AutocompleteField', () => {
 // Helpers
 
 const AllResultsArbitrary = fc.set(fc.string(), 0, 1000);
-const QueriesArbitrary = fc.array(fc.string(), 1, 10);
+const QueriesArbitrary = fc.array(fc.string(), { minLength: 1 });
 
 /**
  * Generate a sequence of events that have to be fired onto the component

--- a/example/005-race/userProfile/main.spec.tsx
+++ b/example/005-race/userProfile/main.spec.tsx
@@ -32,7 +32,7 @@ describe('UserProfilePage', () => {
           s.scheduleSequence([
             async () => {
               rerender(<UserProfilePage userId={uid2} getUserProfile={getUserProfileImplem} bug={bugId} />);
-            }
+            },
           ]);
           await s.waitAll();
 
@@ -49,7 +49,7 @@ describe('UserProfilePage', () => {
   it('should not display data related to another user (complex)', () =>
     fc.assert(
       fc
-        .asyncProperty(fc.array(fc.uuid(), 1, 10), fc.scheduler(), async (loadedUserIds, s) => {
+        .asyncProperty(fc.array(fc.uuid(), { minLength: 1 }), fc.scheduler(), async (loadedUserIds, s) => {
           // Arrange
           const getUserProfileImplem = s.scheduleFunction(function getUserProfile(userId: string) {
             return Promise.resolve({ id: userId, name: userId });
@@ -61,12 +61,12 @@ describe('UserProfilePage', () => {
             <UserProfilePage userId={currentUid} getUserProfile={getUserProfileImplem} bug={bugId} />
           );
           s.scheduleSequence(
-            loadedUserIds.slice(1).map(uid => ({
+            loadedUserIds.slice(1).map((uid) => ({
               label: `Update user id to ${uid}`,
               builder: async () => {
                 currentUid = uid;
                 rerender(<UserProfilePage userId={uid} getUserProfile={getUserProfileImplem} bug={bugId} />);
-              }
+              },
             }))
           );
 

--- a/perf/tasks.js
+++ b/perf/tasks.js
@@ -10,8 +10,7 @@ exports.runComplexFailure = function (fc) {
           start: fc.nat(1),
           end: fc.nat(100),
         }),
-        1,
-        10
+        { minLength: 1 }
       )
     ),
   });
@@ -19,7 +18,7 @@ exports.runComplexFailure = function (fc) {
   const section = (n) =>
     fc.record({
       heading: loremIpsum,
-      children: fc.array(n > 0 ? fc.oneof(loremIpsum, loremIpsum, loremIpsum, section(n - 1)) : loremIpsum, 10),
+      children: fc.array(n > 0 ? fc.oneof(loremIpsum, loremIpsum, loremIpsum, section(n - 1)) : loremIpsum),
     });
 
   fc.check(

--- a/src/check/arbitrary/ArrayArbitrary.ts
+++ b/src/check/arbitrary/ArrayArbitrary.ts
@@ -188,64 +188,16 @@ export interface ArrayConstraints {
 
 /**
  * For arrays of values coming from `arb`
- * @param arb - Arbitrary used to generate the values inside the array
- * @remarks Since 0.0.1
- * @public
- */
-function array<T>(arb: Arbitrary<T>): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having an upper bound size
  *
  * @param arb - Arbitrary used to generate the values inside the array
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.array(arb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function array<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having lower and upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.array(arb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.7
- * @public
- */
-function array<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having lower and upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints): Arbitrary<T[]>;
-function array<T>(arb: Arbitrary<T>, ...args: [] | [number] | [number, number] | [ArrayConstraints]): Arbitrary<T[]> {
-  // fc.array(arb)
-  if (args[0] === undefined) return new ArrayArbitrary<T>(arb, 0, maxLengthFromMinLength(0));
-  // fc.array(arb, constraints)
-  if (typeof args[0] === 'object') {
-    const minLength = args[0].minLength || 0;
-    const specifiedMaxLength = args[0].maxLength;
-    const maxLength = specifiedMaxLength !== undefined ? specifiedMaxLength : maxLengthFromMinLength(minLength);
-    return new ArrayArbitrary<T>(arb, minLength, maxLength);
-  }
-  // fc.array(arb, minLength, maxLength)
-  if (args[1] !== undefined) return new ArrayArbitrary<T>(arb, args[0], args[1]);
-  // fc.array(arb, maxLength)
-  return new ArrayArbitrary<T>(arb, 0, args[0]);
+function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints = {}): Arbitrary<T[]> {
+  const { minLength = 0, maxLength = maxLengthFromMinLength(minLength) } = constraints;
+  return new ArrayArbitrary<T>(arb, minLength, maxLength);
 }
 
 export { array };

--- a/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/ArrayArbitrary.spec.ts
@@ -8,7 +8,6 @@ import { nat } from '../../../../src/check/arbitrary/IntegerArbitrary';
 import { Random } from '../../../../src/random/generator/Random';
 
 import { isStrictlySmallerArray } from './generic/ArrayHelpers';
-import { generateOneValue } from './generic/GenerateOneValue';
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
 import * as stubRng from '../../stubs/generators';
@@ -107,26 +106,6 @@ describe('ArrayArbitrary', () => {
             g.every((v) => typeof v === 'number'),
         }
       );
-    });
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.array(arb, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxLength) => {
-            const refArbitrary = array(nat(), { maxLength });
-            const nonRecommendedArbitrary = array(nat(), maxLength);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.array(arb, minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = array(nat(), { minLength: minMaxLength.min, maxLength: minMaxLength.max });
-            const nonRecommendedArbitrary = array(nat(), minMaxLength.min, minMaxLength.max);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
     });
   });
 });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.array`.