### PR TITLE
🐛 Default reporter performed side-effects on the output

### DIFF
--- a/src/check/runner/utils/RunDetailsFormatter.ts
+++ b/src/check/runner/utils/RunDetailsFormatter.ts
@@ -26,7 +26,7 @@ function formatFailures<Ts>(failures: Ts[], stringifyOne: (value: Ts) => string)
 function formatExecutionSummary<Ts>(executionTrees: ExecutionTree<Ts>[], stringifyOne: (value: Ts) => string): string {
   const summaryLines: string[] = [];
   const remainingTreesAndDepth: { depth: number; tree: ExecutionTree<Ts> }[] = [];
-  for (const tree of executionTrees.reverse()) {
+  for (const tree of executionTrees.slice().reverse()) {
     remainingTreesAndDepth.push({ depth: 1, tree });
   }
   while (remainingTreesAndDepth.length !== 0) {
@@ -48,7 +48,7 @@ function formatExecutionSummary<Ts>(executionTrees: ExecutionTree<Ts>[], stringi
     summaryLines.push(`${leftPadding}${statusIcon} ${stringifyOne(currentTree.value)}`);
 
     // push its children to the queue
-    for (const tree of currentTree.children.reverse()) {
+    for (const tree of currentTree.children.slice().reverse()) {
       remainingTreesAndDepth.push({ depth: currentDepth + 1, tree });
     }
   }


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

The default formatter used within fast-check was performing side-effects onto the execution summary. Hopefully most of the time users are either relying on `fc.check` and manually format the error on their own or rely on `fc.assert` which uses the default formatter but never re-uses the execution summary afterwards.

In the case of a manual formatter, users might rely on the default formatter so could probably be impacted.

Very limited impact expected as most of the users rely on `fc.assert` or fully custom handling.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
