### PR TITLE
✨ Ensure bigint are always instanciated with valid ranges

### DIFF
--- a/src/arbitrary/bigInt.ts
+++ b/src/arbitrary/bigInt.ts
@@ -83,6 +83,9 @@ function bigInt(min: bigint, max: bigint): ArbitraryWithContextualShrink<bigint>
 function bigInt(constraints: BigIntConstraints): ArbitraryWithContextualShrink<bigint>;
 function bigInt(...args: [] | [bigint, bigint] | [BigIntConstraints]): ArbitraryWithContextualShrink<bigint> {
   const constraints = buildCompleteBigIntConstraints(extractBigIntConstraints(args));
+  if (constraints.min > constraints.max) {
+    throw new Error('fc.bigInt expects max to be greater than or equal to min');
+  }
   const arb = new BigIntArbitrary(constraints.min, constraints.max);
   return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }

--- a/src/arbitrary/bigIntN.ts
+++ b/src/arbitrary/bigIntN.ts
@@ -13,6 +13,9 @@ import { BigIntArbitrary } from './_internals/BigIntArbitrary';
  * @public
  */
 export function bigIntN(n: number): ArbitraryWithContextualShrink<bigint> {
+  if (n < 1) {
+    throw new Error('fc.bigIntN expects requested number of bits to be superior or equal to 1');
+  }
   const min = BigInt(-1) << BigInt(n - 1);
   const max = (BigInt(1) << BigInt(n - 1)) - BigInt(1);
   const arb = new BigIntArbitrary(min, max);

--- a/src/arbitrary/bigUint.ts
+++ b/src/arbitrary/bigUint.ts
@@ -45,8 +45,12 @@ function bigUint(max: bigint): ArbitraryWithContextualShrink<bigint>;
  */
 function bigUint(constraints: BigUintConstraints): ArbitraryWithContextualShrink<bigint>;
 function bigUint(constraints?: bigint | BigUintConstraints): ArbitraryWithContextualShrink<bigint> {
-  const max = constraints === undefined ? undefined : typeof constraints === 'object' ? constraints.max : constraints;
-  const arb = new BigIntArbitrary(BigInt(0), max !== undefined ? max : computeDefaultMax());
+  const requestedMax = typeof constraints === 'object' ? constraints.max : constraints;
+  const max = requestedMax !== undefined ? requestedMax : computeDefaultMax();
+  if (max) {
+    throw new Error('fc.bigUint expects max to be greater than or equal to zero');
+  }
+  const arb = new BigIntArbitrary(BigInt(0), max);
   return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }
 export { bigUint };

--- a/src/arbitrary/bigUintN.ts
+++ b/src/arbitrary/bigUintN.ts
@@ -13,6 +13,9 @@ import { BigIntArbitrary } from './_internals/BigIntArbitrary';
  * @public
  */
 export function bigUintN(n: number): ArbitraryWithContextualShrink<bigint> {
+  if (n < 1) {
+    throw new Error('fc.bigUintN expects requested number of bits to be superior or equal to 1');
+  }
   const min = BigInt(0);
   const max = (BigInt(1) << BigInt(n)) - BigInt(1);
   const arb = new BigIntArbitrary(min, max);


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Wrongly instantiated bigint will throw earlier
