### PR TITLE
🔊 Warn users earlier for wrong params on `integer`

### DIFF
--- a/src/arbitrary/integer.ts
+++ b/src/arbitrary/integer.ts
@@ -98,6 +98,12 @@ function integer(
   if (constraints.min > constraints.max) {
     throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
   }
+  if (!Number.isInteger(constraints.min)) {
+    throw new Error('fc.integer minimum value should be an integer');
+  }
+  if (!Number.isInteger(constraints.max)) {
+    throw new Error('fc.integer maximum value should be an integer');
+  }
   const arb = new IntegerArbitrary(constraints.min, constraints.max);
   return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }

--- a/src/arbitrary/nat.ts
+++ b/src/arbitrary/nat.ts
@@ -46,6 +46,9 @@ function nat(arg?: number | NatConstraints): ArbitraryWithContextualShrink<numbe
   if (max < 0) {
     throw new Error('fc.nat value should be greater than or equal to 0');
   }
+  if (!Number.isInteger(max)) {
+    throw new Error('fc.nat maximum value should be an integer');
+  }
   const arb = new IntegerArbitrary(0, max);
   return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }

--- a/test/unit/arbitrary/integer.spec.ts
+++ b/test/unit/arbitrary/integer.spec.ts
@@ -162,4 +162,24 @@ describe('integer', () => {
         expect(() => integer({ min: high, max: low })).toThrowError();
       })
     ));
+
+  it('should throw when minimum value or maximum value is not an integer', () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(
+          fc.tuple(fc.maxSafeInteger(), fc.double({ next: true })),
+          fc.tuple(fc.double({ next: true }), fc.double({ next: true }))
+        ),
+        ([a, b]) => {
+          // Arrange
+          fc.pre(!Number.isInteger(a) || !Number.isInteger(b));
+          fc.pre(a !== b);
+          const [low, high] = a < b ? [a, b] : [b, a];
+
+          // Act / Assert
+          expect(() => integer({ min: low, max: high })).toThrowError();
+        }
+      )
+    );
+  });
 });

--- a/test/unit/arbitrary/nat.spec.ts
+++ b/test/unit/arbitrary/nat.spec.ts
@@ -89,4 +89,16 @@ describe('nat', () => {
         expect(() => nat({ max })).toThrowError();
       })
     ));
+
+  it('should throw when maximum value is not an integer', () => {
+    fc.assert(
+      fc.property(fc.double({ next: true }), (max) => {
+        // Arrange
+        fc.pre(!Number.isInteger(max));
+
+        // Act / Assert
+        expect(() => nat({ max })).toThrowError();
+      })
+    );
+  });
 });


### PR DESCRIPTION
Let's adopt something better than what we have today. As said in comment https://github.com/dubzzz/fast-check/issues/2038#issuecomment-918885358, there is no fully bulletproof way to check that the values will able to work. Values outside of the safe range can fail but can also work.

Fixes #2038

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
