### PR TITLE
💚 Escape strings passed to `userEvent.type` in examples

### DIFF
--- a/example/005-race/debounced-autocomplete/main.spec.tsx
+++ b/example/005-race/debounced-autocomplete/main.spec.tsx
@@ -11,6 +11,11 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
+// Copied from https://github.com/testing-library/user-event/issues/586
+function escapeKeyboardInput(value: string): string {
+  return value.replace(/[{[]/g, '$&$&');
+}
+
 describe('DebouncedAutocomplete', () => {
   it('should autocomplete queries (with mocked timers)', async () => {
     await fc.assert(
@@ -32,7 +37,8 @@ describe('DebouncedAutocomplete', () => {
             s.scheduleSequence(
               [...userQuery].map((c, idx) => ({
                 label: `Typing "${c}"`,
-                builder: async () => await userEvent.type(screen.getByRole('textbox'), userQuery.substr(idx, 1)),
+                builder: async () =>
+                  await userEvent.type(screen.getByRole('textbox'), escapeKeyboardInput(userQuery.substr(idx, 1))),
               }))
             );
             await waitAllWithTimers(s);
@@ -71,7 +77,9 @@ describe('DebouncedAutocomplete', () => {
               [...userQuery].map((c, idx) => ({
                 label: `Typing "${c}"`,
                 builder: async () =>
-                  await userEvent.type(screen.getByRole('textbox'), userQuery.substr(idx, 1), { delay: 0 }),
+                  await userEvent.type(screen.getByRole('textbox'), escapeKeyboardInput(userQuery.substr(idx, 1)), {
+                    delay: 0,
+                  }),
               }))
             );
             await s.waitAll();


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

We forgot to properly escaped the strings passed to `userEvent.type`.

For the moment let's use the regex suggested by https://github.com/testing-library/user-event/issues/586.
<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
