### PR TITLE
🩹 `canGenerate` method on integer should reject `-0`

### DIFF
--- a/src/arbitrary/_internals/IntegerArbitrary.ts
+++ b/src/arbitrary/_internals/IntegerArbitrary.ts
@@ -20,7 +20,13 @@ export class IntegerArbitrary extends NextArbitrary<number> {
   }
 
   canGenerate(value: unknown): value is number {
-    return typeof value === 'number' && Number.isInteger(value) && this.min <= value && value <= this.max;
+    return (
+      typeof value === 'number' &&
+      Number.isInteger(value) &&
+      !Object.is(value, -0) &&
+      this.min <= value &&
+      value <= this.max
+    );
   }
 
   shrink(current: number, context?: unknown): Stream<NextValue<number>> {


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None