### PR TITLE
💥 Remove deprecated signatures of `fc.set`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2337,11 +2337,6 @@ fc.array(fc.nat(), {minLength: 5, maxLength: 7})
 
 - `fc.set(arb)`
 - `fc.set(arb, {minLength?, maxLength?, compare?})`
-- _`fc.set(arb, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.set(arb, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.set(arb, compare)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.set(arb, maxLength, compare)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.set(arb, minLength, maxLength, compare)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/example/005-race/autocomplete/main.spec.tsx
+++ b/example/005-race/autocomplete/main.spec.tsx
@@ -109,7 +109,7 @@ describe('AutocompleteField', () => {
 
 // Helpers
 
-const AllResultsArbitrary = fc.set(fc.string(), 0, 1000);
+const AllResultsArbitrary = fc.set(fc.string(), { maxLength: 1000 });
 const QueriesArbitrary = fc.array(fc.string(), { minLength: 1 });
 
 /**

--- a/example/005-race/todolist/main.spec.tsx
+++ b/example/005-race/todolist/main.spec.tsx
@@ -18,7 +18,7 @@ describe('TodoList', () => {
           TodoListCommands,
           fc.set(
             fc.record({ id: fc.hexaString({ minLength: 8, maxLength: 8 }), label: fc.string(), checked: fc.boolean() }),
-            (a, b) => a.id === b.id
+            { compare: (a, b) => a.id === b.id }
           ),
           fc.infiniteStream(fc.boolean()),
           async (s, commands, initialTodos, allFailures) => {

--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -245,7 +245,8 @@ const anythingInternal = (constraints: QualifiedObjectConstraints): Arbitrary<un
   const baseArb = oneof(...arbitrariesForBase);
   const arrayBaseArb = oneof(...arbitrariesForBase.map((arb) => array(arb, { maxLength: maxKeys })));
   const objectBaseArb = (n: number) => oneof(...arbitrariesForBase.map((arb) => dictOf(arbKeys(n), arb)));
-  const setBaseArb = () => oneof(...arbitrariesForBase.map((arb) => set(arb, 0, maxKeys).map((v) => new Set(v))));
+  const setBaseArb = () =>
+    oneof(...arbitrariesForBase.map((arb) => set(arb, { maxLength: maxKeys }).map((v) => new Set(v))));
   const mapBaseArb = (n: number) => oneof(...arbitrariesForBase.map((arb) => mapOf(arbKeys(n), arb)));
 
   // base[] | anything[]
@@ -257,7 +258,7 @@ const anythingInternal = (constraints: QualifiedObjectConstraints): Arbitrary<un
       setBaseArb(),
 
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      set(anythingArb(n), 0, maxKeys).map((v) => new Set(v))
+      set(anythingArb(n), { maxLength: maxKeys }).map((v) => new Set(v))
     )
   );
   // Map<key, base> | (Map<key, anything> | Map<anything, anything>)

--- a/src/check/arbitrary/SetArbitrary.ts
+++ b/src/check/arbitrary/SetArbitrary.ts
@@ -2,53 +2,6 @@ import { ArrayArbitrary, maxLengthFromMinLength } from './ArrayArbitrary';
 import { Arbitrary } from './definition/Arbitrary';
 
 /**
- * Build fully set SetConstraints from a partial data
- * @internal
- */
-function buildCompleteSetConstraints<T>(constraints: SetConstraints<T>): Required<SetConstraints<T>> {
-  const minLength = constraints.minLength !== undefined ? constraints.minLength : 0;
-  const maxLength = constraints.maxLength !== undefined ? constraints.maxLength : maxLengthFromMinLength(minLength);
-  const compare = constraints.compare !== undefined ? constraints.compare : (a: T, b: T) => a === b;
-  return { minLength, maxLength, compare };
-}
-
-/**
- * Extract constraints from args received by set
- * @internal
- */
-function extractSetConstraints<T>(
-  args:
-    | []
-    | [number]
-    | [number, number]
-    | [(a: T, b: T) => boolean]
-    | [number, (a: T, b: T) => boolean]
-    | [number, number, (a: T, b: T) => boolean]
-    | [SetConstraints<T>]
-): SetConstraints<T> {
-  if (args[0] === undefined) {
-    // set(arb)
-    return {};
-  } // args.length > 0
-
-  if (args[1] === undefined) {
-    const sargs = args as typeof args & [unknown]; // exactly 1 arg specified
-    if (typeof sargs[0] === 'number') return { maxLength: sargs[0] }; // set(arb, maxLength)
-    if (typeof sargs[0] === 'function') return { compare: sargs[0] }; // set(arb, compare)
-    return sargs[0]; // set(arb, constraints)
-  } // args.length > 1
-
-  if (args[2] === undefined) {
-    const sargs = args as typeof args & [unknown, unknown]; // exactly 2 args specified
-    if (typeof sargs[1] === 'number') return { minLength: sargs[0], maxLength: sargs[1] }; // set(arb, minLength, maxLength)
-    return { maxLength: sargs[0], compare: sargs[1] }; // set(arb, maxLength, compare)
-  } // args.length > 2
-
-  const sargs = args as typeof args & [unknown, unknown, unknown];
-  return { minLength: sargs[0], maxLength: sargs[1], compare: sargs[2] }; // set(arb, minLength, maxLength, compare)
-}
-
-/**
  * Constraints to be applied on {@link set}
  * @remarks Since 2.4.0
  * @public
@@ -75,117 +28,17 @@ export interface SetConstraints<T> {
  * For arrays of unique values coming from `arb`
  *
  * @param arb - Arbitrary used to generate the values inside the array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 0.0.11
  * @public
  */
-function set<T>(arb: Arbitrary<T>): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb` having an upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.set(arb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function set<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb` having lower and upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.set(arb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function set<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb` - unicity defined by `compare`
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param compare - Return true when the two values are equals
- *
- * @deprecated
- * Superceded by `fc.set(arb, {compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function set<T>(arb: Arbitrary<T>, compare: (a: T, b: T) => boolean): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb` having an upper bound size - unicity defined by `compare`
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param maxLength - Upper bound of the generated array size
- * @param compare - Return true when the two values are equals
- *
- * @deprecated
- * Superceded by `fc.array(arb, {maxLength, compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function set<T>(arb: Arbitrary<T>, maxLength: number, compare: (a: T, b: T) => boolean): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb` having lower and upper bound size - unicity defined by `compare`
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- * @param compare - Return true when the two values are equals
- *
- * @deprecated
- * Superceded by `fc.array(arb, {minLength, maxLength, compare})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.11
- * @public
- */
-function set<T>(
-  arb: Arbitrary<T>,
-  minLength: number,
-  maxLength: number,
-  compare: (a: T, b: T) => boolean
-): Arbitrary<T[]>;
-/**
- * For arrays of unique values coming from `arb`
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function set<T>(arb: Arbitrary<T>, constraints: SetConstraints<T>): Arbitrary<T[]>;
-function set<T>(
-  arb: Arbitrary<T>,
-  ...args:
-    | []
-    | [number]
-    | [number, number]
-    | [(a: T, b: T) => boolean]
-    | [number, (a: T, b: T) => boolean]
-    | [number, number, (a: T, b: T) => boolean]
-    | [SetConstraints<T>]
-): Arbitrary<T[]> {
-  const constraints = buildCompleteSetConstraints(extractSetConstraints(args));
-
-  const minLength = constraints.minLength;
-  const maxLength = constraints.maxLength;
-  const compare = constraints.compare;
-
+function set<T>(arb: Arbitrary<T>, constraints: SetConstraints<T> = {}): Arbitrary<T[]> {
+  const {
+    minLength = 0,
+    maxLength = maxLengthFromMinLength(minLength),
+    compare = (a: T, b: T) => a === b,
+  } = constraints;
   const arrayArb = new ArrayArbitrary<T>(arb, minLength, maxLength, compare);
   if (minLength === 0) return arrayArb;
   return arrayArb.filter((tab) => tab.length >= minLength);

--- a/test/unit/check/arbitrary/SetArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/SetArbitrary.spec.ts
@@ -2,9 +2,7 @@ import * as fc from '../../../../lib/fast-check';
 
 import { set } from '../../../../src/check/arbitrary/SetArbitrary';
 import { nat } from '../../../../src/check/arbitrary/IntegerArbitrary';
-import { string } from '../../../../src/check/arbitrary/StringArbitrary';
 
-import { generateOneValue } from './generic/GenerateOneValue';
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
 const customMapper = (v: number) => {
@@ -71,56 +69,6 @@ describe('SetArbitrary', () => {
             validSet(g) && g.length >= constraints.min && g.length <= constraints.max,
         }
       );
-    });
-    describe('Still support non recommended signatures', () => {
-      const compare = (a: string, b: string) => {
-        return a.split('').sort().join('') === b.split('').sort().join('');
-      };
-      it('Should support fc.set(arb, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxLength) => {
-            const refArbitrary = set(nat(), { maxLength });
-            const nonRecommendedArbitrary = set(nat(), maxLength);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.set(arb, compare)', () => {
-        fc.assert(
-          fc.property(fc.integer(), (seed) => {
-            const refArbitrary = set(string(), { compare });
-            const nonRecommendedArbitrary = set(string(), compare);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.set(arb, maxLength, compare)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxLength) => {
-            const refArbitrary = set(string(), { maxLength, compare });
-            const nonRecommendedArbitrary = set(string(), maxLength, compare);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.set(arb, minLength, maxLength)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = set(nat(), { minLength: minMaxLength.min, maxLength: minMaxLength.max });
-            const nonRecommendedArbitrary = set(nat(), minMaxLength.min, minMaxLength.max);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
-      it('Should support fc.set(arb, minLength, maxLength, compare)', () => {
-        fc.assert(
-          fc.property(fc.integer(), genericHelper.minMax(fc.nat(100)), (seed, minMaxLength) => {
-            const refArbitrary = set(string(), { minLength: minMaxLength.min, maxLength: minMaxLength.max, compare });
-            const nonRecommendedArbitrary = set(string(), minMaxLength.min, minMaxLength.max, compare);
-            expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
     });
   });
 });

--- a/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
@@ -105,7 +105,7 @@ describe('SparseArrayArbitrary', () => {
             expect(nat).toHaveBeenCalledTimes(1);
             expect(set).toHaveBeenCalledTimes(1);
             const maxRequestedIndexes = nat.mock.calls[0][0] as number;
-            const maxRequestedLength = set.mock.calls[0][1].maxLength!;
+            const maxRequestedLength = set.mock.calls[0][1]!.maxLength!;
             if (ct !== undefined && ct.noTrailingHole) {
               // maxRequestedIndexes is the maximal index we may have for the current instance (+1 is the length)
               // maxRequestedLength is the maximal number of elements we ask to the set


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.set`.