### PR TITLE
✨ Simpler way to create unique identifier for depths

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -3632,6 +3632,26 @@ fc.letrec(tie => ({
 // • {"value":13,"left":null,"right":{"value":23,"left":null,"right":null}}
 // • …
 
+// Setup the depth identifier shared across all nodes:
+const depthIdentifier = fc.createDepthIdentifier();
+// Use the arbitrary:
+fc.letrec(tie => ({
+  node: fc.record({
+    value: fc.nat(),
+    left: fc.option(tie('node'), {maxDepth: 1, depthIdentifier}),
+    right: fc.option(tie('node'), {maxDepth: 1, depthIdentifier}),
+  })
+})).node
+// Note: Calling `createDepthIdentifier` is another way to pass a value for `depthIdentifier`. Compared to the string-based
+// version, demo-ed in the snippet above, it has the benefit to never collide with other identifiers manually specified.
+// Examples of generated values:
+// • {"value":1174690793,"left":{"value":16,"left":null,"right":null},"right":{"value":27,"left":null,"right":null}}
+// • {"value":2147483618,"left":{"value":139704885,"left":null,"right":null},"right":{"value":1378176410,"left":null,"right":null}}
+// • {"value":1655727852,"left":{"value":17,"left":null,"right":null},"right":{"value":904507089,"left":null,"right":null}}
+// • {"value":1136122085,"left":{"value":1247629324,"left":null,"right":null},"right":{"value":12,"left":null,"right":null}}
+// • {"value":10,"left":{"value":4,"left":null,"right":null},"right":{"value":1054043111,"left":null,"right":null}}
+// • …
+
 fc.letrec(tie => ({
   node: fc.record({
     value: fc.nat(),

--- a/src/arbitrary/_internals/ArrayArbitrary.ts
+++ b/src/arbitrary/_internals/ArrayArbitrary.ts
@@ -7,7 +7,7 @@ import { NextArbitrary } from '../../check/arbitrary/definition/NextArbitrary';
 import { convertToNext } from '../../check/arbitrary/definition/Converters';
 import { NextValue } from '../../check/arbitrary/definition/NextValue';
 import { CustomSetBuilder } from './interfaces/CustomSet';
-import { DepthContext, getDepthContextFor } from './helpers/DepthContext';
+import { DepthContext, DepthIdentifier, getDepthContextFor } from './helpers/DepthContext';
 
 /** @internal */
 type ArrayArbitraryContext = {
@@ -35,7 +35,7 @@ export class ArrayArbitrary<T> extends NextArbitrary<T[]> {
     readonly minLength: number,
     readonly maxGeneratedLength: number,
     readonly maxLength: number,
-    depthIdentifier: string | undefined,
+    depthIdentifier: DepthIdentifier | string | undefined,
     // Whenever passing a isEqual to ArrayArbitrary, you also have to filter
     // it's output just in case produced values are too small (below minLength)
     readonly setBuilder?: CustomSetBuilder<NextValue<T>>

--- a/src/arbitrary/_internals/FrequencyArbitrary.ts
+++ b/src/arbitrary/_internals/FrequencyArbitrary.ts
@@ -4,7 +4,7 @@ import { Arbitrary } from '../../check/arbitrary/definition/Arbitrary';
 import { convertFromNext, convertToNext } from '../../check/arbitrary/definition/Converters';
 import { NextArbitrary } from '../../check/arbitrary/definition/NextArbitrary';
 import { NextValue } from '../../check/arbitrary/definition/NextValue';
-import { DepthContext, getDepthContextFor } from './helpers/DepthContext';
+import { DepthContext, DepthIdentifier, getDepthContextFor } from './helpers/DepthContext';
 
 /** @internal */
 export class FrequencyArbitrary<T> extends NextArbitrary<T> {
@@ -204,7 +204,7 @@ export type _Constraints = {
   withCrossShrink?: boolean;
   depthFactor?: number;
   maxDepth?: number;
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 };
 
 /** @internal */

--- a/src/arbitrary/_internals/helpers/DepthContext.ts
+++ b/src/arbitrary/_internals/helpers/DepthContext.ts
@@ -1,6 +1,32 @@
 /** @internal */
+declare const depthIdentifierSymbol: unique symbol;
+
+/**
+ * Type used to strongly type instances of depth identifier while keeping internals
+ * what they contain internally
+ *
+ * @remarks Since 2.25.0
+ * @public
+ */
+export type DepthIdentifier = { [depthIdentifierSymbol]: true };
+
+/**
+ * Instance of depth, can be used to alter the depth perceived by an arbitrary
+ * or to bias your own arbitraries based on the current depth
+ *
+ * @remarks Since 2.25.0
+ * @public
+ */
 export type DepthContext = {
-  /** Current depth (starts at 0) */
+  /**
+   * Current depth (starts at 0, continues with 1, 2...).
+   * Only made of integer values superior or equal to 0.
+   *
+   * Remark: Whenever altering the `depth` during a `generate`, please make sure to ALWAYS
+   * reset it to its original value before you leave the `generate`. Otherwise the execution
+   * will imply side-effects that will potentially impact the following runs and make replay
+   * of the issue barely impossible.
+   */
   depth: number;
 };
 
@@ -12,14 +38,15 @@ const depthContextCache = new Map<string, DepthContext>();
 
 /**
  * Get back the requested DepthContext
- * @internal
+ * @remarks Since 2.25.0
+ * @public
  */
-export function getDepthContextFor(contextMeta: DepthContext | string | undefined): DepthContext {
+export function getDepthContextFor(contextMeta: DepthContext | DepthIdentifier | string | undefined): DepthContext {
   if (contextMeta === undefined) {
     return { depth: 0 };
   }
   if (typeof contextMeta !== 'string') {
-    return contextMeta;
+    return contextMeta as DepthContext;
   }
   const cachedContext = depthContextCache.get(contextMeta);
   if (cachedContext !== undefined) {
@@ -28,4 +55,14 @@ export function getDepthContextFor(contextMeta: DepthContext | string | undefine
   const context = { depth: 0 };
   depthContextCache.set(contextMeta, context);
   return context;
+}
+
+/**
+ * Create a new and unique instance of DepthIdentifier
+ * that can be shared across multiple arbitraries if needed
+ * @public
+ */
+export function createDepthIdentifier(): DepthIdentifier {
+  const identifier: DepthContext = { depth: 0 };
+  return identifier as unknown as DepthIdentifier;
 }

--- a/src/arbitrary/_internals/helpers/DepthContext.ts
+++ b/src/arbitrary/_internals/helpers/DepthContext.ts
@@ -1,4 +1,7 @@
-/** @internal */
+/**
+ * Internal symbol used to declare an opaque type for DepthIdentifier
+ * @public
+ */
 declare const depthIdentifierSymbol: unique symbol;
 
 /**

--- a/src/arbitrary/array.ts
+++ b/src/arbitrary/array.ts
@@ -7,6 +7,7 @@ import {
   SizeForArbitrary,
   maxGeneratedLengthFromSizeForArbitrary,
 } from './_internals/helpers/MaxLengthFromMinLength';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /**
  * Constraints to be applied on {@link array}
@@ -47,7 +48,7 @@ export interface ArrayConstraints {
    *
    * @remarks Since 2.25.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 }
 
 /** @internal */
@@ -56,7 +57,7 @@ function createArrayArbitrary<T>(
   size: SizeForArbitrary | undefined,
   minLength: number,
   maxLengthOrUnset: number | undefined,
-  depthIdentifier: string | undefined
+  depthIdentifier: DepthIdentifier | string | undefined
 ): Arbitrary<T[]> {
   const maxLength = maxLengthOrUnset !== undefined ? maxLengthOrUnset : MaxLengthUpperBound;
   const specifiedMaxLength = maxLengthOrUnset !== undefined;

--- a/src/arbitrary/frequency.ts
+++ b/src/arbitrary/frequency.ts
@@ -1,5 +1,6 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { FrequencyArbitrary } from './_internals/FrequencyArbitrary';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /**
  * Conjonction of a weight and an arbitrary used by {@link frequency}
@@ -79,7 +80,7 @@ export type FrequencyContraints = {
    *
    * @remarks Since 2.14.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 };
 
 /** @internal */

--- a/src/arbitrary/oneof.ts
+++ b/src/arbitrary/oneof.ts
@@ -1,5 +1,6 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { FrequencyArbitrary } from './_internals/FrequencyArbitrary';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /**
  * Infer the type of the Arbitrary produced by {@link oneof}
@@ -53,7 +54,7 @@ export type OneOfConstraints = {
    *
    * @remarks Since 2.14.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 };
 
 /**

--- a/src/arbitrary/option.ts
+++ b/src/arbitrary/option.ts
@@ -1,6 +1,7 @@
 import { constant } from './constant';
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { FrequencyArbitrary, _Constraints as FrequencyContraints } from './_internals/FrequencyArbitrary';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /**
  * Constraints to be applied on {@link option}
@@ -41,7 +42,7 @@ export interface OptionConstraints<TNil = null> {
    *
    * @remarks Since 2.14.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 }
 
 /** @internal */

--- a/src/arbitrary/set.ts
+++ b/src/arbitrary/set.ts
@@ -12,6 +12,7 @@ import { NextValue } from '../check/arbitrary/definition/NextValue';
 import { StrictlyEqualSet } from './_internals/helpers/StrictlyEqualSet';
 import { SameValueSet } from './_internals/helpers/SameValueSet';
 import { SameValueZeroSet } from './_internals/helpers/SameValueZeroSet';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /** @internal */
 function buildSetBuilder<T>(constraints: SetConstraints<T>): CustomSetBuilder<NextValue<T>> {
@@ -37,7 +38,7 @@ function buildSetBuilder<T>(constraints: SetConstraints<T>): CustomSetBuilder<Ne
 type CompleteSetConstraints<T> = Required<Omit<SetConstraints<T>, 'compare' | 'size' | 'depthIdentifier'>> & {
   setBuilder: CustomSetBuilder<NextValue<T>>;
   maxGeneratedLength: number;
-  depthIdentifier: string | undefined;
+  depthIdentifier: DepthIdentifier | string | undefined;
 };
 
 /**
@@ -170,7 +171,7 @@ export interface SetConstraints<T> {
    *
    * @remarks Since 2.25.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 }
 
 /**

--- a/src/arbitrary/sparseArray.ts
+++ b/src/arbitrary/sparseArray.ts
@@ -3,6 +3,7 @@ import { convertFromNext, convertToNext } from '../check/arbitrary/definition/Co
 import { tuple } from './tuple';
 import { uniqueArray } from './uniqueArray';
 import { restrictedIntegerArbitraryBuilder } from './_internals/builders/RestrictedIntegerArbitraryBuilder';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 import {
   maxGeneratedLengthFromSizeForArbitrary,
   MaxLengthUpperBound,
@@ -53,7 +54,7 @@ export interface SparseArrayConstraints {
    *
    * @remarks Since 2.25.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 }
 
 /** @internal */

--- a/src/arbitrary/uniqueArray.ts
+++ b/src/arbitrary/uniqueArray.ts
@@ -12,6 +12,7 @@ import { NextValue } from '../check/arbitrary/definition/NextValue';
 import { StrictlyEqualSet } from './_internals/helpers/StrictlyEqualSet';
 import { SameValueSet } from './_internals/helpers/SameValueSet';
 import { SameValueZeroSet } from './_internals/helpers/SameValueZeroSet';
+import { DepthIdentifier } from './_internals/helpers/DepthContext';
 
 /** @internal */
 function buildUniqueArraySetBuilder<T, U>(constraints: UniqueArrayConstraints<T, U>): CustomSetBuilder<NextValue<T>> {
@@ -77,7 +78,7 @@ export type UniqueArraySharedConstraints = {
    *
    * @remarks Since 2.25.0
    */
-  depthIdentifier?: string;
+  depthIdentifier?: DepthIdentifier | string;
 };
 
 /**

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -173,6 +173,12 @@ import { NextValue } from './check/arbitrary/definition/NextValue';
 import { convertFromNext, convertFromNextWithShrunkOnce, convertToNext } from './check/arbitrary/definition/Converters';
 import { PureRandom } from './random/generator/PureRandom';
 import { Size, SizeForArbitrary } from './arbitrary/_internals/helpers/MaxLengthFromMinLength';
+import {
+  createDepthIdentifier,
+  DepthContext,
+  DepthIdentifier,
+  getDepthContextFor,
+} from './arbitrary/_internals/helpers/DepthContext';
 
 // Explicit cast into string to avoid to have __type: "__PACKAGE_TYPE__"
 /**
@@ -362,6 +368,8 @@ export {
   asyncToStringMethod,
   hasAsyncToStringMethod,
   WithAsyncToStringMethod,
+  DepthContext,
+  getDepthContextFor,
   // print values
   stringify,
   asyncStringify,
@@ -449,6 +457,8 @@ export {
   Random,
   Stream,
   stream,
+  DepthIdentifier,
+  createDepthIdentifier,
   // depreciated
   Context,
   FalsyType,

--- a/test/e2e/RecursiveStructures.spec.ts
+++ b/test/e2e/RecursiveStructures.spec.ts
@@ -146,7 +146,7 @@ describe(`RecursiveStructures (seed: ${seed})`, () => {
       const initialGlobal = fc.readConfigureGlobal();
       fc.configureGlobal({ ...initialGlobal, baseSize });
       try {
-        const depthIdentifier = `array-based-recursive-structure-${baseSize}`;
+        const depthIdentifier = fc.createDepthIdentifier();
         const arb = fc.letrec((tie) => ({
           self: fc.oneof({ depthFactor, depthIdentifier }, fc.nat(), fc.array(tie('self'), { depthIdentifier })),
         })).self;


### PR DESCRIPTION
Up-to-now building depth identifier was possible by passing a string that can be shared across many instances that want to benefit from the same depth. But there was no way to come with a fully unique identifier that will have no chance to collide with existing ones (except by randomly generating a unique string).

With that PR we create a new helper that makes it possible for our users to create fully unique instances of depth identifiers they may or may not share with others. It as an extra benefit compared to the string version: it does not rely on a cache (never cleaned) and handled by fast-check internally.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
