### PR TITLE
💥 Drop support for TypeScript 3.2 (min ≥4.1)

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -237,10 +237,8 @@ jobs:
           - '*'
           # Various intermediate versions of Typescript
           - '4.4'
-          - '3.9'
-          - '3.4'
           # Minimal requirement for TypeScript
-          - '3.2'
+          - '4.0'
           # Other release channels for TypeScript
           - 'rc'
           - 'next'
@@ -258,16 +256,6 @@ jobs:
         uses: ./.github/actions/install-deps-with-current-fc
         with:
           path: 'test/type'
-      - name: Adapt test/type/for TypeScript 3.4
-        if: matrix.ts-version == '3.2' || matrix.ts-version == '3.4'
-        run: |
-          cd test/type
-          sed -i 's/ts-expect-error/ts-ignore/g' *.ts
-      - name: Adapt test/type/for TypeScript 3.2
-        if: matrix.ts-version == '3.2'
-        run: |
-          cd test/type
-          sed -i 's/fc-require-ts-3.4/ts-ignore/g' *.ts
       - name: TypeScript version
         run: |
           cd test/type
@@ -282,7 +270,7 @@ jobs:
           cd test/type
           npx -p typescript@${{matrix.ts-version}} tsc --moduleResolution nodenext
       - name: Test test/type/ with --exactOptionalPropertyTypes
-        if: matrix.ts-version != '3.2' && matrix.ts-version != '3.4' && matrix.ts-version != '3.9'
+        if: matrix.ts-version != '4.0'
         run: |
           cd test/type
           sed -i 's/fc-expect-error-require-exactOptionalPropertyTypes/ts-expect-error/g' *.ts

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -238,7 +238,7 @@ jobs:
           # Various intermediate versions of Typescript
           - '4.4'
           # Minimal requirement for TypeScript
-          - '4.0'
+          - '4.1'
           # Other release channels for TypeScript
           - 'rc'
           - 'next'
@@ -270,7 +270,7 @@ jobs:
           cd test/type
           npx -p typescript@${{matrix.ts-version}} tsc --moduleResolution nodenext
       - name: Test test/type/ with --exactOptionalPropertyTypes
-        if: matrix.ts-version != '4.0'
+        if: matrix.ts-version != '4.1'
         run: |
           cd test/type
           sed -i 's/fc-expect-error-require-exactOptionalPropertyTypes/ts-expect-error/g' *.ts

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Here are the minimal requirements to use fast-check properly without any polyfil
 
 | fast-check | node                | ECMAScript version | _TypeScript (optional)_ |
 | ---------- | ------------------- | ------------------ | ----------------------- |
-| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.0                    |
+| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.1                    |
 | **2.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥3.2                    |
 | **1.x**    | ≥0.12<sup>(1)</sup> | ES3                | ≥3.0                    |
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Here are the minimal requirements to use fast-check properly without any polyfil
 
 | fast-check | node                | ECMAScript version | _TypeScript (optional)_ |
 | ---------- | ------------------- | ------------------ | ----------------------- |
+| **3.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥4.0                    |
 | **2.x**    | ≥8<sup>(1)</sup>    | ES2017             | ≥3.2                    |
 | **1.x**    | ≥0.12<sup>(1)</sup> | ES3                | ≥3.0                    |
 

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -128,18 +128,18 @@ expectType<fc.Arbitrary<number>>()(
   fc.constantFrom(1, 2),
   'By default, "constantFrom" simplifies the type (eg.: "1 -> number")'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<1 | 2>>()(fc.constantFrom(...([1, 2] as const)), '"as const" prevent extra simplification of "constantFrom"');
-// prettier-ignore-end
+expectType<fc.Arbitrary<1 | 2>>()(
+  fc.constantFrom(...([1, 2] as const)),
+  '"as const" prevent extra simplification of "constantFrom"'
+);
 expectType<fc.Arbitrary<number | string>>()(
   fc.constantFrom(1, 2, 'hello'),
   '"constantFrom" accepts arguments not having the same types without any typing trick'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<1 | 2 | 'hello'>>()(fc.constantFrom(...([1, 2, 'hello'] as const)), '"as const" prevent extra simplification of "constantFrom"');
-// prettier-ignore-end
+expectType<fc.Arbitrary<1 | 2 | 'hello'>>()(
+  fc.constantFrom(...([1, 2, 'hello'] as const)),
+  '"as const" prevent extra simplification of "constantFrom"'
+);
 
 // uniqueArray arbitrary
 expectType<fc.Arbitrary<string[]>>()(fc.uniqueArray(fc.string()), 'simple arrays of unique values');
@@ -267,16 +267,12 @@ expectType<fc.Arbitrary<never>>()(
 type Query = { data: { field: 'X' } };
 expectType<fc.Arbitrary<Query>>()(
   // issue 1453
-  // @fc-require-ts-3.4
   fc.record<Query>({ data: fc.record({ field: fc.constant('X') }) }),
-  // @fc-require-ts-3.4
   '"record" can be passed the requested type in <*>'
 );
 expectType<fc.Arbitrary<Partial<Query>>>()(
   // issue 1453
-  // @fc-require-ts-3.4
   fc.record<Partial<Query>>({ data: fc.record({ field: fc.constant('X') }) }),
-  // @fc-require-ts-3.4
   '"record" can be passed something assignable to the requested type in <*>'
 );
 // @ts-expect-error - requiredKeys references an unknown key
@@ -342,10 +338,10 @@ expectType<fc.Arbitrary<number | null>>()(
   fc.option(fc.nat(), { nil: null }),
   '"option" with nil overriden to null (the original default)'
 );
-// prettier-ignore
-// @fc-require-ts-3.4
-expectType<fc.Arbitrary<number | 'custom_default'>>()(fc.option(fc.nat(), { nil: 'custom_default' as const }), '"option" with nil overriden to custom value');
-// prettier-ignore-end
+expectType<fc.Arbitrary<number | 'custom_default'>>()(
+  fc.option(fc.nat(), { nil: 'custom_default' as const }),
+  '"option" with nil overriden to custom value'
+);
 // @ts-expect-error - option expects arbitraries not raw values
 fc.option(1);
 


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Officially dropping support for TypeScript <4.1 for next major aka 3.x.

In version 2.x of fast-check, we used to support any version of TypeScript ≥3.2. It will not be the case anymore starting at 3.x.
In version 3.x, we will support any version of TypeScript ≥4.1, so we dropped part of the supported range.

This PR is a rework of #1517 and #1520 for the target 3.x major of fast-check.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [x] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [x] Typings
- [ ] _Other(s):_ ...
