### PR TITLE
🐛 `infiniteStream` was not properly cloning cloneable instances

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2624,7 +2624,7 @@ fc.sparseArray(fc.nat())
 
 ```js
 fc.infiniteStream(fc.nat(9))
-// Examples of generated values: Stream(...)…
+// Examples of generated values: Stream(…)…
 ```
 </details>
 

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2624,13 +2624,7 @@ fc.sparseArray(fc.nat())
 
 ```js
 fc.infiniteStream(fc.nat(9))
-// Examples of generated values:
-// • Stream(5,2,2,1,3,9,9,8,9,9...)
-// • Stream(1,0,8,1,6,8,6,7,7,7...)
-// • Stream(0,4,6,5,2,3,5,3,2,1...)
-// • Stream(2,5,0,0,1,9,9,0,7,3...)
-// • Stream(2,4,9,4,0,8,8,4,2,2...)
-// • …
+// Examples of generated values: Stream(...)…
 ```
 </details>
 

--- a/src/check/arbitrary/StreamArbitrary.ts
+++ b/src/check/arbitrary/StreamArbitrary.ts
@@ -22,7 +22,7 @@ class StreamArbitrary<T> extends Arbitrary<Stream<T>> {
         }
       };
       const s = new Stream(g(this.arb, mrng.clone()));
-      const toString = () => `Stream(${seenValues.map(stringify).join(',')}...)`;
+      const toString = () => `Stream(${seenValues.map(stringify).join(',')}…)`;
       return Object.assign(s, { toString, [cloneMethod]: enrichedProducer });
     };
     return new Shrinkable(enrichedProducer());

--- a/src/check/arbitrary/StreamArbitrary.ts
+++ b/src/check/arbitrary/StreamArbitrary.ts
@@ -13,7 +13,7 @@ class StreamArbitrary<T> extends Arbitrary<Stream<T>> {
   }
   generate(mrng: Random): Shrinkable<Stream<T>> {
     const g = function* (arb: Arbitrary<T>, clonedMrng: Random) {
-      while (true) yield arb.generate(clonedMrng).value_;
+      while (true) yield arb.generate(clonedMrng).value;
     };
     const producer = () => new Stream(g(this.arb, mrng.clone()));
     const toString = () => `Stream(${[...producer().take(10).map(stringify)].join(',')}...)`;

--- a/src/check/arbitrary/StreamArbitrary.ts
+++ b/src/check/arbitrary/StreamArbitrary.ts
@@ -12,12 +12,19 @@ class StreamArbitrary<T> extends Arbitrary<Stream<T>> {
     super();
   }
   generate(mrng: Random): Shrinkable<Stream<T>> {
-    const g = function* (arb: Arbitrary<T>, clonedMrng: Random) {
-      while (true) yield arb.generate(clonedMrng).value;
+    const enrichedProducer = () => {
+      const seenValues: T[] = [];
+      const g = function* (arb: Arbitrary<T>, clonedMrng: Random) {
+        while (true) {
+          const value = arb.generate(clonedMrng).value;
+          yield value;
+          seenValues.push(value);
+        }
+      };
+      const s = new Stream(g(this.arb, mrng.clone()));
+      const toString = () => `Stream(${seenValues.map(stringify).join(',')}...)`;
+      return Object.assign(s, { toString, [cloneMethod]: enrichedProducer });
     };
-    const producer = () => new Stream(g(this.arb, mrng.clone()));
-    const toString = () => `Stream(${[...producer().take(10).map(stringify)].join(',')}...)`;
-    const enrichedProducer = () => Object.assign(producer(), { toString, [cloneMethod]: enrichedProducer });
     return new Shrinkable(enrichedProducer());
   }
   withBias(freq: number): Arbitrary<Stream<T>> {

--- a/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -1493,12 +1493,12 @@ Execution summary:
 exports[`NoRegression infiniteStream 1`] = `
 "Property failed after 1 tests
 { seed: 42, path: \\"0\\", endOnFailure: true }
-Counterexample: [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28...)]
+Counterexample: [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]
 Shrunk 0 time(s)
 Got error: Property failed by returning false
 
 Execution summary:
-[31m×[0m [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28...)]"
+[31m×[0m [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]"
 `;
 
 exports[`NoRegression int8Array 1`] = `

--- a/test/unit/check/arbitrary/StreamArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/StreamArbitrary.spec.ts
@@ -34,7 +34,7 @@ describe('StreamArbitrary', () => {
       ctx1.log('plop');
       ctx2.log('plip');
       ctx2.log('plap');
-      expect(String(g)).toEqual('Stream({"logs":["plop"]},{"logs":["plip","plap"]}...)');
+      expect(String(g)).toEqual('Stream({"logs":["plop"]},{"logs":["plip","plap"]}…)');
     });
     it('Should be able to generate any number of values', () =>
       fc.assert(
@@ -50,7 +50,7 @@ describe('StreamArbitrary', () => {
           const mrng = stubRng.mutable.counter(seed);
           const g = infiniteStream(nat()).generate(mrng).value_;
           const firstN = [...g.take(numberOfReadsBeforeToString)];
-          const expectedToString = `Stream(${firstN.join(',')}...)`;
+          const expectedToString = `Stream(${firstN.join(',')}…)`;
           expect(g.toString()).toEqual(expectedToString);
         })
       ));

--- a/test/unit/check/arbitrary/StreamArbitrary.spec.ts
+++ b/test/unit/check/arbitrary/StreamArbitrary.spec.ts
@@ -27,6 +27,15 @@ describe('StreamArbitrary', () => {
       expect(ctx1.size()).toEqual(1);
       expect(ctx2.size()).toEqual(0);
     });
+    it('Should print correctly values even when cloneable', () => {
+      const mrng = stubRng.mutable.counter(0);
+      const g = infiniteStream(context()).generate(mrng).value_;
+      const [ctx1, ctx2] = [...g.take(2)];
+      ctx1.log('plop');
+      ctx2.log('plip');
+      ctx2.log('plap');
+      expect(String(g)).toEqual('Stream({"logs":["plop"]},{"logs":["plip","plap"]}...)');
+    });
     it('Should be able to generate any number of values', () =>
       fc.assert(
         fc.property(fc.integer(), fc.integer(10, 500), (seed, numberOfReadsBeforeToString) => {
@@ -35,13 +44,13 @@ describe('StreamArbitrary', () => {
           return [...g.take(numberOfReadsBeforeToString)].length === numberOfReadsBeforeToString;
         })
       ));
-    it('Should print the 10 first values of the Stream on toString', () =>
+    it('Should print any of the seen values on toString', () =>
       fc.assert(
-        fc.property(fc.integer(), fc.integer(10, 500), (seed, numberOfReadsBeforeToString) => {
+        fc.property(fc.integer(), fc.integer({ max: 500 }), (seed, numberOfReadsBeforeToString) => {
           const mrng = stubRng.mutable.counter(seed);
           const g = infiniteStream(nat()).generate(mrng).value_;
           const firstN = [...g.take(numberOfReadsBeforeToString)];
-          const expectedToString = `Stream(${firstN.slice(0, 10).join(',')}...)`;
+          const expectedToString = `Stream(${firstN.join(',')}...)`;
           expect(g.toString()).toEqual(expectedToString);
         })
       ));


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

- Generated values impact: values will always be properly cloned
- ToString impact: now we print the accessed values (not the top 10)
