### PR TITLE
🚚 Move tuple arbitraries into /arbitrary

### DIFF
--- a/prebuild/property.cjs
+++ b/prebuild/property.cjs
@@ -41,7 +41,7 @@ const generateProperty = (num, isAsync) => {
   const blocks = [
     // imports
     `import { Arbitrary } from '../arbitrary/definition/Arbitrary';`,
-    `import { genericTuple } from '../arbitrary/TupleArbitrary';`,
+    `import { genericTuple } from '../../arbitrary/genericTuple';`,
     `import { ${className}, I${className}WithHooks } from './${className}.generic';`,
     // declare all signatures
     ...iota(num).map((id) => signatureFor(id + 1, isAsync)),

--- a/src/arbitrary/_internals/TupleArbitrary.ts
+++ b/src/arbitrary/_internals/TupleArbitrary.ts
@@ -1,10 +1,8 @@
 import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
-import { cloneIfNeeded, cloneMethod, WithCloneMethod } from '../symbols';
-import { Arbitrary } from './definition/Arbitrary';
-import { convertFromNext, convertToNext } from './definition/Converters';
-import { NextArbitrary } from './definition/NextArbitrary';
-import { NextValue } from './definition/NextValue';
+import { cloneIfNeeded, cloneMethod, WithCloneMethod } from '../../check/symbols';
+import { NextArbitrary } from '../../check/arbitrary/definition/NextArbitrary';
+import { NextValue } from '../../check/arbitrary/definition/NextValue';
 
 /** @internal */
 type ArbsArray<Ts extends unknown[]> = { [K in keyof Ts]: NextArbitrary<Ts[K]> };
@@ -85,32 +83,3 @@ export class GenericTupleArbitrary<Ts extends unknown[]> extends NextArbitrary<T
     return s;
   }
 }
-
-/**
- * For tuples produced by the provided `arbs`
- *
- * @param arbs - Ordered list of arbitraries
- *
- * @deprecated Switch to {@link tuple} instead
- * @remarks Since 1.0.0
- * @public
- */
-function genericTuple<Ts extends unknown[]>(arbs: { [K in keyof Ts]: Arbitrary<Ts[K]> }): Arbitrary<Ts> {
-  const nextArbs = arbs.map((arb) => convertToNext(arb)) as { [K in keyof Ts]: NextArbitrary<Ts[K]> };
-  return convertFromNext(new GenericTupleArbitrary<Ts>(nextArbs));
-}
-
-/**
- * For tuples produced using the provided `arbs`
- *
- * @param arbs - Ordered list of arbitraries
- *
- * @remarks Since 0.0.1
- * @public
- */
-function tuple<Ts extends unknown[]>(...arbs: { [K in keyof Ts]: Arbitrary<Ts[K]> }): Arbitrary<Ts> {
-  const nextArbs = arbs.map((arb) => convertToNext(arb)) as { [K in keyof Ts]: NextArbitrary<Ts[K]> };
-  return convertFromNext(new GenericTupleArbitrary<Ts>(nextArbs));
-}
-
-export { genericTuple, tuple };

--- a/src/arbitrary/genericTuple.ts
+++ b/src/arbitrary/genericTuple.ts
@@ -1,0 +1,18 @@
+import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
+import { convertFromNext, convertToNext } from '../check/arbitrary/definition/Converters';
+import { NextArbitrary } from '../check/arbitrary/definition/NextArbitrary';
+import { GenericTupleArbitrary } from './_internals/TupleArbitrary';
+
+/**
+ * For tuples produced by the provided `arbs`
+ *
+ * @param arbs - Ordered list of arbitraries
+ *
+ * @deprecated Switch to {@link tuple} instead
+ * @remarks Since 1.0.0
+ * @public
+ */
+export function genericTuple<Ts extends unknown[]>(arbs: { [K in keyof Ts]: Arbitrary<Ts[K]> }): Arbitrary<Ts> {
+  const nextArbs = arbs.map((arb) => convertToNext(arb)) as { [K in keyof Ts]: NextArbitrary<Ts[K]> };
+  return convertFromNext(new GenericTupleArbitrary<Ts>(nextArbs));
+}

