### PR TITLE
💥 Remove deprecated signatures of `fc.array`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2413,8 +2413,6 @@ fc.genericTuple([fc.nat(), fc.string()])
 
 - `fc.array(arb)`
 - `fc.array(arb, {minLength?, maxLength?, size?, depthIdentifier?})`
-- _`fc.array(arb, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
-- _`fc.array(arb, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/arbitrary/array.ts
+++ b/src/arbitrary/array.ts
@@ -1,5 +1,4 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
-import { NextArbitrary } from '../check/arbitrary/definition/NextArbitrary';
 import { convertFromNext, convertToNext } from '../check/arbitrary/definition/Converters';
 import { ArrayArbitrary } from './_internals/ArrayArbitrary';
 import {
@@ -51,87 +50,24 @@ export interface ArrayConstraints {
   depthIdentifier?: DepthIdentifier | string;
 }
 
-/** @internal */
-function createArrayArbitrary<T>(
-  nextArb: NextArbitrary<T>,
-  size: SizeForArbitrary | undefined,
-  minLength: number,
-  maxLengthOrUnset: number | undefined,
-  depthIdentifier: DepthIdentifier | string | undefined
-): Arbitrary<T[]> {
+/**
+ * For arrays of values coming from `arb`
+ *
+ * @param arb - Arbitrary used to generate the values inside the array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
+ *
+ * @remarks Since 0.0.1
+ * @public
+ */
+function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints = {}): Arbitrary<T[]> {
+  const nextArb = convertToNext(arb);
+  const size = constraints.size;
+  const minLength = constraints.minLength || 0;
+  const maxLengthOrUnset = constraints.maxLength;
+  const depthIdentifier = constraints.depthIdentifier;
   const maxLength = maxLengthOrUnset !== undefined ? maxLengthOrUnset : MaxLengthUpperBound;
   const specifiedMaxLength = maxLengthOrUnset !== undefined;
   const maxGeneratedLength = maxGeneratedLengthFromSizeForArbitrary(size, minLength, maxLength, specifiedMaxLength);
   return convertFromNext(new ArrayArbitrary<T>(nextArb, minLength, maxGeneratedLength, maxLength, depthIdentifier));
-}
-
-/**
- * For arrays of values coming from `arb`
- * @param arb - Arbitrary used to generate the values inside the array
- * @remarks Since 0.0.1
- * @public
- */
-function array<T>(arb: Arbitrary<T>): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having an upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.array(arb, {maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.1
- * @public
- */
-function array<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having lower and upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.array(arb, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.7
- * @public
- */
-function array<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For arrays of values coming from `arb` having lower and upper bound size
- *
- * @param arb - Arbitrary used to generate the values inside the array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints): Arbitrary<T[]>;
-function array<T>(arb: Arbitrary<T>, ...args: [] | [number] | [number, number] | [ArrayConstraints]): Arbitrary<T[]> {
-  const nextArb = convertToNext(arb);
-  // fc.array(arb)
-  if (args[0] === undefined) {
-    return createArrayArbitrary(nextArb, undefined, 0, undefined, undefined); // no size, no maxLength, no depthIdentifier
-  }
-  // fc.array(arb, constraints)
-  if (typeof args[0] === 'object') {
-    return createArrayArbitrary(
-      nextArb,
-      args[0].size,
-      args[0].minLength || 0,
-      args[0].maxLength,
-      args[0].depthIdentifier
-    );
-  }
-  // fc.array(arb, minLength, maxLength)
-  if (args[1] !== undefined) {
-    return createArrayArbitrary(nextArb, undefined, args[0], args[1], undefined); // no size, no depthIdentifier
-  }
-  // fc.array(arb, maxLength)
-  return createArrayArbitrary(nextArb, undefined, 0, args[0], undefined); // no size, no depthIdentifier
 }
 export { array };

--- a/test/unit/arbitrary/array.spec.ts
+++ b/test/unit/arbitrary/array.spec.ts
@@ -140,45 +140,6 @@ describe('array', () => {
     );
   });
 
-  it('[legacy] should instantiate ArrayArbitrary(arb, 0, maxLength, maxLength, n.a) for array(arb, maxLength)', () => {
-    fc.assert(
-      fc.property(fc.nat({ max: 2 ** 31 - 1 }), (maxLength) => {
-        // Arrange
-        const { instance: childInstance } = fakeNextArbitrary<unknown>();
-        const { instance } = fakeNextArbitrary<unknown[]>();
-        const ArrayArbitrary = jest.spyOn(ArrayArbitraryMock, 'ArrayArbitrary');
-        ArrayArbitrary.mockImplementation(() => instance as ArrayArbitraryMock.ArrayArbitrary<unknown>);
-
-        // Act
-        const arb = array(convertFromNext(childInstance), maxLength);
-
-        // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength, undefined);
-        expect(convertToNext(arb)).toBe(instance);
-      })
-    );
-  });
-
-  it('[legacy] should instantiate ArrayArbitrary(arb, minLength, maxLength, maxLength, n.a) for array(arb, minLength, maxLength)', () => {
-    fc.assert(
-      fc.property(fc.nat({ max: 2 ** 31 - 1 }), fc.nat({ max: 2 ** 31 - 1 }), (aLength, bLength) => {
-        // Arrange
-        const [minLength, maxLength] = aLength < bLength ? [aLength, bLength] : [bLength, aLength];
-        const { instance: childInstance } = fakeNextArbitrary<unknown>();
-        const { instance } = fakeNextArbitrary<unknown[]>();
-        const ArrayArbitrary = jest.spyOn(ArrayArbitraryMock, 'ArrayArbitrary');
-        ArrayArbitrary.mockImplementation(() => instance as ArrayArbitraryMock.ArrayArbitrary<unknown>);
-
-        // Act
-        const arb = array(convertFromNext(childInstance), minLength, maxLength);
-
-        // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength, maxLength, undefined);
-        expect(convertToNext(arb)).toBe(instance);
-      })
-    );
-  });
-
   it('should throw when minimum length is greater than maximum one', () => {
     fc.assert(
       fc.property(fc.nat({ max: 2 ** 31 - 1 }), fc.nat({ max: 2 ** 31 - 1 }), (aLength, bLength) => {

--- a/test/unit/arbitrary/base64String.spec.ts
+++ b/test/unit/arbitrary/base64String.spec.ts
@@ -75,7 +75,7 @@ describe('base64String', () => {
 
           // Assert
           expect(array).toHaveBeenCalledTimes(1);
-          const constraintsOnArray = array.mock.calls[0][1];
+          const constraintsOnArray = array.mock.calls[0][1]!;
           const rounded4 = (value: number) => {
             switch (value % 4) {
               case 0:


### PR DESCRIPTION
Drop any legacy signatures of `fc.array`as planned in #992.
Any signature marked as deprecated on `fc.array` will be dropped by this PR.

Originally merged as #1494 for alpha versions.

Dropped signatures:
- `function array<T>(arb: Arbitrary<T>, maxLength: number): Arbitrary<T[]>`
- `function array<T>(arb: Arbitrary<T>, minLength: number, maxLength: number): Arbitrary<T[]>`

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change for Next major
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ Drop some existing signatures
