### PR TITLE
🐛 fix nodejs import bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "require": "./lib/fast-check.js",
-      "default": "./lib/esm/fast-check.js"
+      "default": "./lib/esm/fast-check.js",
+      "import": "./lib/esm/fast-check.js"
     }
   },
   "module": "lib/esm/fast-check.js",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "exports": {
     ".": {
       "require": "./lib/fast-check.js",
-      "default": "./lib/esm/fast-check.js",
-      "import": "./lib/esm/fast-check.js"
+      "import": "./lib/esm/fast-check.js",
+      "default": "./lib/esm/fast-check.js"
     }
   },
   "module": "lib/esm/fast-check.js",

--- a/test/esm/esbuild-with-import/package.json
+++ b/test/esm/esbuild-with-import/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build:browser": "esbuild main.js --bundle --platform=browser --outfile=dist/main.browser.js",
-    "build:node": "esbuild main.js --bundle --platform=node --outfile=dist/main.node.js",
+    "build:node": "esbuild main.js --bundle --platform=node --format=esm --outfile=dist/main.node.js",
     "build": "yarn build:browser && yarn build:node",
     "out": "node dist/main.browser.js > out.txt && node dist/main.node.js >> out.txt",
     "start": "yarn build && yarn out"


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

If you expect some noticeable impacts with your change please explain.

- Usage Impact - As [documented](https://nodejs.org/api/esm.html#esm_import_specifiers), modern veersion of node.js needs an explicit `import` specifier to be able to use ESM format in node.js
