### PR TITLE
💥 Remove deprecated signatures of `fc.*subarray`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2391,7 +2391,6 @@ fc.set(fc.hexaString(), {minLength: 5, maxLength: 10, compare: (s1, s2) => s1.le
 
 - `fc.subarray(originalArray)`
 - `fc.subarray(originalArray, {minLength?, maxLength?})`
-- _`fc.subarray(originalArray, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -2429,7 +2428,6 @@ fc.subarray([1, 42, 48, 69, 75, 92], {minLength: 2, maxLength: 3})
 
 - `fc.shuffledSubarray(originalArray)`
 - `fc.shuffledSubarray(originalArray, {minLength?, maxLength?})`
-- _`fc.shuffledSubarray(originalArray, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/check/arbitrary/SubarrayArbitrary.ts
+++ b/src/check/arbitrary/SubarrayArbitrary.ts
@@ -114,43 +114,13 @@ export interface SubarrayConstraints {
  * For subarrays of `originalArray` (keeps ordering)
  *
  * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 1.5.0
  * @public
  */
-function subarray<T>(originalArray: T[]): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray` (keeps ordering)
- *
- * @param originalArray - Original array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.subarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-function subarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray` (keeps ordering)
- *
- * @param originalArray - Original array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function subarray<T>(originalArray: T[], constraints: SubarrayConstraints): Arbitrary<T[]>;
-function subarray<T>(originalArray: T[], ...args: [] | [number, number] | [SubarrayConstraints]): Arbitrary<T[]> {
-  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
-    return new SubarrayArbitrary(originalArray, true, args[0], args[1]);
-  }
-  const ct = args[0] as SubarrayConstraints | undefined;
-  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
-  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+function subarray<T>(originalArray: T[], constraints: SubarrayConstraints = {}): Arbitrary<T[]> {
+  const { minLength = 0, maxLength = originalArray.length } = constraints;
   return new SubarrayArbitrary(originalArray, true, minLength, maxLength);
 }
 
@@ -158,46 +128,13 @@ function subarray<T>(originalArray: T[], ...args: [] | [number, number] | [Subar
  * For subarrays of `originalArray`
  *
  * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 1.5.0
  * @public
  */
-function shuffledSubarray<T>(originalArray: T[]): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray`
- *
- * @param originalArray - Original array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.shuffledSubarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-function shuffledSubarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray`
- *
- * @param originalArray - Original array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function shuffledSubarray<T>(originalArray: T[], constraints: SubarrayConstraints): Arbitrary<T[]>;
-function shuffledSubarray<T>(
-  originalArray: T[],
-  ...args: [] | [number, number] | [SubarrayConstraints]
-): Arbitrary<T[]> {
-  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
-    return new SubarrayArbitrary(originalArray, false, args[0], args[1]);
-  }
-  const ct = args[0] as SubarrayConstraints | undefined;
-  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
-  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+function shuffledSubarray<T>(originalArray: T[], constraints: SubarrayConstraints = {}): Arbitrary<T[]> {
+  const { minLength = 0, maxLength = originalArray.length } = constraints;
   return new SubarrayArbitrary(originalArray, false, minLength, maxLength);
 }
 

--- a/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
@@ -151,27 +151,6 @@ describe('SubarrayArbitrary', () => {
         }
       );
     });
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.subarray(originalArray, minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(
-            fc.integer(),
-            fc.array(fc.nat(), { minLength: 1 }),
-            fc.nat(),
-            fc.nat(),
-            (seed, originalArray, aLength, bLength) => {
-              const aLengthMod = aLength % originalArray.length;
-              const bLengthMod = bLength % originalArray.length;
-              const minLength = Math.min(aLengthMod, bLengthMod);
-              const maxLength = Math.max(aLengthMod, bLengthMod);
-              const refArbitrary = subarray(originalArray, { minLength, maxLength });
-              const nonRecommendedArbitrary = subarray(originalArray, minLength, maxLength);
-              expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-            }
-          )
-        );
-      });
-    });
   });
   describe('shuffledSubarray', () => {
     describe('Given no length constraints', () => {
@@ -200,28 +179,6 @@ describe('SubarrayArbitrary', () => {
           },
         }
       );
-    });
-
-    describe('Still support non recommended signatures', () => {
-      it('Should support fc.shuffledSubarray(originalArray, minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(
-            fc.integer(),
-            fc.array(fc.nat(), { minLength: 1 }),
-            fc.nat(),
-            fc.nat(),
-            (seed, originalArray, aLength, bLength) => {
-              const aLengthMod = aLength % originalArray.length;
-              const bLengthMod = bLength % originalArray.length;
-              const minLength = Math.min(aLengthMod, bLengthMod);
-              const maxLength = Math.max(aLengthMod, bLengthMod);
-              const refArbitrary = shuffledSubarray(originalArray, { minLength, maxLength });
-              const nonRecommendedArbitrary = shuffledSubarray(originalArray, minLength, maxLength);
-              expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-            }
-          )
-        );
-      });
     });
   });
 });

--- a/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/SubarrayArbitrary.spec.ts
@@ -2,7 +2,6 @@ import * as fc from '../../../../lib/fast-check';
 
 import { subarray, shuffledSubarray } from '../../../../src/check/arbitrary/SubarrayArbitrary';
 
-import { generateOneValue } from './generic/GenerateOneValue';
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
 const isOrderedSubarray = (originalArray: number[], subarray: number[]): boolean => {


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.*subarray`.