### PR TITLE
♻️ Move `ts-jest` types related helpers internally

### DIFF
--- a/test/unit/__test-helpers__/Mocked.ts
+++ b/test/unit/__test-helpers__/Mocked.ts
@@ -1,0 +1,35 @@
+// Copied from ts-jest/dist/utils/testing
+
+type MockableFunction = (...args: any[]) => any;
+type ArgumentsOf<T> = T extends (...args: infer A) => any ? A : never;
+type ConstructorArgumentsOf<T> = T extends new (...args: infer A) => any ? A : never;
+
+export interface MockWithArgs<T extends MockableFunction> extends jest.MockInstance<ReturnType<T>, ArgumentsOf<T>> {
+  new (...args: ConstructorArgumentsOf<T>): T;
+  (...args: ArgumentsOf<T>): ReturnType<T>;
+}
+
+type MethodKeysOf<T> = {
+  [K in keyof T]: T[K] extends MockableFunction ? K : never;
+}[keyof T];
+type PropertyKeysOf<T> = {
+  [K in keyof T]: T[K] extends MockableFunction ? never : K;
+}[keyof T];
+type MaybeMockedConstructor<T> = T extends new (...args: any[]) => infer R
+  ? jest.MockInstance<R, ConstructorArgumentsOf<T>>
+  : T;
+type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & {
+  [K in keyof T]: T[K];
+};
+type MockedObject<T> = MaybeMockedConstructor<T> & {
+  [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFunction<T[K]> : T[K];
+} & {
+  [K in PropertyKeysOf<T>]: T[K];
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type MaybeMocked<T> = T extends MockableFunction ? MockedFunction<T> : T extends object ? MockedObject<T> : T;
+
+export function mocked<T>(item: T): MaybeMocked<T> {
+  return item as MaybeMocked<T>;
+}

--- a/test/unit/arbitrary/__test-helpers__/NextArbitraryHelpers.ts
+++ b/test/unit/arbitrary/__test-helpers__/NextArbitraryHelpers.ts
@@ -1,5 +1,4 @@
-import { mocked } from 'ts-jest';
-import { MaybeMocked, MockWithArgs } from 'ts-jest/dist/utils/testing';
+import { MaybeMocked, MockWithArgs } from '../../__test-helpers__/Mocked';
 import { NextArbitrary } from '../../../../src/check/arbitrary/definition/NextArbitrary';
 import { NextValue } from '../../../../src/check/arbitrary/definition/NextValue';
 import { Random } from '../../../../src/random/generator/Random';
@@ -20,7 +19,7 @@ export function fakeNextArbitraryClass<T = any>(): { Class: new () => NextArbitr
   const chain = jest.fn();
   const noShrink = jest.fn();
   const noBias = jest.fn();
-  mocked;
+
   class FakeNextArbitrary extends NextArbitrary<T> {
     generate = generate;
     canShrinkWithoutContext = canShrinkWithoutContext;

--- a/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
+++ b/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
@@ -1,4 +1,4 @@
-import { MaybeMocked } from 'ts-jest/dist/utils/testing';
+import { MaybeMocked } from '../../__test-helpers__/Mocked';
 import { Random } from '../../../../src/random/generator/Random';
 
 export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, 'internalRng' | 'uniformIn'> {

--- a/test/unit/check/arbitrary/definition/Converters.utest.spec.ts
+++ b/test/unit/check/arbitrary/definition/Converters.utest.spec.ts
@@ -3,7 +3,7 @@ import {
   convertFromNextWithShrunkOnce,
   convertToNext,
 } from '../../../../../src/check/arbitrary/definition/Converters';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from '../../../__test-helpers__/Mocked';
 
 import { Arbitrary } from '../../../../../src/check/arbitrary/definition/Arbitrary';
 import { NextArbitrary } from '../../../../../src/check/arbitrary/definition/NextArbitrary';

--- a/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
+++ b/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
@@ -1,4 +1,4 @@
-import { MaybeMocked } from 'ts-jest/dist/utils/testing';
+import { MaybeMocked } from '../../../__test-helpers__/Mocked';
 import { INextRawProperty } from '../../../../../src/check/property/INextRawProperty';
 
 /**


### PR DESCRIPTION
Up-to-now those helpers have been pulled from `ts-jest`. But in recent releases they have been moved (if not removed). In order to reduce the risk of such moves and also to decouple our tests from `ts-jest` we copied some of those helpers directly into our set of helpers dedicated to tests.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->
**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
<!-- Don't forget to add the gitmoji icon in the name of the PR -->
<!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->
- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