--- a/src/arbitrary/tuple.ts
+++ b/src/arbitrary/tuple.ts
@@ -1,0 +1,17 @@
+import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
+import { convertFromNext, convertToNext } from '../check/arbitrary/definition/Converters';
+import { NextArbitrary } from '../check/arbitrary/definition/NextArbitrary';
+import { GenericTupleArbitrary } from './_internals/TupleArbitrary';
+
+/**
+ * For tuples produced using the provided `arbs`
+ *
+ * @param arbs - Ordered list of arbitraries
+ *
+ * @remarks Since 0.0.1
+ * @public
+ */
+export function tuple<Ts extends unknown[]>(...arbs: { [K in keyof Ts]: Arbitrary<Ts[K]> }): Arbitrary<Ts> {
+  const nextArbs = arbs.map((arb) => convertToNext(arb)) as { [K in keyof Ts]: NextArbitrary<Ts[K]> };
+  return convertFromNext(new GenericTupleArbitrary<Ts>(nextArbs));
+}

--- a/src/check/arbitrary/DictionaryArbitrary.ts
+++ b/src/check/arbitrary/DictionaryArbitrary.ts
@@ -1,7 +1,7 @@
 import { Arbitrary } from './definition/Arbitrary';
 
 import { set } from '../../arbitrary/set';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 
 /** @internal */
 export function toObject<T>(items: [string, T][]): { [key: string]: T } {

--- a/src/check/arbitrary/EmailArbitrary.ts
+++ b/src/check/arbitrary/EmailArbitrary.ts
@@ -2,7 +2,7 @@ import { array } from '../../arbitrary/array';
 import { buildLowerAlphaNumericArb } from './helpers/SpecificCharacterRange';
 import { domain } from './HostArbitrary';
 import { stringOf } from './StringArbitrary';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { Arbitrary } from './definition/Arbitrary';
 
 /**

--- a/src/check/arbitrary/FloatingPointArbitrary.ts
+++ b/src/check/arbitrary/FloatingPointArbitrary.ts
@@ -2,7 +2,7 @@ import { Arbitrary } from './definition/Arbitrary';
 import { doubleNext, DoubleNextConstraints } from './DoubleNextArbitrary';
 import { floatNext, FloatNextConstraints } from './FloatNextArbitrary';
 import { integer } from '../../arbitrary/integer';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 
 /** @internal */
 function next(n: number): Arbitrary<number> {

--- a/src/check/arbitrary/FunctionArbitrary.ts
+++ b/src/check/arbitrary/FunctionArbitrary.ts
@@ -4,7 +4,7 @@ import { cloneMethod, hasCloneMethod } from '../symbols';
 import { array } from '../../arbitrary/array';
 import { Arbitrary } from './definition/Arbitrary';
 import { integer } from '../../arbitrary/integer';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { escapeForMultilineComments } from './helpers/TextEscaper';
 
 /**

--- a/src/check/arbitrary/HostArbitrary.ts
+++ b/src/check/arbitrary/HostArbitrary.ts
@@ -6,7 +6,7 @@ import {
 } from './helpers/SpecificCharacterRange';
 import { option } from '../../arbitrary/option';
 import { stringOf } from './StringArbitrary';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { Arbitrary } from './definition/Arbitrary';
 
 /** @internal */

--- a/src/check/arbitrary/IpArbitrary.ts
+++ b/src/check/arbitrary/IpArbitrary.ts
@@ -4,7 +4,7 @@ import { Arbitrary } from './definition/Arbitrary';
 import { nat } from '../../arbitrary/nat';
 import { oneof } from '../../arbitrary/oneof';
 import { hexaString } from './StringArbitrary';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 
 /**
  * For valid IP v4

--- a/src/check/arbitrary/ObjectArbitrary.ts
+++ b/src/check/arbitrary/ObjectArbitrary.ts
@@ -12,7 +12,7 @@ import { memo, Memo } from './MemoArbitrary';
 import { oneof } from '../../arbitrary/oneof';
 import { set } from '../../arbitrary/set';
 import { string, unicodeString } from './StringArbitrary';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { bigInt } from '../../arbitrary/bigInt';
 import { date } from './DateArbitrary';
 import {

--- a/src/check/arbitrary/RecordArbitrary.ts
+++ b/src/check/arbitrary/RecordArbitrary.ts
@@ -1,7 +1,7 @@
 import { Arbitrary } from './definition/Arbitrary';
 
 import { option } from '../../arbitrary/option';
-import { genericTuple } from './TupleArbitrary';
+import { genericTuple } from '../../arbitrary/genericTuple';
 
 /**
  * Constraints to be applied on {@link record}

--- a/src/check/arbitrary/SparseArrayArbitrary.ts
+++ b/src/check/arbitrary/SparseArrayArbitrary.ts
@@ -1,7 +1,7 @@
 import { Arbitrary } from './definition/Arbitrary';
 import { nat } from '../../arbitrary/nat';
 import { set } from '../../arbitrary/set';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { maxLengthFromMinLength } from '../../arbitrary/_internals/helpers/MaxLengthFromMinLength';
 
 /**

--- a/src/check/arbitrary/UuidArbitrary.ts
+++ b/src/check/arbitrary/UuidArbitrary.ts
@@ -1,7 +1,7 @@
 import { Arbitrary } from './definition/Arbitrary';
 import { integer } from '../../arbitrary/integer';
 import { nat } from '../../arbitrary/nat';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 
 /** @internal */
 const padEight = (arb: Arbitrary<number>) => arb.map((n) => n.toString(16).padStart(8, '0'));

--- a/src/check/arbitrary/WebArbitrary.ts
+++ b/src/check/arbitrary/WebArbitrary.ts
@@ -8,7 +8,7 @@ import { ipV4, ipV4Extended, ipV6 } from './IpArbitrary';
 import { oneof } from '../../arbitrary/oneof';
 import { option } from '../../arbitrary/option';
 import { stringOf } from './StringArbitrary';
-import { tuple } from './TupleArbitrary';
+import { tuple } from '../../arbitrary/tuple';
 import { Arbitrary } from './definition/Arbitrary';
 
 /**

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -77,7 +77,8 @@ import {
   unicodeString,
 } from './check/arbitrary/StringArbitrary';
 import { shuffledSubarray, subarray, SubarrayConstraints } from './check/arbitrary/SubarrayArbitrary';
-import { genericTuple, tuple } from './check/arbitrary/TupleArbitrary';
+import { genericTuple } from './arbitrary/genericTuple';
+import { tuple } from './arbitrary/tuple';
 import { uuid, uuidV } from './check/arbitrary/UuidArbitrary';
 import {
   webAuthority,

--- a/test/unit/arbitrary/_internals/TupleArbitrary.itest.spec.ts
+++ b/test/unit/arbitrary/_internals/TupleArbitrary.itest.spec.ts
@@ -1,4 +1,4 @@
-import { tuple as tupleOld } from '../../../../src/check/arbitrary/TupleArbitrary';
+import { tuple as tupleOld } from '../../../../src/arbitrary/tuple';
 
 import { convertFromNext, convertToNext } from '../../../../src/check/arbitrary/definition/Converters';
 import { Arbitrary } from '../../../../src/check/arbitrary/definition/Arbitrary';
@@ -8,7 +8,7 @@ import { Random } from '../../../../src/random/generator/Random';
 import { Stream } from '../../../../src/stream/Stream';
 
 import * as stubRng from '../../stubs/generators';
-import { buildNextShrinkTree, renderTree, walkTree } from './generic/ShrinkTree';
+import { buildNextShrinkTree, renderTree, walkTree } from '../../check/arbitrary/generic/ShrinkTree';
 import {
   assertGenerateProducesCorrectValues,
   assertGenerateProducesSameValueGivenSameSeed,
@@ -17,8 +17,8 @@ import {
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
   assertShrinkProducesValuesFlaggedAsCanGenerate,
-} from './generic/NextArbitraryAssertions';
-import { FakeIntegerArbitrary } from './generic/NextArbitraryHelpers';
+} from '../../check/arbitrary/generic/NextArbitraryAssertions';
+import { FakeIntegerArbitrary } from '../../check/arbitrary/generic/NextArbitraryHelpers';
 import { cloneMethod } from '../../../../src/check/symbols';
 
 const mrngNoCall = stubRng.mutable.nocall();

--- a/test/unit/arbitrary/_internals/TupleArbitrary.utest.spec.ts
+++ b/test/unit/arbitrary/_internals/TupleArbitrary.utest.spec.ts
@@ -1,4 +1,4 @@
-import { tuple as tupleOld } from '../../../../src/check/arbitrary/TupleArbitrary';
+import { tuple as tupleOld } from '../../../../src/arbitrary/tuple';
 
 import { convertFromNext, convertToNext } from '../../../../src/check/arbitrary/definition/Converters';
 import { Arbitrary } from '../../../../src/check/arbitrary/definition/Arbitrary';
@@ -7,7 +7,7 @@ import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue'
 
 import * as stubRng from '../../stubs/generators';
 
-import { fakeNextArbitrary } from './generic/NextArbitraryHelpers';
+import { fakeNextArbitrary } from '../../check/arbitrary/generic/NextArbitraryHelpers';
 import { cloneMethod, hasCloneMethod } from '../../../../src/check/symbols';
 import { Stream } from '../../../../src/stream/Stream';
 

--- a/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/SparseArrayArbitrary.utest.spec.ts
@@ -6,12 +6,12 @@ import { mocked } from 'ts-jest/utils';
 import fc from '../../../../lib/fast-check';
 
 import * as NatMock from '../../../../src/arbitrary/nat';
-import * as SetArbitraryMock from '../../../../src/arbitrary/set';
-import * as TupleArbitraryMock from '../../../../src/check/arbitrary/TupleArbitrary';
+import * as SetMock from '../../../../src/arbitrary/set';
+import * as TupleMock from '../../../../src/arbitrary/tuple';
 import { arbitraryFor } from './generic/ArbitraryBuilder';
 jest.mock('../../../../src/arbitrary/nat');
 jest.mock('../../../../src/arbitrary/set');
-jest.mock('../../../../src/check/arbitrary/TupleArbitrary');
+jest.mock('../../../../src/arbitrary/tuple');
 
 const validSparseArrayConstraints = (removedKeys: (keyof SparseArrayConstraints)[] = []) =>
   fc
@@ -63,8 +63,8 @@ describe('SparseArrayArbitrary', () => {
           .property(fc.option(validSparseArrayConstraints(), { nil: undefined }), (ct) => {
             // Arrange
             fc.pre(!isLimitNoTrailingCase(ct));
-            const { set } = mocked(SetArbitraryMock);
-            const { tuple } = mocked(TupleArbitraryMock);
+            const { set } = mocked(SetMock);
+            const { tuple } = mocked(TupleMock);
             set.mockImplementationOnce(() => arbitraryFor([{ value: [] }]));
             tuple.mockImplementationOnce(() => arbitraryFor([{ value: [] as any }]));
 
@@ -90,8 +90,8 @@ describe('SparseArrayArbitrary', () => {
           .property(fc.option(validSparseArrayConstraints(), { nil: undefined }), (ct) => {
             // Arrange
             fc.pre(!isLimitNoTrailingCase(ct));
-            const { set } = mocked(SetArbitraryMock);
-            const { tuple } = mocked(TupleArbitraryMock);
+            const { set } = mocked(SetMock);
+            const { tuple } = mocked(TupleMock);
             const { nat } = mocked(NatMock); // called to build indexes
             set.mockImplementationOnce(() => arbitraryFor([{ value: [] }]));
             tuple.mockImplementationOnce(() => arbitraryFor([{ value: [] as any }]));

--- a/test/unit/check/arbitrary/UuidArbitrary.utest.spec.ts
+++ b/test/unit/check/arbitrary/UuidArbitrary.utest.spec.ts
@@ -5,10 +5,10 @@ import { ArbitraryWithShrink } from '../../../../src/check/arbitrary/definition/
 
 jest.mock('../../../../src/arbitrary/integer');
 jest.mock('../../../../src/arbitrary/nat');
-jest.mock('../../../../src/check/arbitrary/TupleArbitrary');
+jest.mock('../../../../src/arbitrary/tuple');
 import * as _IntegerMock from '../../../../src/arbitrary/integer';
 import * as _NatMock from '../../../../src/arbitrary/nat';
-import * as TupleArbitraryMock from '../../../../src/check/arbitrary/TupleArbitrary';
+import * as TupleMock from '../../../../src/arbitrary/tuple';
 import { arbitraryFor } from './generic/ArbitraryBuilder';
 
 const IntegerMock: { integer: (min: number, max: number) => ArbitraryWithShrink<number> } = _IntegerMock;
@@ -25,7 +25,7 @@ describe('UuidArbitrary', () => {
       // Arrange
       const { integer } = mocked(IntegerMock);
       const { nat } = mocked(NatMock);
-      const { tuple } = mocked(TupleArbitraryMock);
+      const { tuple } = mocked(TupleMock);
       nat.mockImplementation(() => arbitraryFor([{ value: 0 }, { value: 0 }, { value: 0 }]));
       integer.mockImplementation((a, _b) => arbitraryFor([{ value: a }]));
       tuple.mockImplementation((...arbs) =>
@@ -44,7 +44,7 @@ describe('UuidArbitrary', () => {
       // Arrange
       const { integer } = mocked(IntegerMock);
       const { nat } = mocked(NatMock);
-      const { tuple } = mocked(TupleArbitraryMock);
+      const { tuple } = mocked(TupleMock);
       nat.mockImplementation((a) => arbitraryFor([{ value: a }, { value: a }, { value: a }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: b }]));
       tuple.mockImplementation((...arbs) =>
@@ -68,7 +68,7 @@ describe('UuidArbitrary', () => {
       // Arrange
       const { integer } = mocked(IntegerMock);
       const { nat } = mocked(NatMock);
-      const { tuple } = mocked(TupleArbitraryMock);
+      const { tuple } = mocked(TupleMock);
       nat.mockImplementation(() => arbitraryFor([{ value: 0 }, { value: 0 }]));
       integer.mockImplementation((a, _b) => arbitraryFor([{ value: a }]));
       tuple.mockImplementation((...arbs) =>
@@ -87,7 +87,7 @@ describe('UuidArbitrary', () => {
       // Arrange
       const { integer } = mocked(IntegerMock);
       const { nat } = mocked(NatMock);
-      const { tuple } = mocked(TupleArbitraryMock);
+      const { tuple } = mocked(TupleMock);
       nat.mockImplementation((a) => arbitraryFor([{ value: a }, { value: a }]));
       integer.mockImplementation((a, b) => arbitraryFor([{ value: b }]));
       tuple.mockImplementation((...arbs) =>

--- a/test/unit/check/arbitrary/definition/Arbitrary.itest.spec.ts
+++ b/test/unit/check/arbitrary/definition/Arbitrary.itest.spec.ts
@@ -4,7 +4,7 @@ import { constant } from '../../../../../src/check/arbitrary/ConstantArbitrary';
 import { Arbitrary } from '../../../../../src/check/arbitrary/definition/Arbitrary';
 import { Shrinkable } from '../../../../../src/check/arbitrary/definition/Shrinkable';
 import { nat } from '../../../../../src/arbitrary/nat';
-import { tuple } from '../../../../../src/check/arbitrary/TupleArbitrary';
+import { tuple } from '../../../../../src/arbitrary/tuple';
 import { Random } from '../../../../../src/random/generator/Random';
 import { stream } from '../../../../../src/stream/Stream';
 

--- a/test/unit/check/model/commands/CommandsArbitrary.spec.ts
+++ b/test/unit/check/model/commands/CommandsArbitrary.spec.ts
@@ -5,7 +5,7 @@ import { Command } from '../../../../../src/check/model/command/Command';
 import { Random } from '../../../../../src/random/generator/Random';
 import { constant } from '../../../../../src/check/arbitrary/ConstantArbitrary';
 import { commands } from '../../../../../src/check/model/commands/CommandsArbitrary';
-import { genericTuple } from '../../../../../src/check/arbitrary/TupleArbitrary';
+import { genericTuple } from '../../../../../src/arbitrary/genericTuple';
 import { nat } from '../../../../../src/arbitrary/nat';
 import { Arbitrary } from '../../../../../src/check/arbitrary/definition/Arbitrary';
 import { Shrinkable } from '../../../../../src/check/arbitrary/definition/Shrinkable';


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *moving code*

(✔️: yes, ❌: no)

## Potential impacts

No impact is expected as IDE fail to import the right paths with auto-imports different from root.
Non-root import changed for tuple, genericTuple
