### PR TITLE
✨ Add template string arbitrary as sugar for mapping a tuple

### DIFF
--- a/src/arbitrary/template-string.ts
+++ b/src/arbitrary/template-string.ts
@@ -1,0 +1,36 @@
+import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
+import { convertFromNext, convertToNext } from '../check/arbitrary/definition/Converters';
+import { constant } from './constant';
+import { TupleArbitrary } from './_internals/TupleArbitrary';
+export { StringSharedConstraints } from './_internals/helpers/StringConstraintsExtractor';
+
+/**
+ * Zip the inputs of a tagged template and transform them with a function.
+ * @remarks `first` is assumed to always have one more item than `second`
+ */
+const zipTemplateAndMap =
+  <A, B>(fn: (a: A) => B) =>
+  (first: Array<A>, second: Array<A>): Array<B> => {
+    const sum = [] as Array<B>;
+    for (let i = 0; i < second.length; i++) {
+      sum.push(fn(first[i]));
+      sum.push(fn(second[i]));
+    }
+    sum.push(fn(first[first.length - 1]));
+    return sum;
+  };
+
+const constantArb = <T>(arb: T) => constant(arb);
+const interpolate = (val: unknown) => `${val}`;
+const joinStrings = (strings: Array<string>) => strings.join('');
+
+const zipStrings = zipTemplateAndMap(<T>(arb: Arbitrary<T>) => convertToNext(arb.map(interpolate)));
+
+/**
+ * For strings produced by interpolating the provided `arbs`
+ * @public
+ */
+export function templateString(strings: TemplateStringsArray, ...arbs: Array<Arbitrary<unknown>>): Arbitrary<string> {
+  const nextArbs = zipStrings(strings.map(constantArb), arbs);
+  return convertFromNext(new TupleArbitrary(nextArbs).map(joinStrings));
+}

--- a/test/unit/arbitrary/template-string.spec.ts
+++ b/test/unit/arbitrary/template-string.spec.ts
@@ -1,0 +1,31 @@
+import { anything } from '../../../src/arbitrary/anything';
+import { constant } from '../../../src/arbitrary/constant';
+import { templateString } from '../../../src/arbitrary/template-string';
+import { tuple } from '../../../src/arbitrary/tuple';
+import { property } from '../../../src/check/property/Property';
+import { assert } from '../../../src/check/runner/Runner';
+import { sample } from '../../../src/check/runner/Sampler';
+
+describe('template string', () => {
+  it('should interpolate constant strings', () => {
+    expect(sample(templateString`foo`, 1)[0]).toStrictEqual('foo');
+    expect(sample(templateString`foo${constant('bar')}`, 1)[0]).toStrictEqual('foobar');
+    expect(sample(templateString`${constant('foo')}bar`, 1)[0]).toStrictEqual('foobar');
+    expect(sample(templateString`foo${constant('bar')}baz`, 1)[0]).toStrictEqual('foobarbaz');
+  });
+
+  it('should interpolate values into strings identically to untagged template strings', () => {
+    assert(
+      property(
+        anything().chain((value) => tuple(templateString`${constant(value)}`, constant(`${value}`))),
+        ([templated, interpolated]) => expect(templated).toBe(interpolated)
+      )
+    );
+  });
+
+  it('should fail for uninterpolatable values', () => {
+    expect(() => sample(templateString`${constant(Symbol())}`)[0]).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot convert a Symbol value to a string"`
+    );
+  });
+});


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

This PR adds a new arbitrary that lets you use a template string to interpolate arbitraries.

e.g.

```javascript
fc.templateString`Hello ${fc.string()}, my name is ${fc.string()}!`
```

It's equivalent to:
```javascript
fc.tuple(fc.string(), fc.string()).map(([guest, host]) => `Hello ${guest}, my name is ${host}!`)
```

Do you think this is valuable, or is it needless sugar?

If you think it's useful I'm happy to add some documentation, ala
https://github.com/dubzzz/fast-check/blob/main/documentation/Arbitraries.md#string

I don't fully understand what `convertToNext` does, but I took the implementation largely from
`src/arbitrary/tuple.ts`.

The tests don't look much like the other unit tests for arbitraries, so I'm happy to rewrite them!
Please let me know if you have any questions!

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
