### PR TITLE
💚 Adapt inputs for wrongly defined property on `date`

### DIFF
--- a/test/unit/arbitrary/date.spec.ts
+++ b/test/unit/arbitrary/date.spec.ts
@@ -212,11 +212,14 @@ function constraintsArb() {
 }
 
 function invalidRangeConstraintsArb() {
-  return fc.tuple(fc.date(), fc.date()).map(([d1, d2]) => {
-    const min = d1 < d2 ? d1 : d2;
-    const max = d1 < d2 ? d2 : d1;
-    return { min: max, max: min };
-  });
+  return fc
+    .tuple(fc.date(), fc.date())
+    .filter(([d1, d2]) => +d1 !== +d2)
+    .map(([d1, d2]) => {
+      const min = d1 < d2 ? d1 : d2;
+      const max = d1 < d2 ? d2 : d1;
+      return { min: max, max: min };
+    });
 }
 
 function invalidMinConstraintsArb() {


### PR DESCRIPTION


<!-- Why is this PR for? -->
<!-- Describe the reason why you opened this PR or give a link towards the associated issue. -->

## In a nutshell

Fixes  #1880

❌ New feature
❌ Fix an issue
❌ Documentation improvement
✔️ Other: *please explain*

(✔️: yes, ❌: no)

## Potential impacts

None
