### PR TITLE
🏷️ More precise typing for `jsonObject` and related

### DIFF
--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -46,8 +46,22 @@ export function jsonConstraintsBuilder(
 }
 
 /**
+ * Typings for a Json array
+ * @remarks Since 2.20.0
+ * @internal
+ */
+interface JsonArray extends Array<JsonValue> {}
+
+/**
+ * Typings for a Json object
+ * @remarks Since 2.20.0
+ * @internal
+ */
+type JsonObject = { [key in string]?: JsonValue };
+
+/**
  * Typings for a Json value
  * @remarks Since 2.20.0
  * @public
  */
-export type JsonValue = boolean | number | string | null | JsonValue[] | { [key in string]?: JsonValue };
+export type JsonValue = boolean | number | string | null | JsonArray | JsonObject;

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -44,3 +44,22 @@ export function jsonConstraintsBuilder(
       : { key, values, maxDepth: constraints.maxDepth }
     : { key, values };
 }
+
+/**
+ * Typings for a Json object
+ * @internal
+ */
+type JsonObject = { [key in string]?: JsonValue };
+
+/**
+ * Typings for a Json array
+ * @internal
+ */
+type JsonArray = JsonValue[];
+
+/**
+ * Typings for a Json value
+ * @remarks Since 2.20.0
+ * @public
+ */
+export type JsonValue = boolean | number | string | null | JsonArray | JsonObject;

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -46,20 +46,8 @@ export function jsonConstraintsBuilder(
 }
 
 /**
- * Typings for a Json object
- * @internal
- */
-type JsonObject = { [key in string]?: JsonValue };
-
-/**
- * Typings for a Json array
- * @internal
- */
-type JsonArray = JsonValue[];
-
-/**
  * Typings for a Json value
  * @remarks Since 2.20.0
  * @public
  */
