### PR TITLE
♻️ Migrate integer/bigint/double to NextArbitrary

### DIFF
--- a/src/check/arbitrary/BigIntArbitrary.ts
+++ b/src/check/arbitrary/BigIntArbitrary.ts
@@ -1,31 +1,39 @@
 import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
-import { Arbitrary } from './definition/Arbitrary';
 import { ArbitraryWithContextualShrink } from './definition/ArbitraryWithContextualShrink';
-import { biasWrapper } from './definition/BiasedArbitraryWrapper';
-import { Shrinkable } from './definition/Shrinkable';
-import { biasNumeric, bigIntLogLike } from './helpers/BiasNumeric';
+import { convertFromNextWithShrunkOnce } from './definition/Converters';
+import { NextArbitrary } from './definition/NextArbitrary';
+import { NextValue } from './definition/NextValue';
+import { retrieveBiasRangesForNumeric, bigIntLogLike } from './helpers/BiasNumeric';
 import { shrinkBigInt } from './helpers/ShrinkBigInt';
 
 /** @internal */
-class BigIntArbitrary extends ArbitraryWithContextualShrink<bigint> {
-  private biasedBigIntArbitrary: Arbitrary<bigint> | null = null;
-
-  constructor(readonly min: bigint, readonly max: bigint, readonly genMin: bigint, readonly genMax: bigint) {
+class BigIntArbitrary extends NextArbitrary<bigint> {
+  constructor(readonly min: bigint, readonly max: bigint) {
     super();
   }
 
-  private wrapper(value: bigint, context: unknown): Shrinkable<bigint> {
-    return new Shrinkable(value, () =>
-      this.contextualShrink(value, context).map(([v, nextContext]) => this.wrapper(v, nextContext))
-    );
+  generate(mrng: Random, biasFactor: number | undefined): NextValue<bigint> {
+    const range = this.computeGenerateRange(mrng, biasFactor);
+    return new NextValue(mrng.nextBigInt(range.min, range.max), undefined);
+  }
+  private computeGenerateRange(mrng: Random, biasFactor: number | undefined): { min: bigint; max: bigint } {
+    if (biasFactor === undefined || mrng.nextInt(1, biasFactor) !== 1) {
+      return { min: this.min, max: this.max };
+    }
+    const ranges = retrieveBiasRangesForNumeric(this.min, this.max, bigIntLogLike);
+    if (ranges.length === 1) {
+      return ranges[0];
+    }
+    const id = mrng.nextInt(-2 * (ranges.length - 1), ranges.length - 2); // 1st range has the highest priority
+    return id < 0 ? ranges[0] : ranges[id + 1];
   }
 
-  generate(mrng: Random): Shrinkable<bigint> {
-    return this.wrapper(mrng.nextBigInt(this.genMin, this.genMax), undefined);
+  canGenerate(value: unknown): value is bigint {
+    return typeof value === 'bigint' && this.min <= value && value <= this.max;
   }
 
-  contextualShrink(current: bigint, context?: unknown): Stream<[bigint, unknown]> {
+  shrink(current: bigint, context?: unknown): Stream<NextValue<bigint>> {
     if (current === BigInt(0)) {
       return Stream.nil();
     }
@@ -40,17 +48,13 @@ class BigIntArbitrary extends ArbitraryWithContextualShrink<bigint> {
       // Last chance try...
       // context is set to undefined, so that shrink will restart
       // without any assumptions in case our try find yet another bug
-      return Stream.of([context, undefined]);
+      return Stream.of(new NextValue(context, undefined));
     }
     // Normal shrink process
     return shrinkBigInt(current, context, false);
   }
 
-  shrunkOnceContext(): unknown {
-    return this.defaultTarget();
-  }
-
-  private defaultTarget(): bigint {
+  defaultTarget(): bigint {
     // min <= 0 && max >= 0   => shrink towards zero
     if (this.min <= 0 && this.max >= 0) {
       return BigInt(0);
@@ -84,18 +88,12 @@ class BigIntArbitrary extends ArbitraryWithContextualShrink<bigint> {
     }
     return true;
   }
+}
 
-  private pureBiasedArbitrary(): Arbitrary<bigint> {
-    if (this.biasedBigIntArbitrary != null) {
-      return this.biasedBigIntArbitrary;
-    }
-    this.biasedBigIntArbitrary = biasNumeric(this.min, this.max, BigIntArbitrary, bigIntLogLike);
-    return this.biasedBigIntArbitrary;
-  }
-
-  withBias(freq: number): Arbitrary<bigint> {
-    return biasWrapper(freq, this, (originalArbitrary: BigIntArbitrary) => originalArbitrary.pureBiasedArbitrary());
-  }
+/** @internal */
+function buildBigIntArbitrary(min: bigint, max: bigint): ArbitraryWithContextualShrink<bigint> {
+  const arb = new BigIntArbitrary(min, max);
+  return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }
 
 /**
@@ -111,7 +109,7 @@ class BigIntArbitrary extends ArbitraryWithContextualShrink<bigint> {
 function bigIntN(n: number): ArbitraryWithContextualShrink<bigint> {
   const min = BigInt(-1) << BigInt(n - 1);
   const max = (BigInt(1) << BigInt(n - 1)) - BigInt(1);
-  return new BigIntArbitrary(min, max, min, max);
+  return buildBigIntArbitrary(min, max);
 }
 
 /**
@@ -127,7 +125,7 @@ function bigIntN(n: number): ArbitraryWithContextualShrink<bigint> {
 function bigUintN(n: number): ArbitraryWithContextualShrink<bigint> {
   const min = BigInt(0);
   const max = (BigInt(1) << BigInt(n)) - BigInt(1);
-  return new BigIntArbitrary(min, max, min, max);
+  return buildBigIntArbitrary(min, max);
 }
 
 /**
@@ -211,7 +209,7 @@ function bigInt(min: bigint, max: bigint): ArbitraryWithContextualShrink<bigint>
 function bigInt(constraints: BigIntConstraints): ArbitraryWithContextualShrink<bigint>;
 function bigInt(...args: [] | [bigint, bigint] | [BigIntConstraints]): ArbitraryWithContextualShrink<bigint> {
   const constraints = buildCompleteBigIntConstraints(extractBigIntConstraints(args));
-  return new BigIntArbitrary(constraints.min, constraints.max, constraints.min, constraints.max);
+  return buildBigIntArbitrary(constraints.min, constraints.max);
 }
 
 /**
@@ -253,7 +251,7 @@ function bigUint(max: bigint): ArbitraryWithContextualShrink<bigint>;
 function bigUint(constraints: BigUintConstraints): ArbitraryWithContextualShrink<bigint>;
 function bigUint(constraints?: bigint | BigUintConstraints): ArbitraryWithContextualShrink<bigint> {
   const max = constraints === undefined ? undefined : typeof constraints === 'object' ? constraints.max : constraints;
-  return max === undefined ? bigUintN(256) : new BigIntArbitrary(BigInt(0), max, BigInt(0), max);
+  return max === undefined ? bigUintN(256) : buildBigIntArbitrary(BigInt(0), max);
 }
 
 export { bigIntN, bigUintN, bigInt, bigUint };

--- a/src/check/arbitrary/IntegerArbitrary.ts
+++ b/src/check/arbitrary/IntegerArbitrary.ts
@@ -1,34 +1,42 @@
 import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
-import { Arbitrary } from './definition/Arbitrary';
 import { ArbitraryWithContextualShrink } from './definition/ArbitraryWithContextualShrink';
-import { biasWrapper } from './definition/BiasedArbitraryWrapper';
-import { Shrinkable } from './definition/Shrinkable';
-import { biasNumeric, integerLogLike } from './helpers/BiasNumeric';
+import { convertFromNextWithShrunkOnce } from './definition/Converters';
+import { NextArbitrary } from './definition/NextArbitrary';
+import { NextValue } from './definition/NextValue';
+import { retrieveBiasRangesForNumeric, integerLogLike } from './helpers/BiasNumeric';
 import { shrinkInteger } from './helpers/ShrinkInteger';
 
 /** @internal */
-class IntegerArbitrary extends ArbitraryWithContextualShrink<number> {
+class IntegerArbitrary extends NextArbitrary<number> {
   static MIN_INT: number = 0x80000000 | 0;
   static MAX_INT: number = 0x7fffffff | 0;
 
-  private biasedIntegerArbitrary: Arbitrary<number> | null = null;
-
-  constructor(readonly min: number, readonly max: number, readonly genMin: number, readonly genMax: number) {
+  constructor(readonly min: number, readonly max: number) {
     super();
   }
 
-  private wrapper(value: number, context: unknown): Shrinkable<number> {
-    return new Shrinkable(value, () =>
-      this.contextualShrink(value, context).map(([v, nextContext]) => this.wrapper(v, nextContext))
-    );
+  generate(mrng: Random, biasFactor: number | undefined): NextValue<number> {
+    const range = this.computeGenerateRange(mrng, biasFactor);
+    return new NextValue(mrng.nextInt(range.min, range.max), undefined);
+  }
+  private computeGenerateRange(mrng: Random, biasFactor: number | undefined): { min: number; max: number } {
+    if (biasFactor === undefined || mrng.nextInt(1, biasFactor) !== 1) {
+      return { min: this.min, max: this.max };
+    }
+    const ranges = retrieveBiasRangesForNumeric(this.min, this.max, integerLogLike);
+    if (ranges.length === 1) {
+      return ranges[0];
+    }
+    const id = mrng.nextInt(-2 * (ranges.length - 1), ranges.length - 2); // 1st range has the highest priority
+    return id < 0 ? ranges[0] : ranges[id + 1];
   }
 
-  generate(mrng: Random): Shrinkable<number> {
-    return this.wrapper(mrng.nextInt(this.genMin, this.genMax), undefined);
+  canGenerate(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && this.min <= value && value <= this.max;
   }
 
-  contextualShrink(current: number, context?: unknown): Stream<[number, unknown]> {
+  shrink(current: number, context?: unknown): Stream<NextValue<number>> {
     if (current === 0) {
       return Stream.nil();
     }
@@ -43,17 +51,13 @@ class IntegerArbitrary extends ArbitraryWithContextualShrink<number> {
       // Last chance try...
       // context is set to undefined, so that shrink will restart
       // without any assumptions in case our try find yet another bug
-      return Stream.of([context, undefined]);
+      return Stream.of(new NextValue(context, undefined));
     }
     // Normal shrink process
     return shrinkInteger(current, context, false);
   }
 
-  shrunkOnceContext(): unknown {
-    return this.defaultTarget();
-  }
-
-  private defaultTarget(): number {
+  defaultTarget(): number {
     // min <= 0 && max >= 0   => shrink towards zero
     if (this.min <= 0 && this.max >= 0) {
       return 0;
@@ -88,18 +92,6 @@ class IntegerArbitrary extends ArbitraryWithContextualShrink<number> {
       throw new Error(`Invalid context value passed to IntegerArbitrary (#2)`);
     }
     return true;
-  }
-
-  private pureBiasedArbitrary(): Arbitrary<number> {
-    if (this.biasedIntegerArbitrary != null) {
-      return this.biasedIntegerArbitrary;
-    }
-    this.biasedIntegerArbitrary = biasNumeric<number>(this.min, this.max, IntegerArbitrary, integerLogLike);
-    return this.biasedIntegerArbitrary;
-  }
-
-  withBias(freq: number): Arbitrary<number> {
-    return biasWrapper(freq, this, (originalArbitrary: IntegerArbitrary) => originalArbitrary.pureBiasedArbitrary());
   }
 }
 
@@ -199,7 +191,8 @@ function integer(
   if (constraints.min > constraints.max) {
     throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
   }
-  return new IntegerArbitrary(constraints.min, constraints.max, constraints.min, constraints.max);
+  const arb = new IntegerArbitrary(constraints.min, constraints.max);
+  return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }
 
 /**
@@ -255,7 +248,8 @@ function nat(arg?: number | NatConstraints): ArbitraryWithContextualShrink<numbe
   if (max < 0) {
     throw new Error('fc.nat value should be greater than or equal to 0');
   }
-  return new IntegerArbitrary(0, max, 0, max);
+  const arb = new IntegerArbitrary(0, max);
+  return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }
 
 /**

--- a/src/check/arbitrary/helpers/BiasNumeric.ts
+++ b/src/check/arbitrary/helpers/BiasNumeric.ts
@@ -1,55 +1,43 @@
-import { Random } from '../../../random/generator/Random';
-import { Arbitrary } from '../definition/Arbitrary';
-import { Shrinkable } from '../definition/Shrinkable';
-
 /** @internal */
-type Numeric = number | bigint;
-
-/** @internal */
-type NumericArbitrary<NType> = new (min: NType, max: NType, genMin: NType, genMax: NType) => Arbitrary<NType>;
-
-/** @internal */
-export class BiasedNumericArbitrary<NType> extends Arbitrary<NType> {
-  private readonly arbs: Arbitrary<NType>[];
-  constructor(readonly arbCloseToZero: Arbitrary<NType>, ...arbs: Arbitrary<NType>[]) {
-    super();
-    this.arbs = arbs;
-  }
-  generate(mrng: Random): Shrinkable<NType> {
-    const id = mrng.nextInt(-2 * this.arbs.length, this.arbs.length - 1); // 2 close to zero for 1 in others
-    return id < 0 ? this.arbCloseToZero.generate(mrng) : this.arbs[id].generate(mrng);
-  }
-}
-
-/** @internal */
-export function biasNumeric<NType extends Numeric>(
+function retrieveBiasRangesForNumeric(
+  min: number,
+  max: number,
+  logLike: (n: number) => number
+): { min: number; max: number }[];
+function retrieveBiasRangesForNumeric(
+  min: bigint,
+  max: bigint,
+  logLike: (n: bigint) => bigint
+): { min: bigint; max: bigint }[];
+function retrieveBiasRangesForNumeric<NType extends number | bigint>(
   min: NType,
   max: NType,
-  Ctor: NumericArbitrary<NType>,
   logLike: (n: NType) => NType
-): Arbitrary<NType> {
+): { min: NType; max: NType }[] {
   if (min === max) {
-    return new Ctor(min, max, min, max);
+    return [{ min: min, max: max }];
   }
   if (min < 0 && max > 0) {
     // min < 0 && max > 0
     const logMin = logLike(-min as any); // min !== 0
     const logMax = logLike(max); // max !== 0
-    return new BiasedNumericArbitrary(
-      new Ctor(min, max, -logMin as any, logMax), // close to zero,
-      new Ctor(min, max, (max - logMax) as any, max), // close to max
-      new Ctor(min, max, min, (min as any) + logMin) // close to min
-    );
+    return [
+      { min: -logMin as any, max: logMax }, // close to zero,
+      { min: (max - logMax) as any, max: max }, // close to max
+      { min: min, max: (min as any) + logMin }, // close to min
+    ];
   }
   // Either min < 0 && max <= 0
   // Or min >= 0, so max >= 0
   const logGap = logLike((max - min) as any); // max-min !== 0
-  const arbCloseToMin = new Ctor(min, max, min, (min as any) + logGap); // close to min
-  const arbCloseToMax = new Ctor(min, max, (max - logGap) as any, max); // close to max
+  const arbCloseToMin = { min: min, max: (min as any) + logGap }; // close to min
+  const arbCloseToMax = { min: (max - logGap) as any, max: max }; // close to max
   return min < 0
-    ? new BiasedNumericArbitrary(arbCloseToMax, arbCloseToMin) // max is closer to zero
-    : new BiasedNumericArbitrary(arbCloseToMin, arbCloseToMax); // min is closer to zero
+    ? [arbCloseToMax, arbCloseToMin] // max is closer to zero
+    : [arbCloseToMin, arbCloseToMax]; // min is closer to zero
 }
+
+export { retrieveBiasRangesForNumeric };
 
 /** @internal */
 export function integerLogLike(v: number): number {

--- a/src/check/arbitrary/helpers/ShrinkBigInt.ts
+++ b/src/check/arbitrary/helpers/ShrinkBigInt.ts
@@ -1,4 +1,5 @@
 import { Stream, stream } from '../../../stream/Stream';
+import { NextValue } from '../definition/NextValue';
 
 /**
  * Halve towards zero
@@ -12,23 +13,23 @@ function halveBigInt(n: bigint): bigint {
  * Compute shrunk values to move from current to target
  * @internal
  */
-export function shrinkBigInt(current: bigint, target: bigint, tryTargetAsap: boolean): Stream<[bigint, unknown]> {
+export function shrinkBigInt(current: bigint, target: bigint, tryTargetAsap: boolean): Stream<NextValue<bigint>> {
   const realGap = current - target;
-  function* shrinkDecr(): IterableIterator<[bigint, unknown]> {
+  function* shrinkDecr(): IterableIterator<NextValue<bigint>> {
     let previous: bigint | undefined = tryTargetAsap ? undefined : target;
     const gap = tryTargetAsap ? realGap : halveBigInt(realGap);
     for (let toremove = gap; toremove > 0; toremove = halveBigInt(toremove)) {
       const next = current - toremove;
-      yield [next, previous]; // previous indicates the last passing value
+      yield new NextValue(next, previous); // previous indicates the last passing value
       previous = next;
     }
   }
-  function* shrinkIncr(): IterableIterator<[bigint, unknown]> {
+  function* shrinkIncr(): IterableIterator<NextValue<bigint>> {
     let previous: bigint | undefined = tryTargetAsap ? undefined : target;
     const gap = tryTargetAsap ? realGap : halveBigInt(realGap);
     for (let toremove = gap; toremove < 0; toremove = halveBigInt(toremove)) {
       const next = current - toremove;
-      yield [next, previous]; // previous indicates the last passing value
+      yield new NextValue(next, previous); // previous indicates the last passing value
       previous = next;
     }
   }

--- a/src/check/arbitrary/helpers/ShrinkInteger.ts
+++ b/src/check/arbitrary/helpers/ShrinkInteger.ts
@@ -1,4 +1,5 @@
 import { Stream, stream } from '../../../stream/Stream';
+import { NextValue } from '../definition/NextValue';
 
 /** @internal */
 function halvePosInteger(n: number): number {
@@ -13,23 +14,23 @@ function halveNegInteger(n: number): number {
  * Compute shrunk values to move from current to target
  * @internal
  */
-export function shrinkInteger(current: number, target: number, tryTargetAsap: boolean): Stream<[number, unknown]> {
+export function shrinkInteger(current: number, target: number, tryTargetAsap: boolean): Stream<NextValue<number>> {
   const realGap = current - target;
-  function* shrinkDecr(): IterableIterator<[number, unknown]> {
+  function* shrinkDecr(): IterableIterator<NextValue<number>> {
     let previous: number | undefined = tryTargetAsap ? undefined : target;
     const gap = tryTargetAsap ? realGap : halvePosInteger(realGap);
     for (let toremove = gap; toremove > 0; toremove = halvePosInteger(toremove)) {
       const next = current - toremove;
-      yield [next, previous]; // previous indicates the last passing value
+      yield new NextValue(next, previous); // previous indicates the last passing value
       previous = next;
     }
   }
-  function* shrinkIncr(): IterableIterator<[number, unknown]> {
+  function* shrinkIncr(): IterableIterator<NextValue<number>> {
     let previous: number | undefined = tryTargetAsap ? undefined : target;
     const gap = tryTargetAsap ? realGap : halveNegInteger(realGap);
     for (let toremove = gap; toremove < 0; toremove = halveNegInteger(toremove)) {
       const next = current - toremove;
-      yield [next, previous]; // previous indicates the last passing value
+      yield new NextValue(next, previous); // previous indicates the last passing value
       previous = next;
     }
   }

--- a/test/unit/check/arbitrary/generic/RandomHelpers.ts
+++ b/test/unit/check/arbitrary/generic/RandomHelpers.ts
@@ -1,0 +1,32 @@
+import { MaybeMocked } from 'ts-jest/dist/utils/testing';
+import { Random } from '../../../../../src/random/generator/Random';
+
+export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, 'internalRng' | 'uniformIn'> {
+  const clone = jest.fn();
+  const next = jest.fn();
+  const nextBoolean = jest.fn();
+  const nextInt = jest.fn();
+  const nextBigInt = jest.fn();
+  const nextArrayInt = jest.fn();
+  const nextDouble = jest.fn();
+  class MyRandom extends Random {
+    clone = clone;
+    next = next;
+    nextBoolean = nextBoolean;
+    nextInt = nextInt;
+    nextBigInt = nextBigInt;
+    nextArrayInt = nextArrayInt;
+    nextDouble = nextDouble;
+  }
+
+  return {
+    instance: new MyRandom(null as any),
+    clone,
+    next,
+    nextBoolean,
+    nextInt,
+    nextBigInt,
+    nextArrayInt,
+    nextDouble,
+  };
+}

--- a/test/unit/check/arbitrary/helpers/BiasNumeric.spec.ts
+++ b/test/unit/check/arbitrary/helpers/BiasNumeric.spec.ts
@@ -99,7 +99,7 @@ describe('BiasNumeric', () => {
             // Assert
             expect(ranges).not.toHaveLength(0);
             for (const range of ranges) {
-              expect(range.max).toBeGreaterThan(range.min);
+              expect(range.max).toBeGreaterThanOrEqual(range.min);
               expect(min).toBeLessThanOrEqual(range.max);
               expect(max).toBeGreaterThanOrEqual(range.max);
               expect(min).toBeLessThanOrEqual(range.min);


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *refactor*

(✔️: yes, ❌: no)

## Potential impacts

None expected but if any on integer/double/bigint and by transition any arbitrary offered by fast-check on:
- Generated values impact,
- Shrink values impact