### PR TITLE
♻️ Migrate `infiniteStream` to `NextArbitrary`

### DIFF
--- a/src/check/arbitrary/StreamArbitrary.ts
+++ b/src/check/arbitrary/StreamArbitrary.ts
@@ -14,11 +14,12 @@ class StreamArbitrary<T> extends NextArbitrary<Stream<T>> {
   }
 
   generate(mrng: Random, biasFactor: number | undefined): NextValue<Stream<T>> {
+    const appliedBiasFactor = biasFactor !== undefined && mrng.nextInt(1, biasFactor) === 1 ? biasFactor : undefined;
     const enrichedProducer = () => {
       const seenValues: T[] = [];
       const g = function* (arb: NextArbitrary<T>, clonedMrng: Random) {
         while (true) {
-          const value = arb.generate(clonedMrng, biasFactor).value;
+          const value = arb.generate(clonedMrng, appliedBiasFactor).value;
           yield value;
           seenValues.push(value);
         }


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *rewrite*

(✔️: yes, ❌: no)

## Potential impacts

No impact expected. But if any: `infiniteStream`
