### PR TITLE
💥 Remove deprecated signatures of `fc.integer`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -91,7 +91,6 @@ fc.boolean()
 - `fc.integer()`
 - `fc.integer({min?, max?})`
 - `fc.integer(min, max)`
-- _`fc.integer(max)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -104,10 +104,6 @@ fc.integer()
 // Note: All possible integers between `-2147483648` (included) and `2147483647` (included)
 // Examples of generated values: 1502944448, 888414599, 1123740386, -440217435, 19…
 
-fc.integer(1000)
-// Note: All possible integers between `-2147483648` (included) and `1000` (included)
-// Examples of generated values: -1057705109, -8, -1089721660, -1878447823, -741474720…
-
 fc.integer(-99, 99)
 // Note: All possible integers between `-99` (included) and `99` (included)
 // Examples of generated values: 6, -1, -96, 91, 5…

--- a/src/check/arbitrary/IntegerArbitrary.ts
+++ b/src/check/arbitrary/IntegerArbitrary.ts
@@ -137,7 +137,7 @@ function buildCompleteIntegerConstraints(constraints: IntegerConstraints): Requi
  * Extract constraints from args received by integer
  * @internal
  */
-function extractIntegerConstraints(args: [] | [number] | [number, number] | [IntegerConstraints]): IntegerConstraints {
+function extractIntegerConstraints(args: [] | [number, number] | [IntegerConstraints]): IntegerConstraints {
   if (args[0] === undefined) {
     // integer()
     return {};
@@ -145,7 +145,6 @@ function extractIntegerConstraints(args: [] | [number] | [number, number] | [Int
 
   if (args[1] === undefined) {
     const sargs = args as typeof args & [unknown]; // exactly 1 arg specified
-    if (typeof sargs[0] === 'number') return { max: sargs[0] }; // integer(max)
     return sargs[0]; // integer(constraints)
   } // args.length > 1
 
@@ -159,19 +158,6 @@ function extractIntegerConstraints(args: [] | [number] | [number, number] | [Int
  * @public
  */
 function integer(): ArbitraryWithContextualShrink<number>;
-/**
- * For integers between -2147483648 (included) and max (included)
- *
- * @param max - Upper bound for the generated integers (eg.: 2147483647, Number.MAX_SAFE_INTEGER)
- *
- * @deprecated
- * Superceded by `fc.integer({max})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.1
- * @public
- */
-function integer(max: number): ArbitraryWithContextualShrink<number>;
 /**
  * For integers between min (included) and max (included)
  *
@@ -192,9 +178,7 @@ function integer(min: number, max: number): ArbitraryWithContextualShrink<number
  * @public
  */
 function integer(constraints: IntegerConstraints): ArbitraryWithContextualShrink<number>;
-function integer(
-  ...args: [] | [number] | [number, number] | [IntegerConstraints]
-): ArbitraryWithContextualShrink<number> {
+function integer(...args: [] | [number, number] | [IntegerConstraints]): ArbitraryWithContextualShrink<number> {
   const constraints = buildCompleteIntegerConstraints(extractIntegerConstraints(args));
   if (constraints.min > constraints.max) {
     throw new Error('fc.integer maximum value should be equal or greater than the minimum one');

--- a/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/IntegerArbitrary.spec.ts
@@ -147,10 +147,10 @@ describe('IntegerArbitrary', () => {
       });
     });
     describe('Given maximal value only [between -2**31 and max]', () => {
-      genericHelper.isValidArbitrary((maxValue: number) => integer(maxValue), {
+      genericHelper.isValidArbitrary((max: number) => integer({ max }), {
         seedGenerator: fc.integer(),
         isStrictlySmallerValue: isStrictlySmallerInteger,
-        isValidValue: (g: number, maxValue: number) => typeof g === 'number' && -0x80000000 <= g && g <= maxValue,
+        isValidValue: (g: number, max: number) => typeof g === 'number' && -0x80000000 <= g && g <= max,
       });
     });
     describe('Given minimal and maximal values [between min and max]', () => {
@@ -168,15 +168,6 @@ describe('IntegerArbitrary', () => {
       );
     });
     describe('Still support older signatures', () => {
-      it('Should support fc.integer(max)', () => {
-        fc.assert(
-          fc.property(fc.integer(), fc.integer(), (seed, max) => {
-            const refArbitrary = integer({ max });
-            const otherArbitrary = integer(max);
-            expect(generateOneValue(seed, otherArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
-          })
-        );
-      });
       it('Should support fc.integer(min, max)', () => {
         fc.assert(
           fc.property(fc.integer(), genericHelper.minMax(fc.integer()), (seed, constraints) => {


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492 
Follow-up of #992

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *remove deprecated*

(✔️: yes, ❌: no)

## Potential impacts

Remove deprecated signatures of `fc.integer`.