### PR TITLE
🐛 `freq` of `0` not considered the same way in constraints-based and simple arg

### DIFF
--- a/src/arbitrary/option.ts
+++ b/src/arbitrary/option.ts
@@ -47,8 +47,8 @@ export interface OptionConstraints<TNil = null> {
 
 /** @internal */
 function extractOptionConstraints<TNil>(constraints?: number | OptionConstraints<TNil>): OptionConstraints<TNil> {
-  if (!constraints) return {};
   if (typeof constraints === 'number') return { freq: constraints };
+  if (!constraints) return {};
   return constraints;
 }
 


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Generated values impact: option(arb, 0) will not take 0 as freq. Previously it was translated into 5.