### PR TITLE
💥 Remove deprecated signatures of `fc.option`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2036,7 +2036,6 @@ fc.clonedConstant(buildCloneable({ keyA: 1, keyB: 2 }))
 
 - `fc.option(arb)`
 - `fc.option(arb, {freq?, nil?})`
-- _`fc.option(arb, freq)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/check/arbitrary/OptionArbitrary.ts
+++ b/src/check/arbitrary/OptionArbitrary.ts
@@ -50,47 +50,17 @@ class OptionArbitrary<T, TNil> extends Arbitrary<T | TNil> {
 }
 
 /**
- * For either null or a value coming from `arb`
- *
- * @param arb - Arbitrary that will be called to generate a non null value
- *
- * @remarks Since 0.0.6
- * @public
- */
-function option<T>(arb: Arbitrary<T>): Arbitrary<T | null>;
-/**
- * For either null or a value coming from `arb` with custom frequency
- *
- * @param arb - Arbitrary that will be called to generate a non null value
- * @param freq - The probability to build a null value is of `1 / freq`
- *
- * @deprecated
- * Superceded by `fc.option(arb, {freq})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.6
- * @public
- */
-function option<T>(arb: Arbitrary<T>, freq: number): Arbitrary<T | null>;
-/**
  * For either nil or a value coming from `arb` with custom frequency
  *
  * @param arb - Arbitrary that will be called to generate a non nil value
- * @param constraints - Constraints on the option
+ * @param constraints - Constraints on the option (since 1.17.0)
  *
- * @remarks Since 1.17.0
+ * @remarks Since 0.0.6
  * @public
  */
-function option<T, TNil = null>(arb: Arbitrary<T>, constraints: OptionConstraints<TNil>): Arbitrary<T | TNil>;
-function option<T, TNil>(arb: Arbitrary<T>, constraints?: number | OptionConstraints<TNil>): Arbitrary<T | TNil> {
-  if (!constraints) return new OptionArbitrary(arb, 5, null as any);
-  if (typeof constraints === 'number') return new OptionArbitrary(arb, constraints, null as any);
-
-  return new OptionArbitrary(
-    arb,
-    constraints.freq == null ? 5 : constraints.freq,
-    Object.prototype.hasOwnProperty.call(constraints, 'nil') ? constraints.nil : (null as any)
-  );
+function option<T, TNil = null>(arb: Arbitrary<T>, constraints: OptionConstraints<TNil> = {}): Arbitrary<T | TNil> {
+  const { freq = 5, nil = null } = constraints;
+  return new OptionArbitrary(arb, freq, nil as TNil);
 }
 
 export { option };

--- a/src/check/arbitrary/OptionArbitrary.ts
+++ b/src/check/arbitrary/OptionArbitrary.ts
@@ -59,8 +59,10 @@ class OptionArbitrary<T, TNil> extends Arbitrary<T | TNil> {
  * @public
  */
 function option<T, TNil = null>(arb: Arbitrary<T>, constraints: OptionConstraints<TNil> = {}): Arbitrary<T | TNil> {
-  const { freq = 5, nil = null } = constraints;
-  return new OptionArbitrary(arb, freq, nil as TNil);
+  const { freq = 5 } = constraints;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const nil: TNil = 'nil' in constraints ? constraints.nil! : null!;
+  return new OptionArbitrary(arb, freq, nil);
 }
 
 export { option };


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.option`.