### PR TITLE
✨ Stricter checks on args of `fc.frequency`

### DIFF
--- a/src/check/arbitrary/FrequencyArbitrary.ts
+++ b/src/check/arbitrary/FrequencyArbitrary.ts
@@ -34,8 +34,15 @@ class FrequencyArbitrary<T> extends Arbitrary<T> {
     }
     let totalWeight = 0;
     for (let idx = 0; idx !== warbs.length; ++idx) {
+      const currentArbitrary = warbs[idx].arbitrary;
+      if (currentArbitrary === undefined) {
+        throw new Error('fc.frequency expects arbitraries to be specified');
+      }
       const currentWeight = warbs[idx].weight;
       totalWeight += currentWeight;
+      if (!Number.isInteger(currentWeight)) {
+        throw new Error('fc.frequency expects weights to be integer values');
+      }
       if (currentWeight < 0) {
         throw new Error('fc.frequency expects weights to be superior or equal to 0');
       }

--- a/test/unit/check/arbitrary/FrequencyArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/FrequencyArbitrary.utest.spec.ts
@@ -71,6 +71,14 @@ describe('FrequencyArbitrary', () => {
     it('Should reject calls without any weighted arbitraries', () => {
       expect(() => frequency()).toThrowError();
     });
+    it('Should reject calls without weight', () => {
+      expect(() => frequency({ arbitrary: stubArb.single(0), weight: undefined! })).toThrowError(
+        /expects weights to be integer values/
+      );
+    });
+    it('Should reject calls without arbitrary', () => {
+      expect(() => frequency({ arbitrary: undefined!, weight: 1 })).toThrowError(/expects arbitraries to be specified/);
+    });
     it('Should reject calls including at least one strictly negative weight', () =>
       fc.assert(
         fc.property(


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Can eventually break some invalid calls to `fc.frequency`. Actually those calls should result in runtime failures on generate or infinite loops.
