### PR TITLE
💥 Remove deprecated signatures of `fc.commands`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -3333,8 +3333,7 @@ fc.context()
 *&#8195;Signatures*
 
 - `fc.commands(commandArbs)`
-- `fc.commands(commandArbs, { disableReplayLog?, maxCommands?, replayPath? })`
-- _`fc.commands(commandArbs, maxCommands)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
+- `fc.commands(commandArbs, {disableReplayLog?, maxCommands?, replayPath?})`
 
 *&#8195;with:*
 

--- a/documentation/Tips.md
+++ b/documentation/Tips.md
@@ -194,7 +194,7 @@ const allCommands = [
 ];
 // run everything
 fc.assert(
-  fc.property(fc.commands(allCommands, 100), cmds => {
+  fc.property(fc.commands(allCommands, {maxCommands: 100}), cmds => {
     const s = () => ({ model: { num: 0 }, real: new List() });
     fc.modelRun(s, cmds);
   })

--- a/src/check/model/commands/CommandsArbitrary.ts
+++ b/src/check/model/commands/CommandsArbitrary.ts
@@ -149,51 +149,9 @@ class CommandsArbitrary<Model extends object, Real, RunResult, CheckAsync extend
  * It should shrink more efficiently than {@link array} for {@link AsyncCommand} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param maxCommands - Maximal number of commands to build
- *
- * @deprecated
- * Superceded by `fc.commands(commandArbs, {maxCommands})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Contraints to be applied when generating the commands (since 1.11.0)
  *
  * @remarks Since 1.5.0
- * @public
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function commands<Model extends object, Real, CheckAsync extends boolean>(
-  commandArbs: Arbitrary<AsyncCommand<Model, Real, CheckAsync>>[],
-  maxCommands?: number
-): Arbitrary<Iterable<AsyncCommand<Model, Real, CheckAsync>>>;
-/**
- * For arrays of {@link Command} to be executed by {@link modelRun}
- *
- * This implementation comes with a shrinker adapted for commands.
- * It should shrink more efficiently than {@link array} for {@link Command} arrays.
- *
- * @param commandArbs - Arbitraries responsible to build commands
- * @param maxCommands - Maximal number of commands to build
- *
- * @deprecated
- * Superceded by `fc.commands(commandArbs, {maxCommands})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function commands<Model extends object, Real>(
-  commandArbs: Arbitrary<Command<Model, Real>>[],
-  maxCommands?: number
-): Arbitrary<Iterable<Command<Model, Real>>>;
-/**
- * For arrays of {@link AsyncCommand} to be executed by {@link asyncModelRun}
- *
- * This implementation comes with a shrinker adapted for commands.
- * It should shrink more efficiently than {@link array} for {@link AsyncCommand} arrays.
- *
- * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Contraints to be applied when generating the commands
- *
- * @remarks Since 1.11.0
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -208,9 +166,9 @@ function commands<Model extends object, Real, CheckAsync extends boolean>(
  * It should shrink more efficiently than {@link array} for {@link Command} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Constraints to be applied when generating the commands
+ * @param constraints - Constraints to be applied when generating the commands (since 1.11.0
  *
- * @remarks Since 1.11.0
+ * @remarks Since 1.5.0
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -221,16 +179,10 @@ function commands<Model extends object, Real>(
 // eslint-disable-next-line @typescript-eslint/ban-types
 function commands<Model extends object, Real, RunResult, CheckAsync extends boolean>(
   commandArbs: Arbitrary<ICommand<Model, Real, RunResult, CheckAsync>>[],
-  constraints?: number | CommandsContraints
+  constraints: CommandsContraints = {}
 ): Arbitrary<Iterable<ICommand<Model, Real, RunResult, CheckAsync>>> {
-  const config =
-    constraints == null ? {} : typeof constraints === 'number' ? { maxCommands: constraints } : constraints;
-  return new CommandsArbitrary(
-    commandArbs,
-    config.maxCommands != null ? config.maxCommands : 10,
-    config.replayPath != null ? config.replayPath : null,
-    !!config.disableReplayLog
-  );
+  const { maxCommands = 10, replayPath = null, disableReplayLog = false } = constraints;
+  return new CommandsArbitrary(commandArbs, maxCommands, replayPath, disableReplayLog);
 }
 
 export { commands };


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.commands`.