### PR TITLE
💥 Drop support for TypeScript 4.0 (min ≥4.1)

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -191,7 +191,7 @@ jobs:
           # Latest version of TypeScript
           - '*'
           # Minimal requirement for TypeScript
-          - '4.0'
+          - '4.1'
     steps:
       - uses: actions/checkout@v2
       - name: Using Node v14.x

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Here are the minimal requirements to use fast-check properly without any polyfil
 
 | fast-check | node                | ECMAScript version | _TypeScript (optional)_ |
 |------------|---------------------|--------------------|-------------------------|
-| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.0                    |
+| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.1                    |
 | **2.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥3.2                    |
 | **1.x**    | ≥0.12<sup>(1)</sup> | ES3                | ≥3.0                    |
 


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Related to #1492
Required for #1519

The new minimal requirement will be 4.1.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *doc*

(✔️: yes, ❌: no)

## Potential impacts

Typings impact
