### PR TITLE
🔥 Remove useless extra step when unmapping from patterns

### DIFF
--- a/src/arbitrary/_internals/mappers/PatternsToString.ts
+++ b/src/arbitrary/_internals/mappers/PatternsToString.ts
@@ -51,8 +51,6 @@ export function patternsToStringUnmapperFor(
             }
             return newChunks; // we found a full match
           }
-          // Pushed in case we need to try for next indices
-          stack.push({ endIndexChunks: last.endIndexChunks, nextStartIndex: index + 1, chunks: last.chunks });
           // Pushed to go deeper in the tree
           stack.push({ endIndexChunks: index, nextStartIndex: index + 1, chunks: newChunks });
           break;


### PR DESCRIPTION
Unmapping from patterns is used within `fc.stringOf` in order to be able to run the shrinker against barely any user defined string.

The current implementation seems to add an extra and unneeded step within the traversal stack. It possibly led to more expensive computations in most of cases. Removing this code will be highly beneficial in terms of performances when shrinking user definable values.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [x] Shrink values: for stringOf, when calling it with user definable values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
