### PR TITLE
🐛 `option` can now properly shrink without any context (incl. to nil)

### DIFF
--- a/src/arbitrary/_internals/FrequencyArbitrary.ts
+++ b/src/arbitrary/_internals/FrequencyArbitrary.ts
@@ -8,7 +8,7 @@ import { DepthContext, getDepthContextFor } from './helpers/DepthContext';
 
 /** @internal */
 export class FrequencyArbitrary<T> extends NextArbitrary<T> {
-  readonly summedWarbs: _WeightedNextArbitrary<T>[];
+  readonly cumulatedWeights: number[];
   readonly totalWeight: number;
 
   static fromOld<T>(warbs: _WeightedArbitrary<T>[], constraints: _Constraints, label: string): Arbitrary<T> {
@@ -26,7 +26,6 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
       throw new Error(`${label} expects at least one weigthed arbitrary`);
     }
     let totalWeight = 0;
-    const warbsNext: _WeightedNextArbitrary<T>[] = [];
     for (let idx = 0; idx !== warbs.length; ++idx) {
       const currentArbitrary = warbs[idx].arbitrary;
       if (currentArbitrary === undefined) {
@@ -40,12 +39,11 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
       if (currentWeight < 0) {
         throw new Error(`${label} expects weights to be superior or equal to 0`);
       }
-      warbsNext.push({ weight: currentWeight, arbitrary: currentArbitrary });
     }
     if (totalWeight <= 0) {
       throw new Error(`${label} expects the sum of weights to be strictly superior to 0`);
     }
-    return new FrequencyArbitrary(warbsNext, constraints, getDepthContextFor(constraints.depthIdentifier));
+    return new FrequencyArbitrary(warbs, constraints, getDepthContextFor(constraints.depthIdentifier));
   }
 
   private constructor(
@@ -55,10 +53,10 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
   ) {
     super();
     let currentWeight = 0;
-    this.summedWarbs = [];
+    this.cumulatedWeights = [];
     for (let idx = 0; idx !== warbs.length; ++idx) {
       currentWeight += warbs[idx].weight;
-      this.summedWarbs.push({ weight: currentWeight, arbitrary: warbs[idx].arbitrary });
+      this.cumulatedWeights.push(currentWeight);
     }
     this.totalWeight = currentWeight;
   }
@@ -69,8 +67,8 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
       return this.safeGenerateForIndex(mrng, 0, biasFactor);
     }
     const selected = mrng.nextInt(this.computeNegDepthBenefit(), this.totalWeight - 1);
