### PR TITLE
🩹 `canGenerate` of `FrequencyArbitrary` was not using depth properly

### DIFF
--- a/src/arbitrary/_internals/FrequencyArbitrary.ts
+++ b/src/arbitrary/_internals/FrequencyArbitrary.ts
@@ -106,11 +106,11 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
 
   /** Extract the index of the generator that would have been able to gennrate the value */
   private canGenerateIndex(value: unknown): number {
-    ++this.context.depth; // increase depth
+    if (this.mustGenerateFirst()) {
+      return this.warbs[0].arbitrary.canGenerate(value) ? 0 : -1;
+    }
     try {
-      if (this.mustGenerateFirst()) {
-        return this.warbs[0].arbitrary.canGenerate(value) ? 0 : -1;
-      }
+      ++this.context.depth; // increase depth
       for (let idx = 0; idx !== this.warbs.length; ++idx) {
         const warb = this.warbs[idx];
         if (warb.weight !== 0 && warb.arbitrary.canGenerate(value)) {


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Not released yet
