### PR TITLE
⚡️ Improve performance of `set`

### DIFF
--- a/src/arbitrary/_internals/helpers/StrictlyEqualSet.ts
+++ b/src/arbitrary/_internals/helpers/StrictlyEqualSet.ts
@@ -1,0 +1,45 @@
+import { CustomSet } from '../interfaces/CustomSet';
+
+/**
+ * CustomSet based on "strict equality" as defined by:
+ * https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isstrictlyequal
+ *
+ * And coming with the ability to select a sub-value from the received one.
+ * @internal
+ */
+export class StrictyEqualSet<T, U> implements CustomSet<T> {
+  // Warning: Map uses SameValueZero equality
+  // SameValueZero means:
+  // - NaN equals NaN   => unexpected for ===
+  // - 0   equals -0    => OK
+  private readonly selectedItemsExceptNaN: Set<U>;
+  private readonly data: T[];
+
+  constructor(private readonly selector: (value: T) => U) {
+    this.selectedItemsExceptNaN = new Set();
+    this.data = [];
+  }
+
+  tryAdd(value: T): boolean {
+    const selected = this.selector(value);
+    if (Number.isNaN(selected)) {
+      this.data.push(value);
+      return true;
+    }
+    const sizeBefore = this.selectedItemsExceptNaN.size;
+    this.selectedItemsExceptNaN.add(selected);
+    if (sizeBefore !== this.selectedItemsExceptNaN.size) {
+      this.data.push(value);
+      return true;
+    }
+    return false;
+  }
+
+  size(): number {
+    return this.data.length;
+  }
+
+  getData(): T[] {
+    return this.data;
+  }
+}

--- a/src/arbitrary/_internals/helpers/StrictlyEqualSet.ts
+++ b/src/arbitrary/_internals/helpers/StrictlyEqualSet.ts
@@ -7,8 +7,8 @@ import { CustomSet } from '../interfaces/CustomSet';
  * And coming with the ability to select a sub-value from the received one.
  * @internal
  */
