### PR TITLE
💥 Drop support for TypeScript 3.2 (min ≥4.0)

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -196,11 +196,8 @@ jobs:
         ts-version:
           # Latest version of TypeScript
           - '*'
-          # Various intermediate versions of Typescript
-          - '3.9'
-          - '3.4'
           # Minimal requirement for TypeScript
-          - '3.2'
+          - '4.0'
     steps:
       - uses: actions/checkout@v2
       - name: Using Node v14.x
@@ -215,16 +212,6 @@ jobs:
         uses: ./.github/actions/install-deps-with-current-fc
         with:
           path: 'test/type'
-      - name: Adapt test/type/for TypeScript 3.4
-        if: matrix.ts-version == '3.2' || matrix.ts-version == '3.4'
-        run: |
-          cd test/type
-          sed -i 's/ts-expect-error/ts-ignore/g' *.ts
-      - name: Adapt test/type/for TypeScript 3.2
-        if: matrix.ts-version == '3.2'
-        run: |
-          cd test/type
-          sed -i 's/fc-require-ts-3.4/ts-ignore/g' *.ts
       - name: Test test/type/
         run: |
           cd test/type

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here are the minimal requirements to use fast-check properly without any polyfil
 
 | fast-check | node                | ECMAScript version | _TypeScript (optional)_ |
 |------------|---------------------|--------------------|-------------------------|
+| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.0                    |
 | **2.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥3.2                    |
 | **1.x**    | ≥0.12<sup>(1)</sup> | ES3                | ≥3.0                    |
 

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -128,18 +128,18 @@ expectType<fc.Arbitrary<number>>()(
   fc.constantFrom(1, 2),
   'By default, "constantFrom" simplifies the type (eg.: "1 -> number")'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<1 | 2>>()(fc.constantFrom(...([1, 2] as const)), '"as const" prevent extra simplification of "constantFrom"');
-// prettier-ignore-end
+expectType<fc.Arbitrary<1 | 2>>()(
+  fc.constantFrom(...([1, 2] as const)),
+  '"as const" prevent extra simplification of "constantFrom"'
+);
 expectType<fc.Arbitrary<number | string>>()(
   fc.constantFrom(1, 2, 'hello'),
   '"constantFrom" accepts arguments not having the same types without any typing trick'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<1 | 2 | 'hello'>>()(fc.constantFrom(...([1, 2, 'hello'] as const)), '"as const" prevent extra simplification of "constantFrom"');
-// prettier-ignore-end
+expectType<fc.Arbitrary<1 | 2 | 'hello'>>()(
+  fc.constantFrom(...([1, 2, 'hello'] as const)),
+  '"as const" prevent extra simplification of "constantFrom"'
+);
 
 // record arbitrary
 const mySymbol1 = Symbol('symbol1');
@@ -212,16 +212,12 @@ expectType<fc.Arbitrary<never>>()(
 type Query = { data: { field: 'X' } };
 expectType<fc.Arbitrary<Query>>()(
   // issue 1453
-  // @fc-require-ts-3.4
   fc.record<Query>({ data: fc.record({ field: fc.constant('X') }) }),
-  // @fc-require-ts-3.4
   '"record" can be passed the requested type in <*>'
 );
 expectType<fc.Arbitrary<Partial<Query>>>()(
   // issue 1453
-  // @fc-require-ts-3.4
   fc.record<Partial<Query>>({ data: fc.record({ field: fc.constant('X') }) }),
-  // @fc-require-ts-3.4
   '"record" can be passed something assignable to the requested type in <*>'
 );
 // @ts-expect-error - requiredKeys references an unknown key
@@ -270,10 +266,10 @@ expectType<fc.Arbitrary<number | null>>()(
   fc.option(fc.nat(), { nil: null }),
   '"option" with nil overriden to null (the original default)'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<number | 'custom_default'>>()(fc.option(fc.nat(), { nil: 'custom_default' as const }), '"option" with nil overriden to custom value');
-// prettier-ignore-end
+expectType<fc.Arbitrary<number | 'custom_default'>>()(
+  fc.option(fc.nat(), { nil: 'custom_default' as const }),
+  '"option" with nil overriden to custom value'
+);
 // @ts-expect-error - option expects arbitraries not raw values
 fc.option(1);
 


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492

Officially dropping support for TypeScript 3.2.
The new minimal requirement will be 4.0.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *doc*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact
