### PR TITLE
🗑 Mark `fc.genericTuple` as deprecated

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2338,7 +2338,7 @@ fc.tuple(fc.nat(), fc.string())
 
 *&#8195;Signatures*
 
-- `fc.genericTuple(arbitraries)`
+- `fc.genericTuple(arbitraries)` — _deprecated since v2.14.0_
 
 *&#8195;with:*
 

--- a/src/check/arbitrary/TupleArbitrary.ts
+++ b/src/check/arbitrary/TupleArbitrary.ts
@@ -73,6 +73,7 @@ export class GenericTupleArbitrary<Ts extends unknown[]> extends Arbitrary<Ts> {
  *
  * @param arbs - Ordered list of arbitraries
  *
+ * @deprecated Switch to {@link tuple} instead
  * @remarks Since 1.0.0
  * @public
  */


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *depreciation notice*

(✔️: yes, ❌: no)

## Potential impacts

None