### PR TITLE
✏️ Documentation fix for `fc.oneof`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2128,7 +2128,7 @@ fc.option(fc.string(), { nil: undefined })
 *&#8195;Signatures*
 
 - `fc.oneof(...arbitraries)`
-- `fc.oneof({withCrossShrink?, maxDepth?, depthIdentifier?}, ...{ arbitrary, weight })`
+- `fc.oneof({withCrossShrink?, maxDepth?, depthIdentifier?}, ...arbitraries)`
 
 *&#8195;with:*
 


### PR DESCRIPTION
`fc.oneof` function does not take weighted arbitraries as the documentation states, so I proposed a correction.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [x] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ ...
Should have no impact beyond an updated documentation
