### PR TITLE
💥 Remove deprecated signatures of `fc.commands`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -4053,7 +4053,6 @@ fc.context()
 
 - `fc.commands(commandArbs)`
 - `fc.commands(commandArbs, {disableReplayLog?, maxCommands?, size?, replayPath?})`
-- _`fc.commands(commandArbs, maxCommands)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/arbitrary/commands.ts
+++ b/src/arbitrary/commands.ts
@@ -17,7 +17,7 @@ import {
  * It should shrink more efficiently than {@link array} for {@link AsyncCommand} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Contraints to be applied when generating the commands (since 1.11.0)
+ * @param constraints - Constraints to be applied when generating the commands (since 1.11.0)
  *
  * @remarks Since 1.5.0
  * @public
@@ -34,7 +34,7 @@ function commands<Model extends object, Real, CheckAsync extends boolean>(
  * It should shrink more efficiently than {@link array} for {@link Command} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Contraints to be applied when generating the commands (since 1.11.0)
+ * @param constraints - Constraints to be applied when generating the commands (since 1.11.0)
  *
  * @remarks Since 1.5.0
  * @public

--- a/src/arbitrary/commands.ts
+++ b/src/arbitrary/commands.ts
@@ -17,51 +17,9 @@ import {
  * It should shrink more efficiently than {@link array} for {@link AsyncCommand} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param maxCommands - Maximal number of commands to build
- *
- * @deprecated
- * Superceded by `fc.commands(commandArbs, {maxCommands})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Contraints to be applied when generating the commands (since 1.11.0)
  *
  * @remarks Since 1.5.0
- * @public
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function commands<Model extends object, Real, CheckAsync extends boolean>(
-  commandArbs: Arbitrary<AsyncCommand<Model, Real, CheckAsync>>[],
-  maxCommands?: number
-): Arbitrary<Iterable<AsyncCommand<Model, Real, CheckAsync>>>;
-/**
- * For arrays of {@link Command} to be executed by {@link modelRun}
- *
- * This implementation comes with a shrinker adapted for commands.
- * It should shrink more efficiently than {@link array} for {@link Command} arrays.
- *
- * @param commandArbs - Arbitraries responsible to build commands
- * @param maxCommands - Maximal number of commands to build
- *
- * @deprecated
- * Superceded by `fc.commands(commandArbs, {maxCommands})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 1.5.0
- * @public
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function commands<Model extends object, Real>(
-  commandArbs: Arbitrary<Command<Model, Real>>[],
-  maxCommands?: number
-): Arbitrary<Iterable<Command<Model, Real>>>;
-/**
- * For arrays of {@link AsyncCommand} to be executed by {@link asyncModelRun}
- *
- * This implementation comes with a shrinker adapted for commands.
- * It should shrink more efficiently than {@link array} for {@link AsyncCommand} arrays.
- *
- * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Contraints to be applied when generating the commands
- *
- * @remarks Since 1.11.0
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -76,9 +34,9 @@ function commands<Model extends object, Real, CheckAsync extends boolean>(
  * It should shrink more efficiently than {@link array} for {@link Command} arrays.
  *
  * @param commandArbs - Arbitraries responsible to build commands
- * @param constraints - Constraints to be applied when generating the commands
+ * @param constraints - Contraints to be applied when generating the commands (since 1.11.0)
  *
- * @remarks Since 1.11.0
+ * @remarks Since 1.5.0
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
Drop any legacy signatures of `fc.commands` as planned in #992.
Any signature marked as deprecated on `fc.commands` will be dropped by this PR.

Originally merged as #1507 for alpha versions.

Dropped signatures:
- `function commands(commandArbs: Arbitrary<C>[], maxCommands: number): Arbitrary<Iterable<C>>`

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change for Next major 
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ Drop some existing signatures
