### PR TITLE
✨ `depthFactor` on arbitraries for objects

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -998,11 +998,12 @@ fc.stringOf(fc.constantFrom('Hello', 'World'), {minLength: 1, maxLength: 3})
 *&#8195;Signatures*
 
 - `fc.json()`
-- `fc.json({maxDepth?})`
+- `fc.json({depthFactor?, maxDepth?})`
 - _`fc.json(maxDepth)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -1044,11 +1045,12 @@ fc.json({maxDepth: 1})
 *&#8195;Signatures*
 
 - `fc.unicodeJson()`
-- `fc.unicodeJson({maxDepth?})`
+- `fc.unicodeJson({depthFactor?, maxDepth?})`
 - _`fc.unicodeJson(maxDepth)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -2757,11 +2759,12 @@ fc.record({
 *&#8195;Signatures*
 
 - `fc.object()`
-- `fc.object({key?, maxDepth?, maxKeys?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
+- `fc.object({key?, depthFactor?, maxDepth?, maxKeys?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
 
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `5` — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `withBigInt?` — default: `false` — _enable `bigint` - eg.: `1n`_
@@ -2838,6 +2841,19 @@ fc.object({
 // • {"};;j/k&2T":{"new Date(\"+220664-08-31T16:38:43.894Z\")":-2289144276660280,"cXLsbV S":1138144113824397},"teD^Ev":"[new Number(-1.5364199974582094e+205),new Number(5.180815866347032e+247),new Number(3.636439525223476e-281)]","!#(o3t":{"1vv":undefined,"wH{;tJ":null},"k{Xkv":{},"":new Set([]),"}":{"false":{"2995845410082023":true,"kV}Hc*yU,.":true,";Wznpcq":false,"&CH+'X":false}},"6W,~y/":new Date("-211027-11-03T15:54:15.338Z"),"ndQOiBz":{}}
 // • {"RrAs^,;_'d":new Set([]),"cx:<rwea":"new Date(\"+020332-01-16T05:46:46.152Z\")","":Object.assign(Object.create(null),{"L'jRbo{j":-31976587169846070239654687470021029877524367311417431076643014306029456266120n,"';}PmFHH![":Float64Array.from([-8.018908485009337e+30,8.496864005059645e+201,-3.9194568152035106e+268,-3.086464372465133e+126,3.7461513350649476e+307,1.8080540145972749e-16,-3.302613637232917e-16,2.919782715590315e-98,5.497279242648775e-209]),"<!a}uk":Object.assign(Object.create(null),{"h!+#q":new Number(-2.201858778700874e-229),"-1.2569260788236659e-20":new Number(-7.614430918991341e-292),"fY*":new Number(-5.6031793388037794e+178),"=v{~S":new Number(1.0861583449836279e-82)}),"3ine":[new Boolean(false),false]})}
 // • …
+
+fc.object({
+  depthFactor: 0.1,
+  maxDepth: 1000,
+})
+// Note: For the moment, we have to specify maxDepth to avoid falling back onto its default value
+// Examples of generated values:
+// • {"#$!":[-6284333281935340],"rfzf":{"\"!`":-1.909234660360722e+235},"{}a~":[]}
+// • {"eE:":[-8.95172863816096e-249,-3.288461904004645e+282],"4s{$4":{"{/$^Sz":"*4"},"|y)-$J":false,"Ai%":[3.538086683290918e-47],"[":[true,true,false,false],"X5BF[d6&'I":[],"H9 :My":[],"[waR\\H":[{"L4xCzK":4132248318901977,"0[x5DB":true,"y":{"Ykx#K!":["","j=Mg%",""],"D lxo>e1":{"":-3.2491742827673436e+204,"m}-tBgvv4\"":-2.6247571723139775e+205,",{*":2.9035310672004322e+206,"~":-1.710487457996338e-260},"\\_k":{"V)sp>=C":" x6","Swj":"(","#<VDu[":"gL","^1b_":"(+m"}},"vw'bGz":[-1.120167166012887e-197]},{"jvn":false,"v|(:db":true,"":true},"d3S ",{"yluHsgJ}s":undefined,"(h$)2]Pk4}":"OK ","nq":undefined,"+y^*.ov9,":undefined}]}
+// • {"0":[2.6703788454731695e+117,-1.6285761065806155e+41,-4.520334174621359e-56,1.492553358044542e+214],"{1Z\\sxWae_":[2565154082148461,8302012241278541,-1390788262228714],"[#.'O/ly;Y":{",cx`iZ":7119745345023617,"j":457026501372385,"=Y":-8910772974540265,"().1Dd^":3683425995195221},"":{",0T":839214944033725,"n8cu]":-2390850956257159,"vkg%(B{5Vv":2876244094548489},"ehE>h-C":[{"#b$Yu6:^O[":[{"x7FG&:":"sWH(=2\\5}","QEb9T":undefined,"{M=x1 ":"_m2"},[true],"5Wo",[null,"",""],{"vcg\"nZ%?ne":{"FiVp:W;":-3.096943297573584e+46,"e3/YX,+4z,":-3.499884681652477e-94,";u":1.1081655059865526e+222,"'@O":-1.9771446652696e-98},"c,0QZ|":[],"":{"B%l{POF":2.517622513383714e+185,"_E236z":-9.365880577754715e-216,"J<SO3":2.892270139519411e-20},"1j":[";4W$z'G-/R",{"IY:y=vzGR":-1.5331683125242364e+82,"a1":-7.368585047763132e-67,"<[/":2.5398091144876033e+88},{},["xp%4","c)WYY","\"35woC","f","&7"],{"(Qf(GZ":"&IM$<]I","d:`":"Y^bL:Od%t","-pVb":"JD!HJAj8\"e","oLQ/h-k,":"aeFafS*}","":"g\"'cJ]-)RS"}]}],"D":{":t_xR,nU":3.7663289884259713e+99,"0C0E7{^":-3.1206201241376693e-93,"":6.04818821701892e+142},"S5":[],"A|.~EX\"(0":"gx"},[{}],{},"3fs0mb9"],"PyTK-2-ecs":{"x":4735433617528581,"@_":{".Csd=UQ":{"MB%}47!\"":9.366687842298366e-178,"F\"`-zN":2.3420168472347057e-241,"uM":4.6277351388165825e-156,"|{":-1.0109916072104198e+114},"~7h&Ap":">_~!","'qs&gG<n":["Q","g5lDpx\\T","4B&v\\j",undefined,"`L[a:ka"],"ti\\q6Iz.w":-2031288555963222},">":[undefined]},"Y\"Qx4&[:d":{},"Q":{"Yc":{"0":"fs[ ","":"c2g T1c>cu","X5(Swxt":"m["},"^D+1-#+V":{"3f&ZRS":false,"Ob":false},"N":["#{",[""],4.228004803697316e-259]},"-U-scsErAG":{"":true,"~":false,"un()":true,"\\_Kj^":true}}
+// • {"M\\ ":{"2F2SCMM>4R":"E","ahq=S|5pS":undefined,"N5<VQ":undefined},"\"|z!":{"p":undefined},"^jk":[-6.76864040582647e-62]}
+// • {"% ":[{},[]],"":{"/":[[]]},"aSC0":[-1.2027554126668666e+206,-2.2823599405296565e+32]}
+// • …
 ```
 </details>
 
@@ -2856,11 +2872,12 @@ fc.object({
 *&#8195;Signatures*
 
 - `fc.jsonObject()`
-- `fc.jsonObject({maxDepth?})`
+- `fc.jsonObject({depthFactor?, maxDepth?})`
 - _`fc.jsonObject(maxDepth)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -2904,11 +2921,12 @@ fc.jsonObject({maxDepth: 1})
 *&#8195;Signatures*
 
 - `fc.unicodeJsonObject()`
-- `fc.unicodeJsonObject({maxDepth?})`
+- `fc.unicodeJsonObject({depthFactor?, maxDepth?})`
 - _`fc.unicodeJsonObject(maxDepth)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -2941,11 +2959,12 @@ fc.unicodeJsonObject({maxDepth: 1})
 *&#8195;Signatures*
 
 - `fc.anything()`
-- `fc.anything({key?, maxDepth?, maxKeys?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
+- `fc.anything({key?, depthFactor?, maxDepth?, maxKeys?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
 
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
+- `depthFactor?` — default: `0` — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `5` — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `withBigInt?` — default: `false` — _enable `bigint` - eg.: `1n`_
@@ -3012,6 +3031,13 @@ fc.anything({
 // • new Set([])
 // • Int32Array.from([-1929856236])
 // • …
+
+fc.anything({
+  depthFactor: 0.1,
+  maxDepth: 1000,
+})
+// Note: For the moment, we have to specify maxDepth to avoid falling back onto its default value
+// Examples of generated values: "<M3<BDD", [[],{"IKoG7_ji":{"\\`~@":true,"g2Yf57C-[":true}},[false],-3.324808399720659e+44], [""], true, -1.0395574284395397e-83…
 ```
 </details>
 

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2938,8 +2938,8 @@ fc.jsonObject({depthFactor: 1})
 // Examples of generated values:
 // • false
 // • {"Z}%Y .":-4.3433701524965336e-129}
-// • {"_J":{"16\\g'vAG":null,"l[+":null},"RA]{n":[],"":{"M":true,"D$vc~":true,">r:":false},"A1xkeCSV":[1.9895949472513747e+93,-8012385929821.01]}
-// • {"0":[null],",}Xl":[1.2e-322,true,true,true]}
+// • {"_J":true," 16\\g'":[true,true,false,true],"A]{nM\\iw<":true,"M":{"7":true,"c~&`>r:":false,"A1xkeCSV":true,"U8q#$g":true,",7b3":true}}
+// • {"0":-1.797693134862306e+308,"I,}Xl":[1.2e-322,true,true,true]}
 // • ["Sk%","*"]
 // • …
 ```
@@ -3001,7 +3001,7 @@ fc.unicodeJsonObject({depthFactor: 0.1})
 fc.unicodeJsonObject({depthFactor: 1})
 // Examples of generated values:
 // • [1.1219945151091497e+195,3.1543268721301525e+101,1.8992521576017034e-284]
-// • {"滢ⴛ瑖㻡ꎾ쾻":[null,null,null,null],"黦넅￰ᗰﾐ'":[1.7976931348623081e+308],"⺓졆ό䌈諐":-9.005091069307619e-302}
+// • {"滢ⴛ瑖㻡ꎾ쾻":"","&":{"ﾐ䉤᫔㈧":"돦","/￶ ":null,"흷씖*!":-6.231586447634778e+81,"옱ຈ睺䝛㉪⢟":-1.7976931348623083e+308},"":null}
 // • [null]
 // • null
 // • []

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2916,15 +2916,6 @@ fc.jsonObject({maxDepth: 1})
 // • {}
 // • …
 
-fc.jsonObject({depthFactor: 0.01, maxDepth: 1000})
-// Examples of generated values:
-// • 1.632639383041831e-286
-// • [[],{"IKoG7_ji":{"\\`~@":1.1383666559247216e-218,"2Yf5":3.1096726241025258e-294}},{},[null,{"/i3W\"FS":[]}]]
-// • [""]
-// • null
-// • -1.0395574284395395e-83
-// • …
-
 fc.jsonObject({depthFactor: 0.1})
 // Examples of generated values:
 // • 2.6e-322
@@ -2932,15 +2923,6 @@ fc.jsonObject({depthFactor: 0.1})
 // • -1e-322
 // • {"wnP-!E%SNp":"Cu2[ '}","}t":"u"}
 // • {"!(":{"ldvae;X":6.618751109058961e+41,"(bvLV5Q":4.163017031290256e+162,"K\"F":1.5339457181496153e+35,"o<|c":-1.3214581486561883e-288,"8< bZ] DP":-6003430007757.388},",":{}}
-// • …
-
-fc.jsonObject({depthFactor: 1})
-// Examples of generated values:
-// • false
-// • {"Z}%Y .":-4.3433701524965336e-129}
-// • {"_J":true," 16\\g'":[true,true,false,true],"A]{nM\\iw<":true,"M":{"7":true,"c~&`>r:":false,"A1xkeCSV":true,"U8q#$g":true,",7b3":true}}
-// • {"0":-1.797693134862306e+308,"I,}Xl":[1.2e-322,true,true,true]}
-// • ["Sk%","*"]
 // • …
 ```
 </details>
@@ -2986,9 +2968,6 @@ fc.unicodeJsonObject({maxDepth: 1})
 // • [null]
 // • …
 
-fc.unicodeJsonObject({depthFactor: 0.01, maxDepth: 1000})
-// Examples of generated values: null, "憞", {"+":null,"䤌抵":null,"㞔踏⫫ওᠶ䧁㩦":null,"&,%ბꧧ蛶":null,"":null}, {}, []…
-
 fc.unicodeJsonObject({depthFactor: 0.1})
 // Examples of generated values:
 // • "荽醮郺旽粈㈾"
@@ -2996,15 +2975,6 @@ fc.unicodeJsonObject({depthFactor: 0.1})
 // • false
 // • {" 㲉䑝*":[false]}
 // • {"":{"":false,"霵":2.2e-322,"￵":4e-323},"-\"者":{"봋":true,"윂ꎽ〚Ꮳ㟺㙰㒈♖暶ጼ":false},"㴴몖":{"谔挴欋킆醴殒ꬖ캩":null,"":"䎕쳳ᆰ"},"#귯໢ഐꃒ礖(&頫":[null,null,null,null,null]}
-// • …
-
-fc.unicodeJsonObject({depthFactor: 1})
-// Examples of generated values:
-// • [1.1219945151091497e+195,3.1543268721301525e+101,1.8992521576017034e-284]
-// • {"滢ⴛ瑖㻡ꎾ쾻":"","&":{"ﾐ䉤᫔㈧":"돦","/￶ ":null,"흷씖*!":-6.231586447634778e+81,"옱ຈ睺䝛㉪⢟":-1.7976931348623083e+308},"":null}
-// • [null]
-// • null
-// • []
 // • …
 ```
 </details>

--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -1029,6 +1029,9 @@ fc.json({maxDepth: 1})
 // • "{\"|\":-9.444458547528003e-26,\"*I\":false,\"6zr(>uO!A\":false,\"2`I_6@YN\":null}"
 // • "[0.00005536178133696582,1.0077587675918889e-197,-1.7048414608911972e-193]"
 // • …
+
+fc.json({depthFactor: 0.1})
+// Examples of generated values: "[{},[false,true]]", "-1.2e-322", "[]", "\"W!oe%r(\"", "{\"!.kQF\":0.07337742984045371,\"Oc&o&sq%!\":-1.0382289906424423e+276}"…
 ```
 </details>
 
@@ -1070,6 +1073,15 @@ fc.unicodeJson({maxDepth: 0})
 
 fc.unicodeJson({maxDepth: 1})
 // Examples of generated values: "false", "true", "\"㬻켔㣃Ꚗ⧅ޔ\"", "[]", "-2.787348602876926e-78"…
+
+fc.unicodeJson({depthFactor: 0.1})
+// Examples of generated values:
+// • "true"
+// • "[null,[],{},{\"麷梒쨼䰻㝚堊\":7.713096177634078e-23,\"\":-2.032086846640786e-16,\"쓹ﻹ벒ﶁКᢷཿ\":\"巌竌﯆뺃孽\"},[7.41252258596104e-103,1.4519829349301023e+133,-9.416217557470048e+125]]"
+// • "[null,[8.629895099097849e+77,null],{\"Ҟﺱoㅕꆗ킬휈悺\":-1.9972723911875336e-192,\"ﰨꇹ綾籭栤\":\"䴦⑌辘峰֊\",\"ᴊ칠ǳ쉷ꎅ䨹㑋酁\":\"ኡￛo蝈聿آ輗᎐\"},[null,-1.40463020552399e+163,-9.604956113050041e+55,true]]"
+// • "false"
+// • "{\"\\\"*ᅤ鎞넨!.㼑䃌,\":true,\"拚臽猺\":true}"
+// • …
 ```
 </details>
 
@@ -2903,6 +2915,33 @@ fc.jsonObject({maxDepth: 1})
 // • {".b?^O.":2.2675666777479575e+300,"1$L{zDJ":-4.497309943661619e+91,"j*s 9%":2.4621957913205494e+195,"m":1.0932950225144496e-204}
 // • {}
 // • …
+
+fc.jsonObject({depthFactor: 0.01, maxDepth: 1000})
+// Examples of generated values:
+// • 1.632639383041831e-286
+// • [[],{"IKoG7_ji":{"\\`~@":1.1383666559247216e-218,"2Yf5":3.1096726241025258e-294}},{},[null,{"/i3W\"FS":[]}]]
+// • [""]
+// • null
+// • -1.0395574284395395e-83
+// • …
+
+fc.jsonObject({depthFactor: 0.1})
+// Examples of generated values:
+// • 2.6e-322
+// • [["H\"C@en.Z-K","}","(WeB`%sT","w","o+vJj7"],["\".B",null]]
+// • -1e-322
+// • {"wnP-!E%SNp":"Cu2[ '}","}t":"u"}
+// • {"!(":{"ldvae;X":6.618751109058961e+41,"(bvLV5Q":4.163017031290256e+162,"K\"F":1.5339457181496153e+35,"o<|c":-1.3214581486561883e-288,"8< bZ] DP":-6003430007757.388},",":{}}
+// • …
+
+fc.jsonObject({depthFactor: 1})
+// Examples of generated values:
+// • false
+// • {"Z}%Y .":-4.3433701524965336e-129}
+// • {"_J":{"16\\g'vAG":null,"l[+":null},"RA]{n":[],"":{"M":true,"D$vc~":true,">r:":false},"A1xkeCSV":[1.9895949472513747e+93,-8012385929821.01]}
+// • {"0":[null],",}Xl":[1.2e-322,true,true,true]}
+// • ["Sk%","*"]
+// • …
 ```
 </details>
 
@@ -2945,6 +2984,27 @@ fc.unicodeJsonObject({maxDepth: 1})
 // • {"ꁺ척蜱젿됻⫄":null,"ั㠰":null,"᧳ꊺ蹀렍ǻ劸":null}
 // • []
 // • [null]
+// • …
+
+fc.unicodeJsonObject({depthFactor: 0.01, maxDepth: 1000})
+// Examples of generated values: null, "憞", {"+":null,"䤌抵":null,"㞔踏⫫ওᠶ䧁㩦":null,"&,%ბꧧ蛶":null,"":null}, {}, []…
+
+fc.unicodeJsonObject({depthFactor: 0.1})
+// Examples of generated values:
+// • "荽醮郺旽粈㈾"
+// • [{"솆薠롺□嬞⥨萳퐋":null,"Ϊ᪤퟿䧂콂讵⨷噟쒖":null,"㶄ﾼ":null,"所":null,"䵮␉":null},[]]
+// • false
+// • {" 㲉䑝*":[false]}
+// • {"":{"":false,"霵":2.2e-322,"￵":4e-323},"-\"者":{"봋":true,"윂ꎽ〚Ꮳ㟺㙰㒈♖暶ጼ":false},"㴴몖":{"谔挴欋킆醴殒ꬖ캩":null,"":"䎕쳳ᆰ"},"#귯໢ഐꃒ礖(&頫":[null,null,null,null,null]}
+// • …
+
+fc.unicodeJsonObject({depthFactor: 1})
+// Examples of generated values:
+// • [1.1219945151091497e+195,3.1543268721301525e+101,1.8992521576017034e-284]
+// • {"滢ⴛ瑖㻡ꎾ쾻":[null,null,null,null],"黦넅￰ᗰﾐ'":[1.7976931348623081e+308],"⺓졆ό䌈諐":-9.005091069307619e-302}
+// • [null]
+// • null
+// • []
 // • …
 ```
 </details>

--- a/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
+++ b/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
@@ -76,13 +76,14 @@ function typedArray() {
 /** @internal */
 export function anyArbitraryBuilder(constraints: QualifiedObjectConstraints): Arbitrary<unknown> {
   const arbitrariesForBase = constraints.values;
+  const depthFactor = constraints.depthFactor;
   const maxDepth = constraints.maxDepth;
   const maxKeys = constraints.maxKeys;
   const baseArb = oneof(...arbitrariesForBase);
 
   return letrec((tie) => ({
     anything: oneof(
-      { maxDepth },
+      { maxDepth, depthFactor },
       baseArb, // Final recursion case
       tie('array'),
       tie('object'),

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -16,6 +16,15 @@ import { ObjectConstraints } from './QualifiedObjectConstraints';
  */
 export interface JsonSharedConstraints {
   /**
+   * Limit the depth of the object by increasing the probability to generate simple values (defined via values)
+   * as we go deeper in the object.
+   *
+   * Example of values: 0.1 (small impact as depth increases), 0.5, 1 (huge impact as depth increases).
+   *
+   * @remarks Since 2.20.0
+   */
+  depthFactor?: number;
+  /**
    * Maximal depth allowed
    * @remarks Since 2.5.0
    */

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -50,7 +50,7 @@ export function jsonConstraintsBuilder(
   return constraints != null
     ? typeof constraints === 'number'
       ? { key, values, maxDepth: constraints }
-      : { key, values, maxDepth: constraints.maxDepth }
+      : { key, values, depthFactor: constraints.depthFactor, maxDepth: constraints.maxDepth }
     : { key, values };
 }
 

--- a/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
+++ b/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
@@ -13,6 +13,15 @@ import { boxedArbitraryBuilder } from '../builders/BoxedArbitraryBuilder';
  */
 export interface ObjectConstraints {
   /**
+   * Limit the depth of the object by increasing the probability to generate simple values (defined via values)
+   * as we go deeper in the object.
+   *
+   * Example of values: 0.1 (small impact as depth increases), 0.5, 1 (huge impact as depth increases).
+   *
+   * @remarks Since 2.20.0
+   */
+  depthFactor?: number;
+  /**
    * Maximal depth allowed
    * @remarks Since 0.0.7
    */
@@ -142,6 +151,7 @@ export function toQualifiedObjectConstraints(settings: ObjectConstraints = {}): 
       orDefault(settings.values, defaultValues()),
       orDefault(settings.withBoxedValues, false)
     ),
+    depthFactor: orDefault(settings.depthFactor, 0),
     maxDepth: orDefault(settings.maxDepth, 2),
     maxKeys: orDefault(settings.maxKeys, 5),
     withSet: orDefault(settings.withSet, false),

--- a/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
+++ b/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
@@ -90,6 +90,7 @@ describe('anyArbitraryBuilder (integration)', () => {
   type Extra = ObjectConstraints;
   const extraParameters: fc.Arbitrary<Extra> = fc.record(
     {
+      depthFactor: fc.double({ min: 0, max: 10 }),
       maxDepth: fc.nat({ max: 5 }),
       maxKeys: fc.nat({ max: 10 }),
       withBigInt: fc.boolean(),

--- a/test/unit/arbitrary/jsonObject.spec.ts
+++ b/test/unit/arbitrary/jsonObject.spec.ts
@@ -14,9 +14,13 @@ import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKey
 describe('jsonObject (integration)', () => {
   type Extra = JsonSharedConstraints | undefined;
   const extraParameters: fc.Arbitrary<Extra> = fc.option(
-    fc.record({
-      maxDepth: fc.nat({ max: 5 }),
-    }),
+    fc.record(
+      {
+        depthFactor: fc.double({ min: 0, max: 10 }),
+        maxDepth: fc.nat({ max: 5 }),
+      },
+      { requiredKeys: [] }
+    ),
     { nil: undefined }
   );
 

--- a/test/unit/arbitrary/unicodeJsonObject.spec.ts
+++ b/test/unit/arbitrary/unicodeJsonObject.spec.ts
@@ -14,9 +14,13 @@ import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKey
 describe('unicodeJsonObject (integration)', () => {
   type Extra = JsonSharedConstraints | undefined;
   const extraParameters: fc.Arbitrary<Extra> = fc.option(
-    fc.record({
-      maxDepth: fc.nat({ max: 5 }),
-    }),
+    fc.record(
+      {
+        depthFactor: fc.double({ min: 0, max: 10 }),
+        maxDepth: fc.nat({ max: 5 }),
+      },
+      { requiredKeys: [] }
+    ),
     { nil: undefined }
   );
 


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

For the moment, arbitraries on objects have not provided any way to alter the depth factor defined its internal `oneof`. The only way to control their depth was to request an explicit (and most of the time arbitrary) maximal depth. This PR adds the ability to provide a depth factor on any arbitrary on objects. In the future, depth factor will certainly be preset with something like 0.1 and maximal depth will just be a fully optional setting only specified if the user really want to limit the depth.

This PR is a prerequisite for https://github.com/dubzzz/fast-check/pull/2464

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
