### PR TITLE
👷 Relax check ensuring default seed defined in CI

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Unit tests
         shell: bash -l {0}
         run: |
+            export EXPECT_DEFAULT_SEED="true"
             export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
             echo "DEFAULT_SEED is: ${DEFAULT_SEED}"
             yarn test
@@ -95,6 +96,7 @@ jobs:
       - name: End-to-end tests
         shell: bash -l {0}
         run: |
+            export EXPECT_DEFAULT_SEED="true"
             export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
             echo "DEFAULT_SEED is: ${DEFAULT_SEED}"
             yarn e2e

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,6 +8,6 @@ jest.setTimeout(120000);
 const defaultSeedRaw = process.env.DEFAULT_SEED;
 if (defaultSeedRaw != null) {
   fc.configureGlobal({ seed: +defaultSeedRaw });
-} else if (process.env.EXPECT_DEFAULT_SEED) {
+} else if (process.env.EXPECT_DEFAULT_SEED || process.env.GITHUB_ACTION) {
   throw new Error('Missing env variable for DEFAULT_SEED in CI context');
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,6 +8,6 @@ jest.setTimeout(120000);
 const defaultSeedRaw = process.env.DEFAULT_SEED;
 if (defaultSeedRaw != null) {
   fc.configureGlobal({ seed: +defaultSeedRaw });
-} else if (process.env.CI) {
+} else if (process.env.EXPECT_DEFAULT_SEED) {
   throw new Error('Missing env variable for DEFAULT_SEED in CI context');
 }


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Checking for the env variable CI, makes running in vscode impossible.
We relax the check and use something else to check we want a seed to be defined.

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None