### PR TITLE
✨ Reject invalid weights on `fc.frequency`

### DIFF
--- a/src/check/arbitrary/FrequencyArbitrary.ts
+++ b/src/check/arbitrary/FrequencyArbitrary.ts
@@ -31,6 +31,17 @@ class FrequencyArbitrary<T> extends Arbitrary<T> {
     if (warbs.length === 0) {
       throw new Error('fc.frequency expects at least one weigthed arbitrary');
     }
+    let totalWeight = 0;
+    for (let idx = 0; idx !== warbs.length; ++idx) {
+      const currentWeight = warbs[idx].weight;
+      totalWeight += currentWeight;
+      if (currentWeight < 0) {
+        throw new Error('fc.frequency expects weights to be superior or equal to 0');
+      }
+    }
+    if (totalWeight <= 0) {
+      throw new Error('fc.frequency expects the sum of weights to be strictly superior to 0');
+    }
     return new FrequencyArbitrary(warbs);
   }
   private constructor(readonly warbs: WeightedArbitrary<T>[]) {

--- a/test/unit/check/arbitrary/FrequencyArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/FrequencyArbitrary.spec.ts
@@ -38,5 +38,56 @@ describe('FrequencyArbitrary', () => {
     it('Should reject calls without any weighted arbitraries', () => {
       expect(() => frequency()).toThrowError();
     });
+    it('Should reject calls including at one strictly negative weight', () =>
+      fc.assert(
+        fc.property(
+          fc.integer({ max: -1 }),
+          fc.array(fc.nat()),
+          fc.array(fc.nat()),
+          (negativeWeight, headingWeights, traillingWeights) => {
+            expect(() =>
+              frequency(
+                ...[...headingWeights, negativeWeight, ...traillingWeights].map((weight) => ({
+                  weight,
+                  arbitrary: stubArb.single(0),
+                }))
+              )
+            ).toThrowError();
+          }
+        )
+      ));
+    it('Should reject calls having a total weight of zero', () =>
+      fc.assert(
+        fc.property(fc.nat({ max: 1000 }), (numEntries) => {
+          // Combined with: 'Should reject calls including at one strictly negative weight'
+          // it means that we have: 'Should reject calls having a total weight inferior or equal to zero'
+          expect(() =>
+            frequency(
+              ...[...Array(numEntries)].map(() => ({
+                weight: 0,
+                arbitrary: stubArb.single(0),
+              }))
+            )
+          ).toThrowError();
+        })
+      ));
+    it('Should not reject calls defining a strictly positive total weight without any negative weights', () =>
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1 }),
+          fc.array(fc.nat()),
+          fc.array(fc.nat()),
+          (negativeWeight, headingWeights, traillingWeights) => {
+            expect(() =>
+              frequency(
+                ...[...headingWeights, negativeWeight, ...traillingWeights].map((weight) => ({
+                  weight,
+                  arbitrary: stubArb.single(0),
+                }))
+              )
+            ).not.toThrowError();
+          }
+        )
+      ));
   });
 });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

`fc.frequency` may reject invalid inputs earlier
