### PR TITLE
♻️ Re-use `fc.frequency` for `fc.oneof`

### DIFF
--- a/test/unit/check/arbitrary/FrequencyArbitrary.itest.spec.ts
+++ b/test/unit/check/arbitrary/FrequencyArbitrary.itest.spec.ts
@@ -2,11 +2,8 @@ import * as fc from '../../../../lib/fast-check';
 
 import { frequency } from '../../../../src/check/arbitrary/FrequencyArbitrary';
 import { integer } from '../../../../src/check/arbitrary/IntegerArbitrary';
-import { oneof } from '../../../../src/check/arbitrary/OneOfArbitrary';
 import { constant } from '../../../../src/check/arbitrary/ConstantArbitrary';
 
-import * as stubArb from '../../stubs/arbitraries';
-import * as stubRng from '../../stubs/generators';
 import * as genericHelper from './generic/GenericArbitraryHelper';
 
 describe('FrequencyArbitrary', () => {
@@ -82,34 +79,5 @@ describe('FrequencyArbitrary', () => {
         },
       }
     );
-
-    const MAX_WEIGHT = 100;
-    const weightArb = () => fc.tuple(fc.integer(), fc.integer(1, MAX_WEIGHT));
-    const rng = (seed: number) => stubRng.mutable.fastincrease(seed);
-
-    it('Should produce the same as oneof when called on weights of 1', () =>
-      fc.assert(
-        fc.property(fc.integer(), fc.array(fc.integer(), { minLength: 1 }), (seed, choices) => {
-          const gFreq = frequency(...choices.map((c) => Object({ weight: 1, arbitrary: stubArb.counter(c) }))).generate(
-            rng(seed)
-          ).value;
-          const gOneOf = oneof(...choices.map(stubArb.counter)).generate(rng(seed)).value;
-          return gFreq === gOneOf;
-        })
-      ));
-    it('Should produce the same as oneof with sum of weights elements', () =>
-      fc.assert(
-        fc.property(fc.integer(), fc.array(weightArb(), { minLength: 1 }), (seed, choices) => {
-          const expand = (value: number, num: number): number[] => [...Array(num)].map(() => value);
-
-          const choicesOneOf = [...choices].reduce((p: number[], c) => p.concat(...expand(c[0], c[1])), []);
-
-          const gFreq = frequency(
-            ...choices.map((c) => Object({ weight: c[1], arbitrary: stubArb.counter(c[0]) }))
-          ).generate(rng(seed)).value;
-          const gOneOf = oneof(...choicesOneOf.map(stubArb.counter)).generate(rng(seed)).value;
-          return gFreq === gOneOf;
-        })
-      ));
   });
 });


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *refactor: oneof is just a special case of frequency*

(✔️: yes, ❌: no)

## Potential impacts

No impact expected
