### PR TITLE
💥 Remove deprecated signatures of `fc.string`

### DIFF
--- a/example/005-race/debounced-autocomplete/main.spec.tsx
+++ b/example/005-race/debounced-autocomplete/main.spec.tsx
@@ -18,7 +18,7 @@ describe('DebouncedAutocomplete', () => {
         .asyncProperty(
           fc.scheduler({ act }),
           fc.set(fc.string()),
-          fc.string(1, 10),
+          fc.string({ minLength: 1 }),
           async (s, allResults, userQuery) => {
             // Arrange
             jest.useFakeTimers();
@@ -56,7 +56,7 @@ describe('DebouncedAutocomplete', () => {
         .asyncProperty(
           fc.scheduler({ act }).map(withTimers),
           fc.set(fc.string()),
-          fc.string(1, 10),
+          fc.string({ minLength: 1 }),
           async (s, allResults, userQuery) => {
             // Arrange
             jest.useFakeTimers();

--- a/example/005-race/todolist/main.spec.tsx
+++ b/example/005-race/todolist/main.spec.tsx
@@ -17,7 +17,7 @@ describe('TodoList', () => {
           fc.scheduler({ act }),
           TodoListCommands,
           fc.set(
-            fc.record({ id: fc.hexaString(8, 8), label: fc.string(), checked: fc.boolean() }),
+            fc.record({ id: fc.hexaString({ minLength: 8, maxLength: 8 }), label: fc.string(), checked: fc.boolean() }),
             (a, b) => a.id === b.id
           ),
           fc.infiniteStream(fc.boolean()),
@@ -30,8 +30,8 @@ describe('TodoList', () => {
 
             // Check the final state (no more items should be loading)
             expect(
-              sortTodos((await listTodos()).map(t => ({ label: t.label, checked: t.checked, loading: t.loading })))
-            ).toEqual(sortTodos(expectedTodos().map(t => ({ label: t.label, checked: t.checked, loading: false }))));
+              sortTodos((await listTodos()).map((t) => ({ label: t.label, checked: t.checked, loading: t.loading })))
+            ).toEqual(sortTodos(expectedTodos().map((t) => ({ label: t.label, checked: t.checked, loading: false }))));
           }
         )
         .beforeEach(async () => {
@@ -43,9 +43,9 @@ describe('TodoList', () => {
 // Helpers
 
 const TodoListCommands = fc.commands([
-  fc.string().map(label => new AddItemCommand(label)),
-  fc.nat().map(pos => new ToggleItemCommand(pos)),
-  fc.nat().map(pos => new RemoveItemCommand(pos))
+  fc.string().map((label) => new AddItemCommand(label)),
+  fc.nat().map((pos) => new ToggleItemCommand(pos)),
+  fc.nat().map((pos) => new RemoveItemCommand(pos)),
 ]);
 
 type ApiTodoItem = { id: string; label: string; checked: boolean };
@@ -71,11 +71,9 @@ const mockApi = (s: fc.Scheduler, initialTodos: ApiTodoItem[], allFailures: fc.S
     | { status: 'error' }
   > {
     const newTodo = {
-      id: `${Math.random()
-        .toString(16)
-        .substring(2)}-${++lastIdx}`,
+      id: `${Math.random().toString(16).substring(2)}-${++lastIdx}`,
       label,
-      checked: false
+      checked: false,
     };
     if (allFailures.next().value) {
       return { status: 'error' };
@@ -93,11 +91,11 @@ const mockApi = (s: fc.Scheduler, initialTodos: ApiTodoItem[], allFailures: fc.S
       }
     | { status: 'error' }
   > {
-    const foundTodo = allTodos.find(t => t.id === id);
+    const foundTodo = allTodos.find((t) => t.id === id);
     if (!foundTodo || allFailures.next().value) {
       return { status: 'error' };
     }
-    allTodos = allTodos.map(t => {
+    allTodos = allTodos.map((t) => {
       if (t.id !== id) return t;
       return { id, label: t.label, checked: !t.checked };
     });
@@ -113,11 +111,11 @@ const mockApi = (s: fc.Scheduler, initialTodos: ApiTodoItem[], allFailures: fc.S
       }
     | { status: 'error' }
   > {
-    const foundTodo = allTodos.find(t => t.id === id);
+    const foundTodo = allTodos.find((t) => t.id === id);
     if (!foundTodo || allFailures.next().value) {
       return { status: 'error' };
     }
-    allTodos = allTodos.filter(t => {
+    allTodos = allTodos.filter((t) => {
       if (t.id !== id) return true;
       return false;
     });
@@ -129,8 +127,8 @@ const mockApi = (s: fc.Scheduler, initialTodos: ApiTodoItem[], allFailures: fc.S
       fetchAllTodos,
       addTodo,
       toggleTodo,
-      removeTodo
+      removeTodo,
     },
-    expectedTodos: () => allTodos.slice()
+    expectedTodos: () => allTodos.slice(),
   };
 };

--- a/src/check/arbitrary/StringArbitrary.ts
+++ b/src/check/arbitrary/StringArbitrary.ts
@@ -21,19 +21,8 @@ export interface StringSharedConstraints {
 }
 
 /** @internal */
-type StringFullConstraintsDefinition = [] | [number] | [number, number] | [StringSharedConstraints];
-
-/** @internal */
-function StringArbitrary(charArb: Arbitrary<string>, ...args: StringFullConstraintsDefinition) {
-  const arrayArb =
-    args[0] !== undefined
-      ? typeof args[0] === 'number'
-        ? typeof args[1] === 'number'
-          ? array(charArb, { minLength: args[0], maxLength: args[1] })
-          : array(charArb, { maxLength: args[0] })
-        : array(charArb, args[0])
-      : array(charArb);
-  return arrayArb.map((tab) => tab.join(''));
+function StringArbitrary(charArb: Arbitrary<string>, constraints: StringSharedConstraints) {
+  return array(charArb, constraints).map((tab) => tab.join(''));
 }
 
 /** @internal */
@@ -63,328 +52,85 @@ function Base64StringArbitrary(unscaledMinLength: number, unscaledMaxLength: num
  * For strings using the characters produced by `charArb`
  *
  * @param charArb - Arbitrary able to generate random strings (possibly multiple characters)
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 1.1.3
  * @public
  */
-function stringOf(charArb: Arbitrary<string>): Arbitrary<string>;
-/**
- * For strings using the characters produced by `charArb`
- *
- * @param charArb - Arbitrary able to generate random strings (possibly multiple characters)
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.stringOf(charArb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.1.3
- * @public
- */
-function stringOf(charArb: Arbitrary<string>, maxLength: number): Arbitrary<string>;
-/**
- * For strings using the characters produced by `charArb`
- *
- * @param charArb - Arbitrary able to generate random strings (possibly multiple characters)
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.stringOf(charArb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.1.3
- * @public
- */
-function stringOf(charArb: Arbitrary<string>, minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings using the characters produced by `charArb`
- *
- * @param charArb - Arbitrary able to generate random strings (possibly multiple characters)
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function stringOf(charArb: Arbitrary<string>, constraints: StringSharedConstraints): Arbitrary<string>;
-function stringOf(charArb: Arbitrary<string>, ...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(charArb, ...args);
+function stringOf(charArb: Arbitrary<string>, constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(charArb, constraints);
 }
 
 /**
  * For strings of {@link char}
- * @remarks Since 0.0.1
- * @public
- */
-function string(): Arbitrary<string>;
-/**
- * For strings of {@link char}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.string({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function string(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link char}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.string({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function string(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link char}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function string(constraints: StringSharedConstraints): Arbitrary<string>;
-function string(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(char(), ...args);
+function string(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(char(), constraints);
 }
 
 /**
  * For strings of {@link ascii}
- * @remarks Since 0.0.1
- * @public
- */
-function asciiString(): Arbitrary<string>;
-/**
- * For strings of {@link ascii}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.asciiString({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function asciiString(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link ascii}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.asciiString({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function asciiString(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link ascii}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function asciiString(constraints: StringSharedConstraints): Arbitrary<string>;
-function asciiString(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(ascii(), ...args);
+function asciiString(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(ascii(), constraints);
 }
 
 /**
  * For strings of {@link char16bits}
- * @remarks Since 0.0.11
- * @public
- */
-function string16bits(): Arbitrary<string>;
-/**
- * For strings of {@link char16bits}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.string16bits({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.11
  * @public
  */
-function string16bits(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link char16bits}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.string16bits({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function string16bits(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link char16bits}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function string16bits(constraints: StringSharedConstraints): Arbitrary<string>;
-function string16bits(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(char16bits(), ...args);
+function string16bits(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(char16bits(), constraints);
 }
 
 /**
  * For strings of {@link unicode}
- * @remarks Since 0.0.11
- * @public
- */
-function unicodeString(): Arbitrary<string>;
-/**
- * For strings of {@link unicode}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.unicodeString({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.11
  * @public
  */
-function unicodeString(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link unicode}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.unicodeString({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function unicodeString(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link unicode}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function unicodeString(constraints: StringSharedConstraints): Arbitrary<string>;
-function unicodeString(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(unicode(), ...args);
+function unicodeString(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(unicode(), constraints);
 }
 
 /**
  * For strings of {@link fullUnicode}
- * @remarks Since 0.0.11
- * @public
- */
-function fullUnicodeString(): Arbitrary<string>;
-/**
- * For strings of {@link fullUnicode}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.fullUnicodeString({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.11
  * @public
  */
-function fullUnicodeString(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link fullUnicode}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.fullUnicodeString({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function fullUnicodeString(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link fullUnicode}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function fullUnicodeString(constraints: StringSharedConstraints): Arbitrary<string>;
-function fullUnicodeString(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(fullUnicode(), ...args);
+function fullUnicodeString(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(fullUnicode(), constraints);
 }
 
 /**
  * For strings of {@link hexa}
- * @remarks Since 0.0.1
- * @public
- */
-function hexaString(): Arbitrary<string>;
-/**
- * For strings of {@link hexa}
  *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.hexaString({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function hexaString(maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link hexa}
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.hexaString({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function hexaString(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For strings of {@link hexa}
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function hexaString(constraints: StringSharedConstraints): Arbitrary<string>;
-function hexaString(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  return StringArbitrary(hexa(), ...args);
+function hexaString(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  return StringArbitrary(hexa(), constraints);
 }
 
 /**
@@ -392,71 +138,14 @@ function hexaString(...args: StringFullConstraintsDefinition): Arbitrary<string>
  *
  * A base64 string will always have a length multiple of 4 (padded with =)
  *
- * @remarks Since 0.0.1
- * @public
- */
-function base64String(): Arbitrary<string>;
-/**
- * For base64 strings
- *
- * A base64 string will always have a length multiple of 4 (padded with =)
- *
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.base64String({maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function base64String(maxLength: number): Arbitrary<string>;
-/**
- * For base64 strings
- *
- * A base64 string will always have a length multiple of 4 (padded with =)
- *
- * @param minLength - Lower bound of the generated string length
- * @param maxLength - Upper bound of the generated string length
- *
- * @deprecated
- * Superceded by `fc.base64String({minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function base64String(minLength: number, maxLength: number): Arbitrary<string>;
-/**
- * For base64 strings
- *
- * A base64 string will always have a length multiple of 4 (padded with =)
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function base64String(constraints: StringSharedConstraints): Arbitrary<string>;
-function base64String(...args: StringFullConstraintsDefinition): Arbitrary<string> {
-  if (args[0] !== undefined) {
-    if (typeof args[0] === 'number') {
-      if (typeof args[1] === 'number') {
-        // base64String(arb, minLength, maxLength)
-        return Base64StringArbitrary(args[0], args[1]);
-      } else {
-        // base64String(arb, maxLength)
-        return Base64StringArbitrary(0, args[0]);
-      }
-    } else {
-      // base64String(arb, constraints)
-      const minLength = args[0].minLength !== undefined ? args[0].minLength : 0;
-      const maxLength = args[0].maxLength !== undefined ? args[0].maxLength : maxLengthFromMinLength(minLength);
-      return Base64StringArbitrary(minLength, maxLength);
-    }
-  }
-  // base64String(arb)
-  return Base64StringArbitrary(0, maxLengthFromMinLength(0));
+function base64String(constraints: StringSharedConstraints = {}): Arbitrary<string> {
+  const { minLength = 0, maxLength = maxLengthFromMinLength(minLength) } = constraints;
+  return Base64StringArbitrary(minLength, maxLength);
 }
 
 export { stringOf, string, asciiString, string16bits, unicodeString, fullUnicodeString, hexaString, base64String };

--- a/test/unit/check/arbitrary/StringArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/StringArbitrary.spec.ts
@@ -11,7 +11,6 @@ import {
   unicodeString,
 } from '../../../../src/check/arbitrary/StringArbitrary';
 
-import { generateOneValue } from './generic/GenerateOneValue';
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
 import * as stubRng from '../../stubs/generators';

--- a/test/unit/check/arbitrary/StringArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/StringArbitrary.spec.ts
@@ -73,29 +73,6 @@ describe('StringArbitrary', () => {
         }
       );
     });
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.stringOf(charArb, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxLength) => {
-            const refArbitrary = stringOf(constantFrom('a', 'b'), { maxLength });
-            const nonRecommendedArbitrary = stringOf(constantFrom('a', 'b'), maxLength);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.stringOf(charArb, minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = stringOf(constantFrom('a', 'b'), {
-              minLength: minMaxLength.min,
-              maxLength: minMaxLength.max,
-            });
-            const nonRecommendedArbitrary = stringOf(constantFrom('a', 'b'), minMaxLength.min, minMaxLength.max);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-    });
   });
   describe('string', () => {
     it('Should generate printable characters', () =>
@@ -122,26 +99,6 @@ describe('StringArbitrary', () => {
           return lengths.min <= g.length && g.length <= lengths.max;
         })
       ));
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.string(maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxLength) => {
-            const refArbitrary = string({ maxLength });
-            const nonRecommendedArbitrary = string(maxLength);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.string(minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = string({ minLength: minMaxLength.min, maxLength: minMaxLength.max });
-            const nonRecommendedArbitrary = string(minMaxLength.min, minMaxLength.max);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-    });
   });
   describe('asciiString', () => {
     it('Should generate ascii string', () =>
@@ -325,25 +282,5 @@ describe('StringArbitrary', () => {
             .every((s) => s.value.length % 4 === 0 && isValidBase64(s.value) && hasValidBase64Padding(s.value));
         })
       ));
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.base64String(maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(25), (seed, maxLength) => {
-            const refArbitrary = base64String({ maxLength: maxLength * 4 });
-            const nonRecommendedArbitrary = base64String(maxLength * 4);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.base64String(minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = base64String({ minLength: minMaxLength.min * 4, maxLength: minMaxLength.max * 4 });
-            const nonRecommendedArbitrary = base64String(minMaxLength.min * 4, minMaxLength.max * 4);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-    });
   });
 });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.*string*`.