### PR TITLE
 ⚡️ Speed-up conversions from/to `NextValue`

### DIFF
--- a/src/check/arbitrary/definition/ConverterFromNext.ts
+++ b/src/check/arbitrary/definition/ConverterFromNext.ts
@@ -12,11 +12,12 @@ const identifier = '__ConverterFromNext__';
 /** @internal */
 function fromNextValueToShrinkableFor<T>(arb: NextArbitrary<T>) {
   return function fromNextValueToShrinkable(v: NextValue<T>): Shrinkable<T, T> {
-    return new Shrinkable(
-      v.value_,
-      () => arb.shrink(v.value_, v.context).map(fromNextValueToShrinkable),
-      () => v.value
-    );
+    const value_ = v.value_;
+    const shrinker = () => arb.shrink(value_, v.context).map(fromNextValueToShrinkable);
+    if (!v.hasToBeCloned) {
+      return new Shrinkable(value_, shrinker);
+    }
+    return new Shrinkable(value_, shrinker, () => v.value);
   };
 }
 

--- a/src/check/arbitrary/definition/ConverterToNext.ts
+++ b/src/check/arbitrary/definition/ConverterToNext.ts
@@ -10,6 +10,9 @@ const identifier = '__ConverterToNext__';
 
 /** @internal */
 function fromShrinkableToNextValue<T>(g: Shrinkable<T>): NextValue<T> {
+  if (!g.hasToBeCloned) {
+    return new NextValue(g.value_, g);
+  }
   return new NextValue(g.value_, g, () => g.value);
 }
 


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Improve performance the conversions from and to NextValue.

From my measurements, improvements are significant:
```ts
Property(fc.constant('a')) on fast-check@2.14.0 x 6,614 ops/sec ±0.82% (90 runs sampled)
Property(fc.constant('a')) on fast-check@2.15.0 x 2,453 ops/sec ±3.65% (85 runs sampled)
Property(fc.constant('a')) on fast-check@99.99.99 x 5,937 ops/sec ±0.48% (94 runs sampled)
```

_99.99.99 is master + #1945 + the change_
<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] _Other(s):_ Performances
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [x] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
