### PR TITLE
✅ Reduce duplication of assertions on `NextArbitrary`

### DIFF
--- a/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
@@ -3,13 +3,11 @@ import { BigIntArbitrary } from '../../../../src/arbitrary/_internals/BigIntArbi
 import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue';
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree, walkTree } from '../../check/arbitrary/generic/ShrinkTree';
 import { Stream } from '../../../../src/stream/Stream';
@@ -243,32 +241,20 @@ describe('BigIntArbitrary (integration)', () => {
 
   const bigIntBuilder = (extra: Extra) => new BigIntArbitrary(extra.min, extra.max);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(bigIntBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(bigIntBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(bigIntBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(bigIntBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(bigIntBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(bigIntBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(bigIntBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(bigIntBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(bigIntBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(bigIntBuilder, { extraParameters });
   });
 
   it('should shrink towards strictly smaller values', () => {

--- a/test/unit/arbitrary/_internals/CloneArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/CloneArbitrary.spec.ts
@@ -6,13 +6,11 @@ import { cloneMethod, hasCloneMethod } from '../../../../src/check/symbols';
 import { Random } from '../../../../src/random/generator/Random';
 import { Stream } from '../../../../src/stream/Stream';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { FakeIntegerArbitrary, fakeNextArbitrary } from '../../check/arbitrary/generic/NextArbitraryHelpers';
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
@@ -161,35 +159,24 @@ describe('CloneArbitrary (integration)', () => {
 
   const cloneBuilder = (extra: Extra) => new CloneArbitrary(new FakeIntegerArbitrary(), extra);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(cloneBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(cloneBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(cloneBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(cloneBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate (only when equal regarding Object.is)', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(cloneBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    // Only when equal regarding Object.is
+    assertProduceValuesShrinkableWithoutContext(cloneBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(cloneBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context if underlyings do', () => {
+  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
     assertShrinkProducesSameValueWithoutInitialContext(cloneBuilder, { extraParameters });
   });
 
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(cloneBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink (only when equal regarding Object.is)', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(cloneBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink (underlyings do)', () => {
+  it('should preserve strictly smaller ordering in shrink (if underlyings do)', () => {
     assertShrinkProducesStrictlySmallerValue(cloneBuilder, isStrictlySmaller, { extraParameters });
   });
 

--- a/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
@@ -3,12 +3,10 @@ import { ConstantArbitrary } from '../../../../src/arbitrary/_internals/Constant
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
 import { cloneMethod } from '../../../../src/check/symbols';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, walkTree } from '../../check/arbitrary/generic/ShrinkTree';
 
@@ -217,28 +215,16 @@ describe('ConstantArbitrary (integration)', () => {
 
   const constantBuilder = (extra: Extra) => new ConstantArbitrary(extra);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(constantBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(constantBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(constantBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(constantBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(constantBuilder, { extraParameters });
-  });
-
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(constantBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(constantBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(constantBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(constantBuilder, { extraParameters });
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
@@ -4,12 +4,10 @@ import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue'
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
 import { FakeIntegerArbitrary, fakeNextArbitrary } from '../../check/arbitrary/generic/NextArbitraryHelpers';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import * as DepthContextMock from '../../../../src/arbitrary/_internals/helpers/DepthContext';
 import { Stream } from '../../../../src/stream/Stream';
@@ -758,31 +756,19 @@ describe('FrequencyArbitrary (integration)', () => {
       'test'
     );
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(frequencyBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(frequencyBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(frequencyBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(frequencyBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(frequencyBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(frequencyBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(frequencyBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(frequencyBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(frequencyBuilder, { extraParameters });
-  });
-
-  it('should shrink towards strictly smaller values (underlyings do)', () => {
+  it('should shrink towards strictly smaller values (if underlyings do)', () => {
     assertShrinkProducesStrictlySmallerValue(frequencyBuilder, isStrictlySmaller, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
@@ -3,13 +3,11 @@ import { IntegerArbitrary } from '../../../../src/arbitrary/_internals/IntegerAr
 import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue';
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree, walkTree } from '../../check/arbitrary/generic/ShrinkTree';
 
@@ -233,32 +231,20 @@ describe('IntegerArbitrary (integration)', () => {
 
   const integerBuilder = (extra: Extra) => new IntegerArbitrary(extra.min, extra.max);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(integerBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(integerBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(integerBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(integerBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(integerBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(integerBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(integerBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(integerBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(integerBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(integerBuilder, { extraParameters });
   });
 
   it('should shrink towards strictly smaller values', () => {

--- a/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
@@ -4,8 +4,8 @@ import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue'
 import { cloneIfNeeded, hasCloneMethod } from '../../../../src/check/symbols';
 import { Stream } from '../../../../src/stream/Stream';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { FakeIntegerArbitrary, fakeNextArbitrary } from '../../check/arbitrary/generic/NextArbitraryHelpers';
 import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
@@ -277,11 +277,11 @@ describe('StreamArbitrary (integration)', () => {
 
   const streamBuilder = () => new StreamArbitrary(sourceArb);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(streamBuilder, { isEqual });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(streamBuilder, { isEqual });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(streamBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(streamBuilder, isCorrect);
   });
 });

--- a/test/unit/arbitrary/_internals/TupleArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/TupleArbitrary.spec.ts
@@ -5,13 +5,11 @@ import { fakeRandom } from '../../check/arbitrary/generic/RandomHelpers';
 import { cloneMethod, hasCloneMethod } from '../../../../src/check/symbols';
 import { Stream } from '../../../../src/stream/Stream';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree, walkTree } from '../../check/arbitrary/generic/ShrinkTree';
 import { NextArbitrary } from '../../../../src/check/arbitrary/definition/NextArbitrary';
@@ -270,35 +268,23 @@ describe('TupleArbitrary (integration)', () => {
   const tupleBuilder = () =>
     new TupleArbitrary([new FakeIntegerArbitrary(), new FakeIntegerArbitrary(), new FakeIntegerArbitrary()]);
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(tupleBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(tupleBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(tupleBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(tupleBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(tupleBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(tupleBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(tupleBuilder);
-  });
-
-  it('should be able to shrink without any context if underlyings do', () => {
+  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
     assertShrinkProducesSameValueWithoutInitialContext(tupleBuilder);
   });
 
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(tupleBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(tupleBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink (underlyings do)', () => {
+  it('should preserve strictly smaller ordering in shrink (if underlyings do)', () => {
     assertShrinkProducesStrictlySmallerValue(tupleBuilder, isStrictlySmaller);
   });
 

--- a/test/unit/arbitrary/ascii.spec.ts
+++ b/test/unit/arbitrary/ascii.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -59,32 +57,20 @@ describe('ascii (integration)', () => {
 
   const asciiBuilder = () => convertToNext(ascii());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(asciiBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(asciiBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(asciiBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(asciiBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(asciiBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(asciiBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(asciiBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(asciiBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(asciiBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(asciiBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/asciiString.spec.ts
+++ b/test/unit/arbitrary/asciiString.spec.ts
@@ -3,12 +3,10 @@ import { asciiString } from '../../../src/arbitrary/asciiString';
 
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('asciiString (integration)', () => {
@@ -35,31 +33,19 @@ describe('asciiString (integration)', () => {
 
   const asciiStringBuilder = (extra: Extra) => convertToNext(asciiString(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(asciiStringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(asciiStringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(asciiStringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(asciiStringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(asciiStringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(asciiStringBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(asciiStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(asciiStringBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(asciiStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(asciiStringBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/base64.spec.ts
+++ b/test/unit/arbitrary/base64.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -73,32 +71,20 @@ describe('base64 (integration)', () => {
 
   const base64Builder = () => convertToNext(base64());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(base64Builder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(base64Builder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(base64Builder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(base64Builder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(base64Builder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(base64Builder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(base64Builder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(base64Builder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(base64Builder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(base64Builder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/base64String.spec.ts
+++ b/test/unit/arbitrary/base64String.spec.ts
@@ -3,11 +3,9 @@ import { base64String } from '../../../src/arbitrary/base64String';
 
 import { convertFromNext, convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 import * as ArrayMock from '../../../src/arbitrary/array';
@@ -133,32 +131,20 @@ describe('base64String (integration)', () => {
 
   const base64StringBuilder = (extra: Extra) => convertToNext(base64String(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(base64StringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(base64StringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(base64StringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(base64StringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(base64StringBuilder, { extraParameters });
-  });
-
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(base64StringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(base64StringBuilder, { extraParameters });
   });
 
   // assertShrinkProducesSameValueWithoutInitialContext is not applicable for base64String has some values will not shrink exactly the same way.
   // For instance: 'abcde' will be mapped to 'abcd', with default shrink it will try to shrink from 'abcde'. With context-less one it will start from 'abcd'.
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(base64StringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(base64StringBuilder, { extraParameters });
-  });
 
   it.each`
     rawValue

--- a/test/unit/arbitrary/char.spec.ts
+++ b/test/unit/arbitrary/char.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -59,32 +57,20 @@ describe('char (integration)', () => {
 
   const charBuilder = () => convertToNext(char());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(charBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(charBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(charBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(charBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(charBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(charBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(charBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(charBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(charBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(charBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/char16bits.spec.ts
+++ b/test/unit/arbitrary/char16bits.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -60,32 +58,20 @@ describe('char16bits (integration)', () => {
 
   const char16bitsBuilder = () => convertToNext(char16bits());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(char16bitsBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(char16bitsBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(char16bitsBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(char16bitsBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(char16bitsBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(char16bitsBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(char16bitsBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(char16bitsBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(char16bitsBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(char16bitsBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/date.spec.ts
+++ b/test/unit/arbitrary/date.spec.ts
@@ -3,13 +3,11 @@ import { date } from '../../../src/arbitrary/date';
 import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpers';
 import { convertFromNextWithShrunkOnce, convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
   assertShrinkProducesStrictlySmallerValue,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 import * as _IntegerMock from '../../../src/arbitrary/integer';
@@ -168,32 +166,20 @@ describe('date (integration)', () => {
 
   const dateBuilder = (extra: Extra) => convertToNext(date(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(dateBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(dateBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(dateBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(dateBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(dateBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(dateBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(dateBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(dateBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(dateBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(dateBuilder, { extraParameters });
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/dictionary.spec.ts
+++ b/test/unit/arbitrary/dictionary.spec.ts
@@ -7,9 +7,9 @@ import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import { Random } from '../../../src/random/generator/Random';
 import { Stream } from '../../../src/stream/Stream';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('dictionary (integration)', () => {
@@ -40,16 +40,16 @@ describe('dictionary (integration)', () => {
     return convertToNext(dictionary(keyArb, valueArb));
   };
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(dictionaryBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(dictionaryBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(dictionaryBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(dictionaryBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(dictionaryBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
+    assertProduceValuesShrinkableWithoutContext(dictionaryBuilder, { extraParameters });
   });
 });
 

--- a/test/unit/arbitrary/fullUnicode.spec.ts
+++ b/test/unit/arbitrary/fullUnicode.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -62,32 +60,20 @@ describe('fullUnicode (integration)', () => {
 
   const fullUnicodeBuilder = () => convertToNext(fullUnicode());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(fullUnicodeBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(fullUnicodeBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(fullUnicodeBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(fullUnicodeBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(fullUnicodeBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(fullUnicodeBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(fullUnicodeBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(fullUnicodeBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(fullUnicodeBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(fullUnicodeBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/fullUnicodeString.spec.ts
+++ b/test/unit/arbitrary/fullUnicodeString.spec.ts
@@ -4,12 +4,10 @@ import { fullUnicodeString } from '../../../src/arbitrary/fullUnicodeString';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -44,32 +42,20 @@ describe('fullUnicodeString (integration)', () => {
 
   const fullUnicodeStringBuilder = (extra: Extra) => convertToNext(fullUnicodeString(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(fullUnicodeStringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(fullUnicodeStringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(fullUnicodeStringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(fullUnicodeStringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(fullUnicodeStringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(fullUnicodeStringBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(fullUnicodeStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(fullUnicodeStringBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(fullUnicodeStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(fullUnicodeStringBuilder, { extraParameters });
   });
 
   it.each`

--- a/test/unit/arbitrary/hexa.spec.ts
+++ b/test/unit/arbitrary/hexa.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -63,32 +61,20 @@ describe('hexa (integration)', () => {
 
   const hexaBuilder = () => convertToNext(hexa());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(hexaBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(hexaBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(hexaBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(hexaBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(hexaBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(hexaBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(hexaBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(hexaBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(hexaBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(hexaBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/hexaString.spec.ts
+++ b/test/unit/arbitrary/hexaString.spec.ts
@@ -3,12 +3,10 @@ import { hexaString } from '../../../src/arbitrary/hexaString';
 
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('hexaString (integration)', () => {
@@ -34,31 +32,19 @@ describe('hexaString (integration)', () => {
 
   const hexaStringBuilder = (extra: Extra) => convertToNext(hexaString(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(hexaStringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(hexaStringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(hexaStringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(hexaStringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(hexaStringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(hexaStringBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(hexaStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(hexaStringBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(hexaStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(hexaStringBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/ipV4.spec.ts
+++ b/test/unit/arbitrary/ipV4.spec.ts
@@ -3,12 +3,10 @@ import { ipV4 } from '../../../src/arbitrary/ipV4';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -24,32 +22,20 @@ describe('ipV4 (integration)', () => {
 
   const ipV4Builder = () => convertToNext(ipV4());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV4Builder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(ipV4Builder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(ipV4Builder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(ipV4Builder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(ipV4Builder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(ipV4Builder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV4Builder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(ipV4Builder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(ipV4Builder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(ipV4Builder);
   });
 
   it.each`

--- a/test/unit/arbitrary/ipV4Extended.spec.ts
+++ b/test/unit/arbitrary/ipV4Extended.spec.ts
@@ -3,12 +3,10 @@ import { ipV4Extended } from '../../../src/arbitrary/ipV4Extended';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -37,32 +35,20 @@ describe('ipV4Extended (integration)', () => {
 
   const ipV4ExtendedBuilder = () => convertToNext(ipV4Extended());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV4ExtendedBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(ipV4ExtendedBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(ipV4ExtendedBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(ipV4ExtendedBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(ipV4ExtendedBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(ipV4ExtendedBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV4ExtendedBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(ipV4ExtendedBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(ipV4ExtendedBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(ipV4ExtendedBuilder);
   });
 
   it.each`

--- a/test/unit/arbitrary/ipV6.spec.ts
+++ b/test/unit/arbitrary/ipV6.spec.ts
@@ -3,12 +3,10 @@ import { ipV6 } from '../../../src/arbitrary/ipV6';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -56,32 +54,20 @@ describe('ipV6 (integration)', () => {
 
   const ipV6Builder = () => convertToNext(ipV6());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV6Builder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(ipV6Builder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(ipV6Builder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(ipV6Builder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(ipV6Builder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(ipV6Builder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(ipV6Builder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(ipV6Builder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(ipV6Builder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(ipV6Builder);
   });
 
   it.each`

--- a/test/unit/arbitrary/letrec.spec.ts
+++ b/test/unit/arbitrary/letrec.spec.ts
@@ -9,10 +9,9 @@ import { FakeIntegerArbitrary, fakeNextArbitrary } from '../check/arbitrary/gene
 import { fakeRandom } from '../check/arbitrary/generic/RandomHelpers';
 import {
   assertGenerateEquivalentTo,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 // Temporary rewrapping around letrec
@@ -359,23 +358,15 @@ describe('letrec (integration)', () => {
     });
   });
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(letrecBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(letrecBuilder);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(letrecBuilder);
+  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
+    assertProduceValuesShrinkableWithoutContext(letrecBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(letrecBuilder);
-  });
-
-  it('should be able to shrink without any context if underlyings do', () => {
+  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
     assertShrinkProducesSameValueWithoutInitialContext(letrecBuilder);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(letrecBuilder);
   });
 });

--- a/test/unit/arbitrary/lorem.spec.ts
+++ b/test/unit/arbitrary/lorem.spec.ts
@@ -2,12 +2,10 @@ import fc from '../../../lib/fast-check';
 import { lorem, LoremConstraints } from '../../../src/arbitrary/lorem';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('lorem', () => {
@@ -66,31 +64,19 @@ describe('lorem (integration)', () => {
 
   const loremBuilder = (extra: Extra) => convertToNext(lorem(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(loremBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(loremBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(loremBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(loremBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(loremBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(loremBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(loremBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(loremBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(loremBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(loremBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/mapToConstant.spec.ts
+++ b/test/unit/arbitrary/mapToConstant.spec.ts
@@ -3,12 +3,10 @@ import { mapToConstant } from '../../../src/arbitrary/mapToConstant';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -74,32 +72,20 @@ describe('mapToConstant (integration)', () => {
     return convertToNext(mapToConstant(...entries));
   };
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(mapToConstantBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(mapToConstantBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(mapToConstantBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(mapToConstantBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(mapToConstantBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(mapToConstantBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(mapToConstantBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(mapToConstantBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(mapToConstantBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(mapToConstantBuilder, { extraParameters });
   });
 
   it('should be able to shrink c given hexa-like entries', () => {
@@ -110,13 +96,14 @@ describe('mapToConstant (integration)', () => {
         { num: 6, build: (index) => String.fromCodePoint(index + 97) } // a-f
       )
     );
-    const value = new NextValue('c', undefined);
+    const rawValue = 'c';
+    const value = new NextValue(rawValue, undefined);
 
     // Act
     const renderedTree = renderTree(buildNextShrinkTree(arb, value)).join('\n');
 
     // Assert
-    expect(arb.canShrinkWithoutContext('c')).toBe(true);
+    expect(arb.canShrinkWithoutContext(rawValue)).toBe(true);
     expect(renderedTree).toMatchSnapshot();
   });
 });

--- a/test/unit/arbitrary/option.spec.ts
+++ b/test/unit/arbitrary/option.spec.ts
@@ -5,12 +5,10 @@ import { convertFromNext, convertToNext } from '../../../src/check/arbitrary/def
 import * as FrequencyArbitraryMock from '../../../src/arbitrary/_internals/FrequencyArbitrary';
 import * as ConstantMock from '../../../src/arbitrary/constant';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -146,31 +144,19 @@ describe('option (integration)', () => {
   const optionBuilder = (extra: Extra) =>
     convertToNext(option(convertFromNext(new FakeIntegerArbitrary()), { ...extra, nil: null }));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(optionBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(optionBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(optionBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(optionBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(optionBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
+    assertProduceValuesShrinkableWithoutContext(optionBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(optionBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
     assertShrinkProducesSameValueWithoutInitialContext(optionBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(optionBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(optionBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/record.spec.ts
+++ b/test/unit/arbitrary/record.spec.ts
@@ -4,12 +4,10 @@ import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { convertFromNext, convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { FakeIntegerArbitrary, fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpers';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 import * as PartialRecordArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder';
@@ -262,31 +260,19 @@ describe('record (integration)', () => {
     return convertToNext(record(recordModel, constraints));
   };
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(recordBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(recordBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(recordBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(recordBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(recordBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
+    assertProduceValuesShrinkableWithoutContext(recordBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(recordBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
     assertShrinkProducesSameValueWithoutInitialContext(recordBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(recordBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(recordBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/string.spec.ts
+++ b/test/unit/arbitrary/string.spec.ts
@@ -4,12 +4,10 @@ import { string } from '../../../src/arbitrary/string';
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -37,32 +35,20 @@ describe('string (integration)', () => {
 
   const stringBuilder = (extra: Extra) => convertToNext(string(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(stringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(stringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(stringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(stringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(stringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(stringBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(stringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(stringBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(stringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(stringBuilder, { extraParameters });
   });
 
   it.each`

--- a/test/unit/arbitrary/string16bits.spec.ts
+++ b/test/unit/arbitrary/string16bits.spec.ts
@@ -3,12 +3,10 @@ import { string16bits } from '../../../src/arbitrary/string16bits';
 
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('string16bits (integration)', () => {
@@ -31,31 +29,19 @@ describe('string16bits (integration)', () => {
 
   const string16bitsBuilder = (extra: Extra) => convertToNext(string16bits(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(string16bitsBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(string16bitsBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(string16bitsBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(string16bitsBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(string16bitsBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(string16bitsBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(string16bitsBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(string16bitsBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(string16bitsBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(string16bitsBuilder, { extraParameters });
   });
 });

--- a/test/unit/arbitrary/stringOf.spec.ts
+++ b/test/unit/arbitrary/stringOf.spec.ts
@@ -7,9 +7,8 @@ import { NextValue } from '../../../src/check/arbitrary/definition/NextValue';
 import { Random } from '../../../src/random/generator/Random';
 import { Stream } from '../../../src/stream/Stream';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceValuesShrinkableWithoutContext,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 import { buildNextShrinkTree, renderTree } from '../check/arbitrary/generic/ShrinkTree';
 
@@ -33,25 +32,17 @@ describe('stringOf (integration)', () => {
   const stringOfBuilder = (extra: Extra) =>
     convertToNext(stringOf(convertFromNext(new PatternsArbitrary(extra.patterns)), extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(stringOfBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(stringOfBuilder, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(stringOfBuilder, { extraParameters });
-  });
-
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(stringOfBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(stringOfBuilder, { extraParameters });
   });
 
   // assertShrinkProducesSameValueWithoutInitialContext is not fully supported by stringOf
   // Indeed depending how much the source strings overlaps there are possibly many possible ways to build a given string
   // so also many possible ways to shrink it.
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(stringOfBuilder, { extraParameters });
-  });
 
   it.each`
     rawValue         | patterns

--- a/test/unit/arbitrary/unicode.spec.ts
+++ b/test/unit/arbitrary/unicode.spec.ts
@@ -6,13 +6,11 @@ import { fakeNextArbitrary } from '../check/arbitrary/generic/NextArbitraryHelpe
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
-  assertShrinkProducesCorrectValues,
+  assertProduceValuesShrinkableWithoutContext,
+  assertProduceCorrectValues,
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 function beforeEachHook() {
@@ -63,32 +61,20 @@ describe('unicode (integration)', () => {
 
   const unicodeBuilder = () => convertToNext(unicode());
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(unicodeBuilder);
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(unicodeBuilder);
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(unicodeBuilder, isCorrect);
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(unicodeBuilder, isCorrect);
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(unicodeBuilder);
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(unicodeBuilder);
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(unicodeBuilder);
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(unicodeBuilder);
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(unicodeBuilder, isCorrect);
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(unicodeBuilder);
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/test/unit/arbitrary/unicodeString.spec.ts
+++ b/test/unit/arbitrary/unicodeString.spec.ts
@@ -3,12 +3,10 @@ import { unicodeString } from '../../../src/arbitrary/unicodeString';
 
 import { convertToNext } from '../../../src/check/arbitrary/definition/Converters';
 import {
-  assertGenerateProducesSameValueGivenSameSeed,
-  assertGenerateProducesCorrectValues,
-  assertGenerateProducesValuesFlaggedAsCanGenerate,
+  assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesCorrectValues,
-  assertShrinkProducesValuesFlaggedAsCanGenerate,
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
 } from '../check/arbitrary/generic/NextArbitraryAssertions';
 
 describe('unicodeString (integration)', () => {
@@ -35,31 +33,19 @@ describe('unicodeString (integration)', () => {
 
   const unicodeStringBuilder = (extra: Extra) => convertToNext(unicodeString(extra));
 
-  it('should generate the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(unicodeStringBuilder, { extraParameters });
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(unicodeStringBuilder, { extraParameters });
   });
 
-  it('should only generate correct values', () => {
-    assertGenerateProducesCorrectValues(unicodeStringBuilder, isCorrect, { extraParameters });
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(unicodeStringBuilder, isCorrect, { extraParameters });
   });
 
-  it('should recognize values that would have been generated using it during generate', () => {
-    assertGenerateProducesValuesFlaggedAsCanGenerate(unicodeStringBuilder, { extraParameters });
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(unicodeStringBuilder, { extraParameters });
   });
 
-  it('should shrink towards the same values given the same seed', () => {
-    assertGenerateProducesSameValueGivenSameSeed(unicodeStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink without any context', () => {
+  it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(unicodeStringBuilder, { extraParameters });
-  });
-
-  it('should only shrink towards correct values', () => {
-    assertShrinkProducesCorrectValues(unicodeStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should recognize values that would have been generated using it during shrink', () => {
-    assertShrinkProducesValuesFlaggedAsCanGenerate(unicodeStringBuilder, { extraParameters });
   });
 });

--- a/test/unit/check/arbitrary/generic/NextArbitraryAssertions.ts
+++ b/test/unit/check/arbitrary/generic/NextArbitraryAssertions.ts
@@ -9,36 +9,7 @@ import { Random } from '../../../../../src/random/generator/Random';
 // > The following assertions are supposed to be fulfilled by any of the arbitraries
 // > provided by fast-check.
 
-export function assertGenerateProducesSameValueGivenSameSeed<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
-  options: {
-    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {}
-): void {
-  const {
-    isEqual,
-    extraParameters: extra = fc.constant(undefined as unknown as U) as fc.Arbitrary<U>,
-    assertParameters,
-  } = options;
-  fc.assert(
-    fc.property(fc.integer().noShrink(), biasFactorArbitrary(), extra, (seed, biasFactor, extraParameters) => {
-      // Arrange
-      const arb = arbitraryBuilder(extraParameters);
-
-      // Act
-      const g1 = arb.generate(randomFromSeed(seed), biasFactor);
-      const g2 = arb.generate(randomFromSeed(seed), biasFactor);
-
-      // Assert
-      assertEquality(isEqual, g1.value, g2.value, extraParameters);
-    }),
-    assertParameters
-  );
-}
-
-export function assertShrinkProducesSameValueGivenSameSeed<T, U = never>(
+export function assertProduceSameValueGivenSameSeed<T, U = never>(
   arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
   options: {
     isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
@@ -89,32 +60,7 @@ export function assertShrinkProducesSameValueGivenSameSeed<T, U = never>(
 // > The following requirements are optional as they do not break the design of fast-check when they are not totally ensured
 // > But some of them are really recommended to build valid arbitraries that can be used.
 
-export function assertGenerateProducesCorrectValues<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
-  isCorrect: (v: T, extraParameters: U, arb: NextArbitrary<T>) => void | boolean,
-  options: {
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {}
-): void {
-  const { extraParameters: extra = fc.constant(undefined as unknown as U) as fc.Arbitrary<U>, assertParameters } =
-    options;
-  fc.assert(
-    fc.property(fc.integer().noShrink(), biasFactorArbitrary(), extra, (seed, biasFactor, extraParameters) => {
-      // Arrange
-      const arb = arbitraryBuilder(extraParameters);
-
-      // Act
-      const g = arb.generate(randomFromSeed(seed), biasFactor);
-
-      // Assert
-      assertCorrectness(isCorrect, g.value, extraParameters, arb);
-    }),
-    assertParameters
-  );
-}
-
-export function assertShrinkProducesCorrectValues<T, U = never>(
+export function assertProduceCorrectValues<T, U = never>(
   arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
   isCorrect: (v: T, extraParameters: U, arb: NextArbitrary<T>) => void | boolean,
   options: {
@@ -200,27 +146,17 @@ export function assertShrinkProducesSameValueWithoutInitialContext<T, U = never>
     assertParameters?: fc.Parameters<unknown>;
   } = {}
 ): void {
-  return assertShrinkProducesSameValueGivenSameSeed(arbitraryBuilder, { ...options, noInitialContext: true });
+  return assertProduceSameValueGivenSameSeed(arbitraryBuilder, { ...options, noInitialContext: true });
 }
 
-export function assertGenerateProducesValuesFlaggedAsCanGenerate<T, U = never>(
+export function assertProduceValuesShrinkableWithoutContext<T, U = never>(
   arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
   options: {
     extraParameters?: fc.Arbitrary<U>;
     assertParameters?: fc.Parameters<unknown>;
   } = {}
 ): void {
-  return assertGenerateProducesCorrectValues(arbitraryBuilder, (v, _, arb) => arb.canShrinkWithoutContext(v), options);
-}
-
-export function assertShrinkProducesValuesFlaggedAsCanGenerate<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => NextArbitrary<T>,
-  options: {
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {}
-): void {
-  return assertShrinkProducesCorrectValues(arbitraryBuilder, (v, _, arb) => arb.canShrinkWithoutContext(v), options);
+  return assertProduceCorrectValues(arbitraryBuilder, (v, _, arb) => arb.canShrinkWithoutContext(v), options);
 }
 
 export function assertShrinkProducesStrictlySmallerValue<T, U = never>(
@@ -255,7 +191,7 @@ export function assertShrinkProducesStrictlySmallerValue<T, U = never>(
       previousValue.value = v;
     }
   }
-  return assertShrinkProducesCorrectValues(arbitraryBuilderInternal, isStrictlySmallerInternal, options);
+  return assertProduceCorrectValues(arbitraryBuilderInternal, isStrictlySmallerInternal, options);
 }
 
 // Various helpers


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Reduce the number of redundant tests. Before that change one assertion checked generated values were ok and one checked generated and shrunk values were ok.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
