### PR TITLE
💚 Integer spec was asking if `integer` can produce `-0`

### DIFF
--- a/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
@@ -283,7 +283,7 @@ describe('IntegerArbitrary (integration)', () => {
 
             // Act
             const source = new NextValue(mid, undefined);
-            const sourceNegate = new NextValue(-mid, undefined);
+            const sourceNegate = new NextValue(mid !== 0 ? -mid : 0, undefined); // !==0 to avoid -0
             const tree = buildNextShrinkTree(arb, source);
             const treeNegate = buildNextShrinkTree(arbNegate, sourceNegate);
             const flat: number[] = [];


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Spec has been wrongly updated thus we tried to run: `integer().canShrinkWithoutContext(-0)` and were expecting `true` while `-0` is not an integer.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
