### PR TITLE
💚 Reduce the maximal minLength requested in tests

### DIFF
--- a/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
+++ b/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
@@ -132,7 +132,7 @@ describe('typedIntArrayArbitraryArbitraryBuilder (integration)', () => {
   const extraParameters: fc.Arbitrary<Extra> = fc
     .record(
       {
-        minLength: fc.nat({ max: 25 }),
+        minLength: fc.nat({ max: 5 }),
         maxLength: fc.nat({ max: 25 }),
         min: fc.integer({ min: -128, max: 127 }),
         max: fc.integer({ min: -128, max: 127 }),

--- a/test/unit/arbitrary/array.spec.ts
+++ b/test/unit/arbitrary/array.spec.ts
@@ -166,7 +166,7 @@ describe('array', () => {
 describe('array (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/asciiString.spec.ts
+++ b/test/unit/arbitrary/asciiString.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('asciiString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/base64String.spec.ts
+++ b/test/unit/arbitrary/base64String.spec.ts
@@ -24,7 +24,7 @@ describe('base64String', () => {
   it('should accept any constraints accepting at least one length multiple of 4', () =>
     fc.assert(
       fc.property(
-        fc.nat({ max: 30 }),
+        fc.nat({ max: 5 }),
         fc.integer({ min: 3, max: 30 }),
         fc.boolean(),
         fc.boolean(),

--- a/test/unit/arbitrary/float32Array.spec.ts
+++ b/test/unit/arbitrary/float32Array.spec.ts
@@ -22,7 +22,7 @@ describe('float32Array (integration)', () => {
   const extraParameters: fc.Arbitrary<Extra> = fc
     .record(
       {
-        minLength: fc.nat({ max: 25 }),
+        minLength: fc.nat({ max: 5 }),
         maxLength: fc.nat({ max: 25 }),
         min: fc.float({ next: true, noDefaultInfinity: true, noNaN: true }),
         max: fc.float({ next: true, noDefaultInfinity: true, noNaN: true }),

--- a/test/unit/arbitrary/float64Array.spec.ts
+++ b/test/unit/arbitrary/float64Array.spec.ts
@@ -22,7 +22,7 @@ describe('float64Array (integration)', () => {
   const extraParameters: fc.Arbitrary<Extra> = fc
     .record(
       {
-        minLength: fc.nat({ max: 25 }),
+        minLength: fc.nat({ max: 5 }),
         maxLength: fc.nat({ max: 25 }),
         min: fc.double({ next: true, noDefaultInfinity: true, noNaN: true }),
         max: fc.double({ next: true, noDefaultInfinity: true, noNaN: true }),

--- a/test/unit/arbitrary/fullUnicodeString.spec.ts
+++ b/test/unit/arbitrary/fullUnicodeString.spec.ts
@@ -14,7 +14,7 @@ import { buildNextShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 describe('fullUnicodeString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/hexaString.spec.ts
+++ b/test/unit/arbitrary/hexaString.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('hexaString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/set.spec.ts
+++ b/test/unit/arbitrary/set.spec.ts
@@ -285,7 +285,7 @@ describe('set', () => {
 describe('set (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/sparseArray.spec.ts
+++ b/test/unit/arbitrary/sparseArray.spec.ts
@@ -197,7 +197,9 @@ function validSparseArrayConstraints(
     .record(
       {
         maxLength: removedKeys.includes('maxLength') ? fc.constant(undefined) : fc.nat({ max }),
-        minNumElements: removedKeys.includes('minNumElements') ? fc.constant(undefined) : fc.nat({ max }),
+        minNumElements: removedKeys.includes('minNumElements')
+          ? fc.constant(undefined)
+          : fc.nat({ max: max !== undefined ? Math.min(5, max) : undefined }),
         maxNumElements: removedKeys.includes('maxNumElements') ? fc.constant(undefined) : fc.nat({ max }),
         noTrailingHole: removedKeys.includes('noTrailingHole') ? fc.constant(undefined) : fc.boolean(),
       },

--- a/test/unit/arbitrary/string.spec.ts
+++ b/test/unit/arbitrary/string.spec.ts
@@ -14,7 +14,7 @@ import { buildNextShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 describe('string (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/string16bits.spec.ts
+++ b/test/unit/arbitrary/string16bits.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('string16bits (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,

--- a/test/unit/arbitrary/stringOf.spec.ts
+++ b/test/unit/arbitrary/stringOf.spec.ts
@@ -16,7 +16,7 @@ describe('stringOf (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number; patterns: string[] };
   const extraParameters: fc.Arbitrary<Extra> = fc
     .tuple(
-      fc.nat({ max: 30 }),
+      fc.nat({ max: 5 }),
       fc.nat({ max: 30 }),
       fc.boolean(),
       fc.boolean(),

--- a/test/unit/arbitrary/unicodeString.spec.ts
+++ b/test/unit/arbitrary/unicodeString.spec.ts
@@ -12,7 +12,7 @@ import {
 describe('unicodeString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
   const extraParameters: fc.Arbitrary<Extra> = fc
-    .tuple(fc.nat({ max: 30 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
+    .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
     .map(([min, gap, withMin, withMax]) => ({
       minLength: withMin ? min : undefined,
       maxLength: withMax ? min + gap : undefined,


### PR DESCRIPTION
Requesting a large value for `minLength` results in long shrink paths. It does not adds so much value at the end except being longer to run. We reduce the maximal value of most of the tests to 5 (instead of 25).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