-    for (let idx = 0; idx !== this.summedWarbs.length; ++idx) {
-      if (selected < this.summedWarbs[idx].weight) {
+    for (let idx = 0; idx !== this.cumulatedWeights.length; ++idx) {
+      if (selected < this.cumulatedWeights[idx]) {
         return this.safeGenerateForIndex(mrng, idx, biasFactor);
       }
     }
@@ -86,7 +84,7 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
       const safeContext = context as _FrequencyArbitraryContext<T>;
       const selectedIndex = safeContext.selectedIndex;
       const originalBias = safeContext.originalBias;
-      const originalArbitrary = this.summedWarbs[selectedIndex].arbitrary;
+      const originalArbitrary = this.warbs[selectedIndex].arbitrary;
       const originalShrinks = originalArbitrary
         .shrink(value, safeContext.originalContext)
         .map((v) => this.mapIntoNextValue(selectedIndex, v, null, originalBias));
@@ -107,9 +105,26 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
     if (potentialSelectedIndex === -1) {
       return Stream.nil(); // No arbitrary found to accept this value
     }
-    return this.summedWarbs[potentialSelectedIndex].arbitrary
-      .shrink(value)
-      .map((v) => this.mapIntoNextValue(potentialSelectedIndex, v, null, undefined));
+    return this.defaultShrinkForFirst(potentialSelectedIndex).join(
+      this.warbs[potentialSelectedIndex].arbitrary
+        .shrink(value)
+        .map((v) => this.mapIntoNextValue(potentialSelectedIndex, v, null, undefined))
+    );
+  }
+
+  /** Generate shrink values for first arbitrary when no context and no value was provided */
+  private defaultShrinkForFirst(selectedIndex: number): Stream<NextValue<T>> {
+    ++this.context.depth; // increase depth
+    try {
+      if (!this.mustFallbackToFirstInShrink(selectedIndex) || this.warbs[0].fallbackValue === undefined) {
+        // Not applicable: no fallback to first arbitrary on shrink OR no hint to shrink without an initial value and context
+        return Stream.nil();
+      }
+    } finally {
+      --this.context.depth; // decrease depth (reset depth)
+    }
+    const rawShrinkValue = new NextValue(this.warbs[0].fallbackValue.default);
+    return Stream.of(this.mapIntoNextValue(0, rawShrinkValue, null, undefined));
   }
 
   /** Extract the index of the generator that would have been able to gennrate the value */
@@ -151,7 +166,7 @@ export class FrequencyArbitrary<T> extends NextArbitrary<T> {
   private safeGenerateForIndex(mrng: Random, idx: number, biasFactor: number | undefined): NextValue<T> {
     ++this.context.depth; // increase depth
     try {
-      const value = this.summedWarbs[idx].arbitrary.generate(mrng, biasFactor);
+      const value = this.warbs[idx].arbitrary.generate(mrng, biasFactor);
       const clonedMrngForFallbackFirst = this.mustFallbackToFirstInShrink(idx) ? mrng.clone() : null;
       return this.mapIntoNextValue(idx, value, clonedMrngForFallbackFirst, biasFactor);
     } finally {
@@ -195,12 +210,14 @@ export type _Constraints = {
 interface _WeightedArbitrary<T> {
   weight: number;
   arbitrary: Arbitrary<T>;
+  fallbackValue?: { default: T };
 }
 
 /** @internal */
 interface _WeightedNextArbitrary<T> {
   weight: number;
   arbitrary: NextArbitrary<T>;
+  fallbackValue?: { default: T };
 }
 
 /** @internal */

--- a/src/arbitrary/option.ts
+++ b/src/arbitrary/option.ts
@@ -87,9 +87,10 @@ function option<T, TNil = null>(arb: Arbitrary<T>, constraints: OptionConstraint
 function option<T, TNil>(arb: Arbitrary<T>, rawConstraints?: number | OptionConstraints<TNil>): Arbitrary<T | TNil> {
   const constraints = extractOptionConstraints(rawConstraints);
   const freq = constraints.freq == null ? 5 : constraints.freq;
-  const nilArb = constant(Object.prototype.hasOwnProperty.call(constraints, 'nil') ? constraints.nil : (null as any));
+  const nilValue = Object.prototype.hasOwnProperty.call(constraints, 'nil') ? constraints.nil : (null as any);
+  const nilArb = constant(nilValue);
   const weightedArbs = [
-    { arbitrary: nilArb, weight: 1 },
+    { arbitrary: nilArb, weight: 1, fallbackValue: { default: nilValue } },
     { arbitrary: arb, weight: freq },
   ];
   const frequencyConstraints: FrequencyContraints = {

--- a/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
@@ -44,6 +44,7 @@ const fromValidInputs = (metas: { weight: number; arbitraryValue: number }[]) =>
       arbitrary: arbitraryMeta.instance,
       expectedValue: meta.arbitraryValue,
       expectedContext,
+      fallbackValue: undefined as { default: number } | undefined,
     };
   });
 
@@ -641,6 +642,50 @@ describe('FrequencyArbitrary', () => {
 
             // Assert
             expect(shrinks.map((v) => v.value)).toEqual([42, selectedIndex]);
+            expect(warbs[selectedIndex].arbitraryMeta.canGenerate).toHaveBeenCalledWith(value);
+            expect(warbs[selectedIndex].arbitraryMeta.shrink).toHaveBeenCalledWith(value);
+          }
+        )
+      ));
+
+    it('should be able to shrink without context if one of the sub-arbitrary can generate the value plus prepend fallback of first (whenever possible)', () =>
+      fc.assert(
+        fc.property(
+          frequencyValidInputsArb,
+          frequencyConstraintsArbFor({}),
+          fc.nat(),
+          (validInputs, constraints, mod) => {
+            // Arrange
+            fc.pre(constraints.maxDepth !== 0);
+            const warbs = fromValidInputs(validInputs);
+            const depthContext = { depth: 0 };
+            const getDepthContextFor = jest.spyOn(DepthContextMock, 'getDepthContextFor');
+            getDepthContextFor.mockReturnValue(depthContext);
+            const value = Symbol();
+            const selectedIndex = mod % warbs.length;
+            fc.pre(warbs[selectedIndex].weight !== 0);
+            for (let index = 0; index !== warbs.length; ++index) {
+              const input = warbs[index];
+              const can = index === selectedIndex;
+              input.arbitraryMeta.canGenerate.mockReturnValue(can);
+              input.arbitraryMeta.shrink.mockReturnValue(Stream.of(new NextValue(42), new NextValue(index)));
+            }
+            warbs[0].fallbackValue = { default: 48 };
+
+            // Act
+            const arb = FrequencyArbitrary.from(warbs, constraints, 'test');
+            const shrinks = [...arb.shrink(value as any)];
+
+            // Assert
+            if (warbs[0].weight !== 0 && selectedIndex !== 0 && constraints.withCrossShrink) {
+              // Can only prepend when applicable ie:
+              // - weight of [0] >0
+              // - not shrinking a value coming from [0]
+              // - cross-shrink enabled
+              expect(shrinks.map((v) => v.value)).toEqual([48, 42, selectedIndex]);
+            } else {
+              expect(shrinks.map((v) => v.value)).toEqual([42, selectedIndex]);
+            }
             expect(warbs[selectedIndex].arbitraryMeta.canGenerate).toHaveBeenCalledWith(value);
             expect(warbs[selectedIndex].arbitraryMeta.shrink).toHaveBeenCalledWith(value);
           }


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding feastures... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [x] Shrink values: _`option` is now able to shrink the same way with or without context (give its underlying is able too)_
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
