### PR TITLE
♻️ Split maxLength into two facets inside the internal for arrays

### DIFF
--- a/src/arbitrary/_internals/ArrayArbitrary.ts
+++ b/src/arbitrary/_internals/ArrayArbitrary.ts
@@ -23,13 +23,14 @@ export class ArrayArbitrary<T> extends NextArbitrary<T[]> {
   constructor(
     readonly arb: NextArbitrary<T>,
     readonly minLength: number,
+    readonly maxGeneratedLength: number,
     readonly maxLength: number,
     // Whenever passing a isEqual to ArrayArbitrary, you also have to filter
     // it's output just in case produced values are too small (below minLength)
     readonly setBuilder?: CustomSetBuilder<NextValue<T>>
   ) {
     super();
-    this.lengthArb = convertToNext(integer(minLength, maxLength));
+    this.lengthArb = convertToNext(integer(minLength, maxGeneratedLength));
   }
 
   private preFilter(tab: NextValue<T>[]): NextValue<T>[] {
@@ -68,7 +69,7 @@ export class ArrayArbitrary<T> extends NextArbitrary<T[]> {
     // so we need to retry and generate other ones. In order to prevent infinite loop,
     // we accept a max of maxLength consecutive failures. This circuit breaker may cause
     // generated to be smaller than the minimal accepted one.
-    while (s.size() < N && numSkippedInRow < this.maxLength) {
+    while (s.size() < N && numSkippedInRow < this.maxGeneratedLength) {
       const current = this.arb.generate(mrng, biasFactorItems);
       if (s.tryAdd(current)) {
         numSkippedInRow = 0;
@@ -137,7 +138,7 @@ export class ArrayArbitrary<T> extends NextArbitrary<T[]> {
       return { size: this.lengthArb.generate(mrng, undefined).value };
     }
     // We directly forward bias to items whenever no bias applicable onto length
-    if (this.minLength === this.maxLength) {
+    if (this.minLength === this.maxGeneratedLength) {
       // We only apply bias on items
       return { size: this.lengthArb.generate(mrng, undefined).value, biasFactorItems: biasFactor };
     }
@@ -146,12 +147,13 @@ export class ArrayArbitrary<T> extends NextArbitrary<T[]> {
       return { size: this.lengthArb.generate(mrng, undefined).value };
     }
     // We apply bias (1 chance over biasFactor)
-    if (mrng.nextInt(1, biasFactor) !== 1 || this.minLength === this.maxLength) {
+    if (mrng.nextInt(1, biasFactor) !== 1 || this.minLength === this.maxGeneratedLength) {
       // We only apply bias on items ((biasFactor-1) chances over biasFactor²)
       return { size: this.lengthArb.generate(mrng, undefined).value, biasFactorItems: biasFactor };
     }
     // We apply bias for both items and length (1 chance over biasFactor²)
-    const maxBiasedLength = this.minLength + Math.floor(Math.log(this.maxLength - this.minLength) / Math.log(2));
+    const maxBiasedLength =
+      this.minLength + Math.floor(Math.log(this.maxGeneratedLength - this.minLength) / Math.log(2));
     const targetSizeValue = convertToNext(integer(this.minLength, maxBiasedLength)).generate(mrng, undefined);
     return { size: targetSizeValue.value, biasFactorItems: biasFactor };
   }

--- a/src/arbitrary/array.ts
+++ b/src/arbitrary/array.ts
@@ -70,17 +70,24 @@ function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints): Arbitrary<T
 function array<T>(arb: Arbitrary<T>, ...args: [] | [number] | [number, number] | [ArrayConstraints]): Arbitrary<T[]> {
   const nextArb = convertToNext(arb);
   // fc.array(arb)
-  if (args[0] === undefined) return convertFromNext(new ArrayArbitrary<T>(nextArb, 0, maxLengthFromMinLength(0)));
+  if (args[0] === undefined) {
+    const maxLength = maxLengthFromMinLength(0);
+    return convertFromNext(new ArrayArbitrary<T>(nextArb, 0, maxLength, maxLength));
+  }
   // fc.array(arb, constraints)
   if (typeof args[0] === 'object') {
     const minLength = args[0].minLength || 0;
     const specifiedMaxLength = args[0].maxLength;
     const maxLength = specifiedMaxLength !== undefined ? specifiedMaxLength : maxLengthFromMinLength(minLength);
-    return convertFromNext(new ArrayArbitrary<T>(nextArb, minLength, maxLength));
+    return convertFromNext(new ArrayArbitrary<T>(nextArb, minLength, maxLength, maxLength));
   }
   // fc.array(arb, minLength, maxLength)
-  if (args[1] !== undefined) return convertFromNext(new ArrayArbitrary<T>(nextArb, args[0], args[1]));
+  if (args[1] !== undefined) {
+    const maxLength = args[1];
+    return convertFromNext(new ArrayArbitrary<T>(nextArb, args[0], maxLength, maxLength));
+  }
   // fc.array(arb, maxLength)
-  return convertFromNext(new ArrayArbitrary<T>(nextArb, 0, args[0]));
+  const maxLength = args[0];
+  return convertFromNext(new ArrayArbitrary<T>(nextArb, 0, maxLength, maxLength));
 }
 export { array };

--- a/src/arbitrary/set.ts
+++ b/src/arbitrary/set.ts
@@ -249,7 +249,7 @@ function set<T>(
   const setBuilder = constraints.setBuilder;
 
   const nextArb = convertToNext(arb);
-  const arrayArb = convertFromNext(new ArrayArbitrary<T>(nextArb, minLength, maxLength, setBuilder));
+  const arrayArb = convertFromNext(new ArrayArbitrary<T>(nextArb, minLength, maxLength, maxLength, setBuilder));
   if (minLength === 0) return arrayArb;
   return arrayArb.filter((tab) => tab.length >= minLength);
 }

--- a/test/unit/arbitrary/array.spec.ts
+++ b/test/unit/arbitrary/array.spec.ts
@@ -24,7 +24,7 @@ function beforeEachHook() {
 beforeEach(beforeEachHook);
 
 describe('array', () => {
-  it('should instantiate ArrayArbitrary(arb, 0, ?) for array(arb)', () => {
+  it('should instantiate ArrayArbitrary(arb, 0, ?, ?) for array(arb)', () => {
     // Arrange
     const { instance: childInstance } = fakeNextArbitrary<unknown>();
     const { instance } = fakeNextArbitrary<unknown[]>();
@@ -35,15 +35,17 @@ describe('array', () => {
     const arb = array(convertFromNext(childInstance));
 
     // Assert
-    expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, expect.any(Number));
-    const receivedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
-    expect(receivedMaxLength).toBeGreaterThan(0);
-    expect(receivedMaxLength).toBeLessThanOrEqual(2 ** 31 - 1);
-    expect(Number.isInteger(receivedMaxLength)).toBe(true);
+    expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, expect.any(Number), expect.any(Number));
+    const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
+    expect(receivedGeneratedMaxLength).toBeGreaterThan(0);
+    expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(2 ** 31 - 1);
+    expect(Number.isInteger(receivedGeneratedMaxLength)).toBe(true);
+    const receivedMaxLength = ArrayArbitrary.mock.calls[0][3]; // Starting at v3, maxLength will be 0x7fffffff in such case
+    expect(receivedMaxLength).toBe(receivedGeneratedMaxLength);
     expect(convertToNext(arb)).toBe(instance);
   });
 
-  it('should instantiate ArrayArbitrary(arb, 0, maxLength) for array(arb, {maxLength})', () => {
+  it('should instantiate ArrayArbitrary(arb, 0, maxLength, maxLength) for array(arb, {maxLength})', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), (maxLength) => {
         // Arrange
@@ -56,13 +58,13 @@ describe('array', () => {
         const arb = array(convertFromNext(childInstance), { maxLength });
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength);
         expect(convertToNext(arb)).toBe(instance);
       })
     );
   });
 
-  it('should instantiate ArrayArbitrary(arb, minLength, ?) for array(arb, {minLength})', () => {
+  it('should instantiate ArrayArbitrary(arb, minLength, ?, ?) for array(arb, {minLength})', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), (minLength) => {
         // Arrange
@@ -75,21 +77,23 @@ describe('array', () => {
         const arb = array(convertFromNext(childInstance), { minLength });
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, expect.any(Number));
-        const receivedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
+        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, expect.any(Number), expect.any(Number));
+        const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         if (minLength !== 2 ** 31 - 1) {
-          expect(receivedMaxLength).toBeGreaterThan(minLength);
-          expect(receivedMaxLength).toBeLessThanOrEqual(2 ** 31 - 1);
-          expect(Number.isInteger(receivedMaxLength)).toBe(true);
+          expect(receivedGeneratedMaxLength).toBeGreaterThan(minLength);
+          expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(2 ** 31 - 1);
+          expect(Number.isInteger(receivedGeneratedMaxLength)).toBe(true);
         } else {
-          expect(receivedMaxLength).toEqual(minLength);
+          expect(receivedGeneratedMaxLength).toEqual(minLength);
         }
+        const receivedMaxLength = ArrayArbitrary.mock.calls[0][3]; // Starting at v3, maxLength will be 0x7fffffff in such case
+        expect(receivedMaxLength).toBe(receivedGeneratedMaxLength);
         expect(convertToNext(arb)).toBe(instance);
       })
     );
   });
 
-  it('should instantiate ArrayArbitrary(arb, minLength, maxLength) for array(arb, {minLength,maxLength})', () => {
+  it('should instantiate ArrayArbitrary(arb, minLength, maxLength, maxLength) for array(arb, {minLength,maxLength})', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), fc.nat({ max: 2 ** 31 - 1 }), (aLength, bLength) => {
         // Arrange
@@ -103,13 +107,13 @@ describe('array', () => {
         const arb = array(convertFromNext(childInstance), { minLength, maxLength });
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength, maxLength);
         expect(convertToNext(arb)).toBe(instance);
       })
     );
   });
 
-  it('[legacy] should instantiate ArrayArbitrary(arb, 0, maxLength) for array(arb, maxLength)', () => {
+  it('[legacy] should instantiate ArrayArbitrary(arb, 0, maxLength, maxLength) for array(arb, maxLength)', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), (maxLength) => {
         // Arrange
@@ -122,13 +126,13 @@ describe('array', () => {
         const arb = array(convertFromNext(childInstance), maxLength);
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength);
         expect(convertToNext(arb)).toBe(instance);
       })
     );
   });
 
-  it('[legacy] should instantiate ArrayArbitrary(arb, minLength, maxLength) for array(arb, minLength, maxLength)', () => {
+  it('[legacy] should instantiate ArrayArbitrary(arb, minLength, maxLength, maxLength) for array(arb, minLength, maxLength)', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), fc.nat({ max: 2 ** 31 - 1 }), (aLength, bLength) => {
         // Arrange
@@ -142,7 +146,7 @@ describe('array', () => {
         const arb = array(convertFromNext(childInstance), minLength, maxLength);
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength, maxLength);
         expect(convertToNext(arb)).toBe(instance);
       })
     );


### PR DESCRIPTION
Prepare the code for #2648 by adding this new capability. So far we don't really use it as maxGeneratedLength and maxLength have always the same values. But things will change in the upcoming PRs.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
