### PR TITLE
💥 Remove deprecated signatures of `fc.*subarray`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2699,7 +2699,6 @@ fc.set(fc.hexaString(), {minLength: 5, maxLength: 10, compare: {selector: s => s
 
 - `fc.subarray(originalArray)`
 - `fc.subarray(originalArray, {minLength?, maxLength?})`
-- _`fc.subarray(originalArray, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -2737,7 +2736,6 @@ fc.subarray([1, 42, 48, 69, 75, 92], {minLength: 2, maxLength: 3})
 
 - `fc.shuffledSubarray(originalArray)`
 - `fc.shuffledSubarray(originalArray, {minLength?, maxLength?})`
-- _`fc.shuffledSubarray(originalArray, minLength, maxLength)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/arbitrary/shuffledSubarray.ts
+++ b/src/arbitrary/shuffledSubarray.ts
@@ -26,46 +26,12 @@ export interface ShuffledSubarrayConstraints {
  * For subarrays of `originalArray`
  *
  * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 1.5.0
  * @public
  */
-function shuffledSubarray<T>(originalArray: T[]): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray`
- *
- * @param originalArray - Original array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.shuffledSubarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-function shuffledSubarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray`
- *
- * @param originalArray - Original array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function shuffledSubarray<T>(originalArray: T[], constraints: ShuffledSubarrayConstraints): Arbitrary<T[]>;
-function shuffledSubarray<T>(
-  originalArray: T[],
-  ...args: [] | [number, number] | [ShuffledSubarrayConstraints]
-): Arbitrary<T[]> {
-  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
-    return convertFromNext(new SubarrayArbitrary(originalArray, false, args[0], args[1]));
-  }
-  const ct = args[0] as ShuffledSubarrayConstraints | undefined;
-  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
-  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+export function shuffledSubarray<T>(originalArray: T[], constraints: ShuffledSubarrayConstraints = {}): Arbitrary<T[]> {
+  const { minLength = 0, maxLength = originalArray.length } = constraints;
   return convertFromNext(new SubarrayArbitrary(originalArray, false, minLength, maxLength));
 }
-export { shuffledSubarray };

--- a/src/arbitrary/subarray.ts
+++ b/src/arbitrary/subarray.ts
@@ -26,43 +26,12 @@ export interface SubarrayConstraints {
  * For subarrays of `originalArray` (keeps ordering)
  *
  * @param originalArray - Original array
+ * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
  * @remarks Since 1.5.0
  * @public
  */
-function subarray<T>(originalArray: T[]): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray` (keeps ordering)
- *
- * @param originalArray - Original array
- * @param minLength - Lower bound of the generated array size
- * @param maxLength - Upper bound of the generated array size
- *
- * @deprecated
- * Superceded by `fc.subarray(originalArray, {minLength, maxLength})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-function subarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>;
-/**
- * For subarrays of `originalArray` (keeps ordering)
- *
- * @param originalArray - Original array
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.4.0
- * @public
- */
-function subarray<T>(originalArray: T[], constraints: SubarrayConstraints): Arbitrary<T[]>;
-function subarray<T>(originalArray: T[], ...args: [] | [number, number] | [SubarrayConstraints]): Arbitrary<T[]> {
-  if (typeof args[0] === 'number' && typeof args[1] === 'number') {
-    return convertFromNext(new SubarrayArbitrary(originalArray, true, args[0], args[1]));
-  }
-  const ct = args[0] as SubarrayConstraints | undefined;
-  const minLength = ct !== undefined && ct.minLength !== undefined ? ct.minLength : 0;
-  const maxLength = ct !== undefined && ct.maxLength !== undefined ? ct.maxLength : originalArray.length;
+export function subarray<T>(originalArray: T[], constraints: SubarrayConstraints = {}): Arbitrary<T[]> {
+  const { minLength = 0, maxLength = originalArray.length } = constraints;
   return convertFromNext(new SubarrayArbitrary(originalArray, true, minLength, maxLength));
 }
-export { subarray };


### PR DESCRIPTION
Drop any legacy signatures of `fc.*subarray` as planned in #992.
Any signature marked as deprecated on `fc.*subarray` will be dropped by this PR.

Originally merged as #1505 for alpha versions.

Dropped signatures:
- `function shuffledSubarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>`
- `function subarray<T>(originalArray: T[], minLength: number, maxLength: number): Arbitrary<T[]>`

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change for Next major 
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ Drop some existing signatures
