### PR TITLE
🐛 `ConstantArbitrary` must not shrink towards the first if it is already the first

### DIFF
--- a/src/arbitrary/_internals/ConstantArbitrary.ts
+++ b/src/arbitrary/_internals/ConstantArbitrary.ts
@@ -25,7 +25,7 @@ export class ConstantArbitrary<T> extends NextArbitrary<T> {
     return false;
   }
   shrink(value: T, context?: unknown): Stream<NextValue<T>> {
-    if (context === 0 || value === this.values[0]) {
+    if (context === 0 || Object.is(value, this.values[0])) {
       return Stream.nil();
     }
     return Stream.of(new NextValue(this.values[0], 0));

--- a/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
@@ -156,7 +156,7 @@ describe('ConstantArbitrary', () => {
           const shrinks = [...arb.shrink(value.value, value.context)];
 
           // Assert
-          if (value.value === values[0]) {
+          if (Object.is(value.value, values[0])) {
             expect(shrinks.map((v) => v.value)).toEqual([]);
           } else {
             expect(shrinks.map((v) => v.value)).toEqual([values[0]]);


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

Shrink values impact: very very rare, only for NaN or -0, 0.
