### PR TITLE
🚧⚡️ Reduce number for intermediate closures in generate-path

### DIFF
--- a/src/check/runner/Sampler.ts
+++ b/src/check/runner/Sampler.ts
@@ -31,18 +31,13 @@ function streamSample<Ts>(
       ? { ...(readConfigureGlobal() as Parameters<Ts>), numRuns: params }
       : { ...(readConfigureGlobal() as Parameters<Ts>), ...params };
   const qParams: QualifiedParameters<Ts> = QualifiedParameters.read<Ts>(extendedParams);
-  const tossedValues: Stream<() => Shrinkable<Ts>> = stream(
+  const tossedValues: Stream<Shrinkable<Ts>> = stream(
     toss(toProperty(generator, qParams), qParams.seed, qParams.randomType, qParams.examples)
   );
   if (qParams.path.length === 0) {
-    return tossedValues.take(qParams.numRuns).map((s) => s().value_);
+    return tossedValues.take(qParams.numRuns).map((s) => s.value_);
   }
-  return stream(
-    pathWalk(
-      qParams.path,
-      tossedValues.map((s) => s())
-    )
-  )
+  return stream(pathWalk(qParams.path, tossedValues))
     .take(qParams.numRuns)
     .map((s) => s.value_);
 }

--- a/src/check/runner/SourceValuesIterator.ts
+++ b/src/check/runner/SourceValuesIterator.ts
@@ -6,7 +6,7 @@
  */
 export class SourceValuesIterator<Ts> implements IterableIterator<Ts> {
   constructor(
-    readonly initialValues: IterableIterator<() => Ts>,
+    readonly initialValues: IterableIterator<Ts>,
     private maxInitialIterations: number,
     private remainingSkips: number
   ) {}
@@ -16,7 +16,7 @@ export class SourceValuesIterator<Ts> implements IterableIterator<Ts> {
   next(): IteratorResult<Ts> {
     if (--this.maxInitialIterations !== -1 && this.remainingSkips >= 0) {
       const n = this.initialValues.next();
-      if (!n.done) return { value: n.value(), done: false };
+      if (!n.done) return { value: n.value, done: false };
     }
     return { value: undefined, done: true };
   }

--- a/src/check/runner/Tosser.ts
+++ b/src/check/runner/Tosser.ts
@@ -5,22 +5,17 @@ import { Shrinkable } from '../arbitrary/definition/Shrinkable';
 import { IRawProperty } from '../property/IRawProperty';
 
 /** @internal */
-function lazyGenerate<Ts>(generator: IRawProperty<Ts>, rng: prand.RandomGenerator, idx: number): () => Shrinkable<Ts> {
-  return () => generator.generate(new Random(rng), idx);
-}
-
-/** @internal */
 export function* toss<Ts>(
   generator: IRawProperty<Ts>,
   seed: number,
   random: (seed: number) => prand.RandomGenerator,
   examples: Ts[]
-): IterableIterator<() => Shrinkable<Ts>> {
-  yield* examples.map((e) => () => new Shrinkable(e));
+): IterableIterator<Shrinkable<Ts>> {
+  yield* examples.map((e) => new Shrinkable(e));
   let idx = 0;
   let rng = random(seed);
   for (;;) {
     rng = rng.jump ? rng.jump() : prand.skipN(rng, 42);
-    yield lazyGenerate(generator, rng, idx++);
+    yield generator.generate(new Random(rng), idx++);
   }
 }

--- a/test/unit/check/runner/Tosser.spec.ts
+++ b/test/unit/check/runner/Tosser.spec.ts
@@ -27,7 +27,7 @@ describe('Tosser', () => {
             ...s
               .drop(start)
               .take(2)
-              .map((f) => f().value),
+              .map((f) => f.value),
           ];
           expect(g1).not.toStrictEqual(g2);
           return true;
@@ -39,11 +39,11 @@ describe('Tosser', () => {
           expect([
             ...stream(toss(wrap(stubArb.forward()), seed, prand.xorshift128plus, []))
               .take(num)
-              .map((f) => f().value),
+              .map((f) => f.value),
           ]).toStrictEqual([
             ...stream(toss(wrap(stubArb.forward()), seed, prand.xorshift128plus, []))
               .take(num)
-              .map((f) => f().value),
+              .map((f) => f.value),
           ]);
         })
       ));
@@ -55,9 +55,9 @@ describe('Tosser', () => {
           expect(
             onGoingItems2
               .reverse()
-              .map((f) => f().value)
+              .map((f) => f.value)
               .reverse()
-          ).toStrictEqual(onGoingItems1.map((f) => f().value));
+          ).toStrictEqual(onGoingItems1.map((f) => f.value));
         })
       ));
     it('Should offset toss with the provided examples', () =>
@@ -65,10 +65,10 @@ describe('Tosser', () => {
         fc.property(fc.integer(), fc.nat(20), fc.array(fc.integer()), (seed, num, examples) => {
           const noExamplesProvided = [
             ...stream(toss(wrap(stubArb.forward()), seed, prand.xorshift128plus, [])).take(num - examples.length),
-          ].map((f) => f().value);
+          ].map((f) => f.value);
           const examplesProvided = [
             ...stream(toss(wrap(stubArb.forward()), seed, prand.xorshift128plus, examples)).take(num),
-          ].map((f) => f().value);
+          ].map((f) => f.value);
           expect([...examples, ...noExamplesProvided].slice(0, num)).toStrictEqual(examplesProvided);
         })
       ));


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Several closures were built by fast-check each time we wanted to produce a value. They may come with a price, so let's try to remove them and see what will be the resulted performance improvement.
<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [x] Generated values: _no impact expected but as it changes the generate path it may impact anything passing through it_
- [ ] Shrink values
- [x] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
