### PR TITLE
🐛 Don't shrink array with trailing hole when not supporting it

### DIFF
--- a/src/arbitrary/sparseArray.ts
+++ b/src/arbitrary/sparseArray.ts
@@ -100,6 +100,9 @@ export function sparseArray<T>(arb: Arbitrary<T>, constraints: SparseArrayConstr
         if (!Array.isArray(value)) {
           throw new Error('Not supported entry type');
         }
+        if (noTrailingHole && value.length !== 0 && !(value.length - 1 in value)) {
+          throw new Error('No trailing hole');
+        }
         return Object.entries(value as T[]).map((entry): [number, T] => [Number(entry[0]), entry[1]]);
       }
     )


### PR DESCRIPTION
When `fc.sparseArray` has been passed the constraint `noTrailingHole` it should refuse to shrink arrays ending with a hole.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
