### PR TITLE
✅ Avoid Error tags in reports caused by some tests

### DIFF
--- a/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
+++ b/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
@@ -21,15 +21,15 @@ describe('IgnoreEqualValuesProperty', () => {
   });
 
   it.each`
-    originalValue                           | isAsync
-    ${null /* success */}                   | ${false}
-    ${'error' /* failure */}                | ${false}
-    ${new PreconditionFailure() /* skip */} | ${false}
-    ${null /* success */}                   | ${true}
-    ${'error' /* failure */}                | ${true}
-    ${new PreconditionFailure() /* skip */} | ${true}
+    originalValue                           | originalValuePretty            | isAsync
+    ${null /* success */}                   | ${'null'}                      | ${false}
+    ${'error' /* failure */}                | ${'"error"'}                   | ${false}
+    ${new PreconditionFailure() /* skip */} | ${'new PreconditionFailure()'} | ${false}
+    ${null /* success */}                   | ${'null'}                      | ${true}
+    ${'error' /* failure */}                | ${'"error"'}                   | ${true}
+    ${new PreconditionFailure() /* skip */} | ${'new PreconditionFailure()'} | ${true}
   `(
-    'should always return the cached value for skipRuns=false, originalValue=$originalValue, isAsync=$isAsync',
+    'should always return the cached value for skipRuns=false, originalValue=$originalValuePretty, isAsync=$isAsync',
     ({ originalValue, isAsync }) => {
       // Arrange
       // success -> success
@@ -49,15 +49,15 @@ describe('IgnoreEqualValuesProperty', () => {
   );
 
   it.each`
-    originalValue                           | isAsync
-    ${null /* success */}                   | ${false}
-    ${'error' /* failure */}                | ${false}
-    ${new PreconditionFailure() /* skip */} | ${false}
-    ${null /* success */}                   | ${true}
-    ${'error' /* failure */}                | ${true}
-    ${new PreconditionFailure() /* skip */} | ${true}
+    originalValue                           | originalValuePretty            | isAsync
+    ${null /* success */}                   | ${'null'}                      | ${false}
+    ${'error' /* failure */}                | ${'"error"'}                   | ${false}
+    ${new PreconditionFailure() /* skip */} | ${'new PreconditionFailure()'} | ${false}
+    ${null /* success */}                   | ${'null'}                      | ${true}
+    ${'error' /* failure */}                | ${'"error"'}                   | ${true}
+    ${new PreconditionFailure() /* skip */} | ${'new PreconditionFailure()'} | ${true}
   `(
-    'should return the cached value but skip success for skipRuns=true, originalValue=$originalValue, isAsync=$isAsync',
+    'should return the cached value but skip success for skipRuns=true, originalValue=$originalValuePretty, isAsync=$isAsync',
     async ({ originalValue, isAsync }) => {
       // Arrange
       // success -> skip


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

`it.each` was printing red **Error** tags whenever we asked it to stringify an instance of error. We just avoid doing that so that our logs will be cleaner.

![image](https://user-images.githubusercontent.com/5300235/140196654-2f87279a-5c0c-4a37-b34e-99119edccf17.png)

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