-export class StrictyEqualSet<T, U> implements CustomSet<T> {
-  // Warning: Map uses SameValueZero equality
+export class StrictlyEqualSet<T, U> implements CustomSet<T> {
+  // Warning: Set uses SameValueZero equality
   // SameValueZero means:
   // - NaN equals NaN   => unexpected for ===
   // - 0   equals -0    => OK

--- a/src/arbitrary/set.ts
+++ b/src/arbitrary/set.ts
@@ -5,7 +5,7 @@ import { maxLengthFromMinLength } from './_internals/helpers/MaxLengthFromMinLen
 import { CustomSetBuilder } from './_internals/interfaces/CustomSet';
 import { CustomEqualSet } from './_internals/helpers/CustomEqualSet';
 import { NextValue } from '../check/arbitrary/definition/NextValue';
-import { StrictyEqualSet } from './_internals/helpers/StrictlyEqualSet';
+import { StrictlyEqualSet } from './_internals/helpers/StrictlyEqualSet';
 
 /** @internal */
 function buildSetBuilder<T>(constraints: SetConstraints<T>): CustomSetBuilder<NextValue<T>> {
@@ -15,7 +15,7 @@ function buildSetBuilder<T>(constraints: SetConstraints<T>): CustomSetBuilder<Ne
     return () => new CustomEqualSet(isEqualForBuilder);
   }
   const basicExtractor = (next: NextValue<T>) => next.value_;
-  return () => new StrictyEqualSet(basicExtractor);
+  return () => new StrictlyEqualSet(basicExtractor);
 }
 
 /**

--- a/test/unit/arbitrary/_internals/helpers/StrictlyEqualSet.spec.ts
+++ b/test/unit/arbitrary/_internals/helpers/StrictlyEqualSet.spec.ts
@@ -1,0 +1,115 @@
+import * as fc from '../../../../../lib/fast-check';
+import { StrictyEqualSet } from '../../../../../src/arbitrary/_internals/helpers/StrictlyEqualSet';
+
+describe('StrictyEqualSet', () => {
+  it('should discard strictly equal items', () => {
+    // Arrange
+    const s = new StrictyEqualSet((item) => item);
+
+    // Arrange / Act
+    expect(s.tryAdd(1)).toBe(true);
+    expect(s.tryAdd(5)).toBe(true);
+    expect(s.tryAdd(-0)).toBe(true);
+    expect(s.tryAdd(0)).toBe(false);
+    expect(s.tryAdd(Number.NaN)).toBe(true);
+    expect(s.tryAdd(Number.NaN)).toBe(true);
+    expect(s.tryAdd(1)).toBe(false);
+    expect(s.tryAdd(5)).toBe(false);
+    expect(s.tryAdd(6)).toBe(true);
+    expect(s.tryAdd('6')).toBe(true);
+    expect(s.getData()).toEqual([1, 5, -0, Number.NaN, Number.NaN, 6, '6']);
+  });
+
+  it('should discard strictly equal items after selector', () => {
+    // Arrange
+    const s = new StrictyEqualSet((item: { value?: unknown }) => item.value);
+
+    // Arrange / Act
+    expect(s.tryAdd({ value: 1 })).toBe(true);
+    expect(s.tryAdd({ value: 5 })).toBe(true);
+    expect(s.tryAdd({ value: -0 })).toBe(true);
+    expect(s.tryAdd({ value: 0 })).toBe(false);
+    expect(s.tryAdd({ value: Number.NaN })).toBe(true);
+    expect(s.tryAdd({ value: Number.NaN })).toBe(true);
+    expect(s.tryAdd({ value: 1 })).toBe(false);
+    expect(s.tryAdd({ value: 5 })).toBe(false);
+    expect(s.tryAdd({ value: 6 })).toBe(true);
+    expect(s.tryAdd({ value: '6' })).toBe(true);
+    expect(s.tryAdd({})).toBe(true);
+    expect(s.tryAdd({ value: undefined })).toBe(false);
+    expect(s.getData()).toEqual([
+      { value: 1 },
+      { value: 5 },
+      { value: -0 },
+      { value: Number.NaN },
+      { value: Number.NaN },
+      { value: 6 },
+      { value: '6' },
+      {},
+    ]);
+  });
+
+  it('should increase the size whenever tryAdd returns true', () => {
+    fc.assert(
+      fc.property(fc.array(fc.anything(), { minLength: 1 }), (rawItems) => {
+        // Arrange
+        let expectedSize = 0;
+        const s = new StrictyEqualSet((item) => item);
+
+        // Act / Assert
+        for (const item of rawItems) {
+          if (s.tryAdd(item)) {
+            expectedSize += 1;
+          }
+          expect(s.size()).toBe(expectedSize);
+        }
+      })
+    );
+  });
+
+  it('should never have two equivalent items in the Set', () => {
+    fc.assert(
+      fc.property(fc.array(fc.anything(), { minLength: 2 }), (rawItems) => {
+        // Arrange
+        const s = new StrictyEqualSet((item) => item);
+
+        // Act
+        for (const item of rawItems) {
+          s.tryAdd(item);
+        }
+        const data = s.getData();
+
+        // Assert
+        for (let i = 0; i !== data.length; ++i) {
+          for (let j = i + 1; j !== data.length; ++j) {
+            expect(data[i] === data[j]).toBe(false);
+          }
+        }
+      })
+    );
+  });
+
+  it('should preserve add order', () => {
+    fc.assert(
+      fc.property(fc.array(fc.anything(), { minLength: 2 }), (rawItems) => {
+        // Arrange
+        const s = new StrictyEqualSet((item) => item);
+
+        // Act
+        for (const item of rawItems) {
+          s.tryAdd(item);
+        }
+        const data = s.getData();
+
+        // Assert
+        for (let i = 1; i < data.length; ++i) {
+          const indexPrevious = rawItems.findIndex((item) => item === data[i - 1]);
+          const indexCurrent = rawItems.findIndex((item) => item === data[i]);
+          expect(indexPrevious).not.toBe(-1);
+          expect(indexCurrent).not.toBe(-1);
+          expect(indexPrevious).toBeLessThan(indexCurrent);
+        }
+      })
+    );
+  });
+});


### PR DESCRIPTION
Only applies for instances of `set` not overriding the default comparator. Any override of the compator will lead to degradated performances. The performance gap will mostly be visible with large arrays.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [x] Generated values: Not expected, but code forks between no user-defined comparison function (with new code) and the other, we may have unwantingly introduced a regression there.
- [ ] Shrink values
- [x] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
