### PR TITLE
💥 Remove deprecated signatures of `fc.option`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -2133,7 +2133,6 @@ fc.clonedConstant(buildCloneable({ keyA: 1, keyB: 2 }))
 
 - `fc.option(arb)`
 - `fc.option(arb, {freq?, nil?, depthFactor?, maxDepth?, depthIdentifier?})`
-- _`fc.option(arb, freq)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 

--- a/src/arbitrary/option.ts
+++ b/src/arbitrary/option.ts
@@ -44,48 +44,19 @@ export interface OptionConstraints<TNil = null> {
   depthIdentifier?: DepthIdentifier | string;
 }
 
-/** @internal */
-function extractOptionConstraints<TNil>(constraints?: number | OptionConstraints<TNil>): OptionConstraints<TNil> {
-  if (typeof constraints === 'number') return { freq: constraints };
-  if (!constraints) return {};
-  return constraints;
-}
-
-/**
- * For either null or a value coming from `arb`
- *
- * @param arb - Arbitrary that will be called to generate a non null value
- *
- * @remarks Since 0.0.6
- * @public
- */
-function option<T>(arb: Arbitrary<T>): Arbitrary<T | null>;
-/**
- * For either null or a value coming from `arb` with custom frequency
- *
- * @param arb - Arbitrary that will be called to generate a non null value
- * @param freq - The probability to build a null value is of `1 / freq`
- *
- * @deprecated
- * Superceded by `fc.option(arb, {freq})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.6
- * @public
- */
-function option<T>(arb: Arbitrary<T>, freq: number): Arbitrary<T | null>;
 /**
  * For either nil or a value coming from `arb` with custom frequency
  *
  * @param arb - Arbitrary that will be called to generate a non nil value
- * @param constraints - Constraints on the option
+ * @param constraints - Constraints on the option(since 1.17.0)
  *
- * @remarks Since 1.17.0
+ * @remarks Since 0.0.6
  * @public
  */
-function option<T, TNil = null>(arb: Arbitrary<T>, constraints: OptionConstraints<TNil>): Arbitrary<T | TNil>;
-function option<T, TNil>(arb: Arbitrary<T>, rawConstraints?: number | OptionConstraints<TNil>): Arbitrary<T | TNil> {
-  const constraints = extractOptionConstraints(rawConstraints);
+export function option<T, TNil = null>(
+  arb: Arbitrary<T>,
+  constraints: OptionConstraints<TNil> = {}
+): Arbitrary<T | TNil> {
   const freq = constraints.freq == null ? 5 : constraints.freq;
   const nilValue = Object.prototype.hasOwnProperty.call(constraints, 'nil') ? constraints.nil : (null as any);
   const nilArb = constant(nilValue);
@@ -101,4 +72,3 @@ function option<T, TNil>(arb: Arbitrary<T>, rawConstraints?: number | OptionCons
   };
   return FrequencyArbitrary.fromOld(weightedArbs, frequencyConstraints, 'fc.option');
 }
-export { option };

--- a/test/unit/arbitrary/option.spec.ts
+++ b/test/unit/arbitrary/option.spec.ts
@@ -99,40 +99,6 @@ describe('option', () => {
     );
     expect(out).toBe(expectedArb);
   });
-  it('[legacy] should call FrequencyArbitrary.from with the right parameters when called with only freq', () =>
-    fc.assert(
-      fc.property(fc.nat(), (freq) => {
-        // Arrange
-        const expectedArb = convertFromNext(fakeNextArbitrary().instance);
-        const fromOld = jest.spyOn(FrequencyArbitraryMock.FrequencyArbitrary, 'fromOld');
-        fromOld.mockReturnValue(expectedArb);
-        const expectedConstantArb = convertFromNext(fakeNextArbitrary().instance);
-        const constant = jest.spyOn(ConstantMock, 'constant');
-        constant.mockReturnValue(expectedConstantArb);
-        const { instance: nextArb } = fakeNextArbitrary();
-        const arb = convertFromNext(nextArb);
-
-        // Act
-        const out = option(arb, freq);
-
-        // Assert
-        expect(constant).toHaveBeenCalledWith(null);
-        expect(fromOld).toHaveBeenCalledWith(
-          [
-            { arbitrary: expectedConstantArb, weight: 1, fallbackValue: { default: null } },
-            { arbitrary: arb, weight: freq },
-          ],
-          {
-            withCrossShrink: true,
-            depthFactor: undefined,
-            maxDepth: undefined,
-            depthIdentifier: undefined,
-          },
-          'fc.option'
-        );
-        expect(out).toBe(expectedArb);
-      })
-    ));
 });
 
 describe('option (integration)', () => {


### PR DESCRIPTION
Drop any legacy signatures of `fc.option` as planned in #992.
Any signature marked as deprecated on `fc.option` will be dropped by this PR.

Originally merged as #1509 for alpha versions.

Dropped signatures:
- `function option<T>(arb: Arbitrary<T>, freq: number): Arbitrary<T | null>`

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change for Next major
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ Drop some existing signatures
