### PR TITLE
✨ Support `canGenerate` and `shrink` of user-defined values on `map`

### DIFF
--- a/src/check/arbitrary/definition/NextArbitrary.ts
+++ b/src/check/arbitrary/definition/NextArbitrary.ts
@@ -290,7 +290,7 @@ class MapArbitrary<T, U> extends NextArbitrary<U> {
     if (this.unmapper !== undefined) {
       // WARNING: canGenerate must have been called first
       //          shrink should only be called for safe values
-      return this.arb.shrink(this.unmapper(value), undefined).map(this.bindValueMapper);
+      return this.arb.shrink(this.unmapper(value)).map(this.bindValueMapper);
     }
     return Stream.nil();
   }


### PR DESCRIPTION
<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Up-to-now the next generation of arbitraries built using `map` were unable to offer capabilities like `canGenerate` and `shrink` of user-defined values. With this PR it becomes possible for users of `.map` to generate a way to `unmap` values.

Please note that normal shrinking process on `.map` will not use this `unmap`. It has been added only for the shrinking process of user-defined values that have not been generated by using `generate` or are missing the context.

✔️ New feature
❌ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
