### PR TITLE
📝 Do not package with comments (except d.ts)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "noFallthroughCasesInSwitch": true,
         "noUnusedLocals": true,
         "preserveConstEnums": true,
-        "removeComments": false,
+        "removeComments": true,
         "sourceMap": true,
         "strict": true,
         "stripInternal": true,


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

It seems that VSCode uses the JSDoc coming with d.ts file. Same for WebStorm.

As a consequence it does not make really sense to package fast-check with all those jsdoc comments again and again in JS files if they are never read.

❌ New feature
❌ Fix an issue
✔️ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Documentation
