### PR TITLE
🚀 create overload constantFrom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ deopt.out
 v8.log
 v8.out
 test/esm/**/out.txt
+.idea

--- a/src/arbitrary/constantFrom.ts
+++ b/src/arbitrary/constantFrom.ts
@@ -16,7 +16,19 @@ type Elem<T> = T extends any[] ? T[number] : T;
  * @public
  */
 function constantFrom<T>(...values: T[]): Arbitrary<T>;
+
+/**
+ * For one `...values` values - all equiprobable
+ *
+ * **WARNING**: It expects at least one value, otherwise it should throw
+ *
+ * @param values - Constant values to be produced (all values shrink to the first one)
+ *
+ * @remarks Since 0.0.12
+ * @public
+ */
 function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]>;
+
 function constantFrom<TArgs extends any[] | [any] | any>(...values: Arrayfy<TArgs>): Arbitrary<Elem<TArgs>> {
   if (values.length === 0) {
     throw new Error('fc.constantFrom expects at least one parameter');

--- a/src/arbitrary/constantFrom.ts
+++ b/src/arbitrary/constantFrom.ts
@@ -17,7 +17,7 @@ type Elem<T> = T extends any[] ? T[number] : T;
  * @remarks Since 0.0.12
  * @public
  */
-function constantFrom<T>(...values: T[]): Arbitrary<T>;
+function constantFrom<T = never>(...values: T[]): Arbitrary<T>;
 
 /**
  * For one `...values` values - all equiprobable

--- a/src/arbitrary/constantFrom.ts
+++ b/src/arbitrary/constantFrom.ts
@@ -2,14 +2,8 @@ import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { convertFromNext } from '../check/arbitrary/definition/Converters';
 import { ConstantArbitrary } from './_internals/ConstantArbitrary';
 
-/**
- * For one `...values` values - all equiprobable
- *
- * **WARNING**: It expects at least one value, otherwise it should throw
- *
- * @param values - Constant values to be produced (all values shrink to the first one)
- */
-function constantFrom<T>(...values: T[]): Arbitrary<T>;
+type Arrayfy<T> = T extends any[] ? T : T[];
+type Elem<T> = T extends any[] ? T[number] : T;
 
 /**
  * For one `...values` values - all equiprobable
@@ -21,11 +15,13 @@ function constantFrom<T>(...values: T[]): Arbitrary<T>;
  * @remarks Since 0.0.12
  * @public
  */
-function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]> {
+function constantFrom<T>(...values: T[]): Arbitrary<T>;
+function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]>;
+function constantFrom<TArgs extends any[] | [any] | any>(...values: Arrayfy<TArgs>): Arbitrary<Elem<TArgs>> {
   if (values.length === 0) {
     throw new Error('fc.constantFrom expects at least one parameter');
   }
-  return convertFromNext(new ConstantArbitrary(values));
+  return convertFromNext(new ConstantArbitrary(values)) as Arbitrary<Elem<TArgs>>;
 }
 
 export { constantFrom };

--- a/src/arbitrary/constantFrom.ts
+++ b/src/arbitrary/constantFrom.ts
@@ -2,7 +2,9 @@ import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { convertFromNext } from '../check/arbitrary/definition/Converters';
 import { ConstantArbitrary } from './_internals/ConstantArbitrary';
 
+/** @internal */
 type Arrayfy<T> = T extends any[] ? T : T[];
+/** @internal */
 type Elem<T> = T extends any[] ? T[number] : T;
 
 /**

--- a/src/arbitrary/constantFrom.ts
+++ b/src/arbitrary/constantFrom.ts
@@ -8,13 +8,24 @@ import { ConstantArbitrary } from './_internals/ConstantArbitrary';
  * **WARNING**: It expects at least one value, otherwise it should throw
  *
  * @param values - Constant values to be produced (all values shrink to the first one)
+ */
+function constantFrom<T>(...values: T[]): Arbitrary<T>;
+
+/**
+ * For one `...values` values - all equiprobable
+ *
+ * **WARNING**: It expects at least one value, otherwise it should throw
+ *
+ * @param values - Constant values to be produced (all values shrink to the first one)
  *
  * @remarks Since 0.0.12
  * @public
  */
-export function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]> {
+function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]> {
   if (values.length === 0) {
     throw new Error('fc.constantFrom expects at least one parameter');
   }
   return convertFromNext(new ConstantArbitrary(values));
 }
+
+export { constantFrom };


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->
Add constantFrom variant.
Now we can only create an arb that produces values like this.

```typescript
type Color = "white" | "black"

const arb = constantFrom<Color[]>("white", "black") // Arbitrary<Color>
```

But type parameter `Color[]` is not intuitive.
With this PR feature we can create an arb from simple type annotation.

```typescript
type Color = "white" | "black"

const arb = constantFrom<Color>("white", "black") // Arbitrary<Color>
```

> NOTE:
You cannot create union type of literal type arbs without a type annotation.
> ```typescript
> type Color = "white" | "black"
> 
> const arb = constantFrom("white", "black") // Arbitrary<string>
> ```

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [x] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [x] Typings
- [ ] _Other(s):_ ...