-export type JsonValue = boolean | number | string | null | JsonArray | JsonObject;
+export type JsonValue = boolean | number | string | null | JsonValue[] | { [key in string]?: JsonValue };

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -48,16 +48,16 @@ export function jsonConstraintsBuilder(
 /**
  * Typings for a Json array
  * @remarks Since 2.20.0
- * @internal
+ * @public
  */
-interface JsonArray extends Array<JsonValue> {}
+export interface JsonArray extends Array<JsonValue> {}
 
 /**
  * Typings for a Json object
  * @remarks Since 2.20.0
- * @internal
+ * @public
  */
-type JsonObject = { [key in string]?: JsonValue };
+export type JsonObject = { [key in string]?: JsonValue };
 
 /**
  * Typings for a Json value

--- a/src/arbitrary/jsonObject.ts
+++ b/src/arbitrary/jsonObject.ts
@@ -1,9 +1,9 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { string } from './string';
-import { jsonConstraintsBuilder, JsonSharedConstraints } from './_internals/helpers/JsonConstraintsBuilder';
+import { jsonConstraintsBuilder, JsonSharedConstraints, JsonValue } from './_internals/helpers/JsonConstraintsBuilder';
 import { anything } from './anything';
 
-export { JsonSharedConstraints };
+export { JsonSharedConstraints, JsonValue };
 
 /**
  * For any JSON compliant values
@@ -16,7 +16,7 @@ export { JsonSharedConstraints };
  * @remarks Since 1.2.3
  * @public
  */
-function jsonObject(): Arbitrary<unknown>;
+function jsonObject(): Arbitrary<JsonValue>;
 /**
  * For any JSON compliant values with a maximal depth
  *
@@ -34,7 +34,7 @@ function jsonObject(): Arbitrary<unknown>;
  * @remarks Since 1.2.3
  * @public
  */
-function jsonObject(maxDepth: number): Arbitrary<unknown>;
+function jsonObject(maxDepth: number): Arbitrary<JsonValue>;
 /**
  * For any JSON compliant values
  *
@@ -48,8 +48,8 @@ function jsonObject(maxDepth: number): Arbitrary<unknown>;
  * @remarks Since 2.5.0
  * @public
  */
-function jsonObject(constraints: JsonSharedConstraints): Arbitrary<unknown>;
-function jsonObject(constraints?: number | JsonSharedConstraints): Arbitrary<unknown> {
-  return anything(jsonConstraintsBuilder(string(), constraints));
+function jsonObject(constraints: JsonSharedConstraints): Arbitrary<JsonValue>;
+function jsonObject(constraints?: number | JsonSharedConstraints): Arbitrary<JsonValue> {
+  return anything(jsonConstraintsBuilder(string(), constraints)) as Arbitrary<JsonValue>;
 }
 export { jsonObject };

--- a/src/arbitrary/unicodeJsonObject.ts
+++ b/src/arbitrary/unicodeJsonObject.ts
@@ -1,9 +1,9 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { unicodeString } from './unicodeString';
-import { jsonConstraintsBuilder, JsonSharedConstraints } from './_internals/helpers/JsonConstraintsBuilder';
+import { jsonConstraintsBuilder, JsonSharedConstraints, JsonValue } from './_internals/helpers/JsonConstraintsBuilder';
 import { anything } from './anything';
 
-export { JsonSharedConstraints };
+export { JsonSharedConstraints, JsonValue };
 
 /**
  * For any JSON compliant values with unicode support
@@ -16,7 +16,7 @@ export { JsonSharedConstraints };
  * @remarks Since 1.2.3
  * @public
  */
-function unicodeJsonObject(): Arbitrary<unknown>;
+function unicodeJsonObject(): Arbitrary<JsonValue>;
 /**
  * For any JSON compliant values with unicode support and a maximal depth
  *
@@ -34,7 +34,7 @@ function unicodeJsonObject(): Arbitrary<unknown>;
  * @remarks Since 1.2.3
  * @public
  */
-function unicodeJsonObject(maxDepth: number): Arbitrary<unknown>;
+function unicodeJsonObject(maxDepth: number): Arbitrary<JsonValue>;
 /**
  * For any JSON compliant values with unicode support
  *
@@ -48,8 +48,8 @@ function unicodeJsonObject(maxDepth: number): Arbitrary<unknown>;
  * @remarks Since 2.5.0
  * @public
  */
-function unicodeJsonObject(constraints: JsonSharedConstraints): Arbitrary<unknown>;
-function unicodeJsonObject(constraints?: number | JsonSharedConstraints): Arbitrary<unknown> {
-  return anything(jsonConstraintsBuilder(unicodeString(), constraints));
+function unicodeJsonObject(constraints: JsonSharedConstraints): Arbitrary<JsonValue>;
+function unicodeJsonObject(constraints?: number | JsonSharedConstraints): Arbitrary<JsonValue> {
+  return anything(jsonConstraintsBuilder(unicodeString(), constraints)) as Arbitrary<JsonValue>;
 }
 export { unicodeJsonObject };

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -67,7 +67,7 @@ import { object, ObjectConstraints } from './arbitrary/object';
 import { json, JsonSharedConstraints } from './arbitrary/json';
 import { anything } from './arbitrary/anything';
 import { unicodeJsonObject } from './arbitrary/unicodeJsonObject';
-import { jsonObject } from './arbitrary/jsonObject';
+import { jsonObject, JsonValue } from './arbitrary/jsonObject';
 import { unicodeJson } from './arbitrary/unicodeJson';
 import { oneof, OneOfValue, OneOfConstraints } from './arbitrary/oneof';
 import { option, OptionConstraints } from './arbitrary/option';
@@ -392,6 +392,7 @@ export {
   DedupValue,
   FalsyValue,
   FrequencyValue,
+  JsonValue,
   OneOfValue,
   RecordValue,
   // arbitrary types (mostly when produced values are difficult to formalize)


### PR DESCRIPTION
As suggested by #2135, let's offer a better typing on `jsonObject` and related. So far, I still have one `as` to keep but I hope to remove it once we get simpler inputs for the builder of arbitraries of "type any".

Fixes #2135

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [x] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [x] Typings
- [ ] _Other(s):_ ...
