### PR TITLE
🐛 `maxCount` of `0` was overriden to `5` in `lorem` instead of being rejected

### DIFF
--- a/src/arbitrary/lorem.ts
+++ b/src/arbitrary/lorem.ts
@@ -263,7 +263,7 @@ function lorem(constraints: LoremConstraints): Arbitrary<string>;
 function lorem(...args: [] | [number] | [number, boolean] | [LoremConstraints]): Arbitrary<string> {
   const maxWordsCount = typeof args[0] === 'object' ? args[0].maxCount : args[0];
   const sentencesMode = typeof args[0] === 'object' ? args[0].mode === 'sentences' : args[1];
-  const maxCount = maxWordsCount || 5;
+  const maxCount = maxWordsCount !== undefined ? maxWordsCount : 5;
   if (maxCount < 1) {
     throw new Error(`lorem has to produce at least one word/sentence`);
   }

--- a/test/unit/arbitrary/LoremArbitrary.spec.ts
+++ b/test/unit/arbitrary/LoremArbitrary.spec.ts
@@ -21,7 +21,7 @@ describe('LoremArbitrary', () => {
       ));
     it('Should generate words by default', () =>
       fc.assert(
-        fc.property(fc.integer(), fc.integer(0, 100), (seed, num) => {
+        fc.property(fc.integer(), fc.integer(1, 100), (seed, num) => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = lorem({ maxCount: num }).generate(mrng).value;
           expect(g).not.toContain('.');
@@ -29,7 +29,7 @@ describe('LoremArbitrary', () => {
       ));
     it('Should not generate commas for words', () =>
       fc.assert(
-        fc.property(fc.integer(), fc.integer(0, 100), (seed, num) => {
+        fc.property(fc.integer(), fc.integer(1, 100), (seed, num) => {
           const mrng = new Random(prand.xorshift128plus(seed));
           const g = lorem({ maxCount: num }).generate(mrng).value;
           expect(g).not.toContain(',');
@@ -61,7 +61,7 @@ describe('LoremArbitrary', () => {
     describe('Still support non recommended signatures', () => {
       it('Should support fc.lorem(maxWordsCount)', () => {
         fc.assert(
-          fc.property(fc.integer(), fc.nat(100), (seed, maxWordsCount) => {
+          fc.property(fc.integer(), fc.integer(1, 100), (seed, maxWordsCount) => {
             const refArbitrary = lorem({ maxCount: maxWordsCount });
             const nonRecommendedArbitrary = lorem(maxWordsCount);
             expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));
@@ -70,7 +70,7 @@ describe('LoremArbitrary', () => {
       });
       it('Should support fc.lorem(maxWordsCount, sentencesMode)', () => {
         fc.assert(
-          fc.property(fc.integer(), fc.nat(100), fc.boolean(), (seed, maxWordsCount, sentencesMode) => {
+          fc.property(fc.integer(), fc.integer(1, 100), fc.boolean(), (seed, maxWordsCount, sentencesMode) => {
             const refArbitrary = lorem({ maxCount: maxWordsCount, mode: sentencesMode ? 'sentences' : 'words' });
             const nonRecommendedArbitrary = lorem(maxWordsCount, sentencesMode);
             expect(generateOneValue(seed, nonRecommendedArbitrary)).toEqual(generateOneValue(seed, refArbitrary));


### PR DESCRIPTION


<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

❌ New feature
✔️ Fix an issue
❌ Documentation improvement
❌ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
