### PR TITLE
💥 Remove deprecated signatures of `fc.integer`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -92,8 +92,6 @@ fc.boolean()
 
 - `fc.integer()`
 - `fc.integer({min?, max?})`
-- `fc.integer(min, max)`
-- _`fc.integer(max)`_ — _deprecated since v2.6.0 ([#992](https://github.com/dubzzz/fast-check/issues/992))_
 
 *&#8195;with:*
 
@@ -106,14 +104,6 @@ fc.boolean()
 fc.integer()
 // Note: All possible integers between `-2147483648` (included) and `2147483647` (included)
 // Examples of generated values: 1502944448, 888414599, 1123740386, -440217435, 19…
-
-fc.integer(1000)
-// Note: All possible integers between `-2147483648` (included) and `1000` (included)
-// Examples of generated values: -1057705109, -8, -1089721660, -1878447823, -741474720…
-
-fc.integer(-99, 99)
-// Note: All possible integers between `-99` (included) and `99` (included)
-// Examples of generated values: 6, -1, -96, 91, 5…
 
 fc.integer({min: -99, max: 99})
 // Note: All possible integers between `-99` (included) and `99` (included)
@@ -3649,9 +3639,9 @@ fc.string().map(s => `[${s.length}] -> ${s}`)
 *&#8195;Usages*
 
 ```js
-fc.nat().chain(min => fc.tuple(fc.constant(min), fc.integer(min, 0xffffffff)))
+fc.nat().chain(min => fc.tuple(fc.constant(min), fc.integer({min, max: 0xffffffff})))
 // Note: Produce a valid range
-// Examples of generated values: [2147483631,2602190685], [722484778,1844243122], [52754604,4294967287], [231714704,420820067], [3983528,3983548]…
+// Examples of generated values: [18,41], [251380276,4294967271], [903576661,1386263072], [1532947910,1532947934], [1301381459,1832484226]…
 ```
 </details>
 

--- a/src/arbitrary/integer.ts
+++ b/src/arbitrary/integer.ts
@@ -33,81 +33,24 @@ function buildCompleteIntegerConstraints(constraints: IntegerConstraints): Requi
 }
 
 /**
- * Extract constraints from args received by integer
- * @internal
- */
-function extractIntegerConstraints(args: [] | [number] | [number, number] | [IntegerConstraints]): IntegerConstraints {
-  if (args[0] === undefined) {
-    // integer()
-    return {};
-  } // args.length > 0
-
-  if (args[1] === undefined) {
-    const sargs = args as typeof args & [unknown]; // exactly 1 arg specified
-    if (typeof sargs[0] === 'number') return { max: sargs[0] }; // integer(max)
-    return sargs[0]; // integer(constraints)
-  } // args.length > 1
-
-  const sargs = args as typeof args & [unknown, unknown];
-  return { min: sargs[0], max: sargs[1] }; // integer(min, max)
-}
-
-/**
- * For integers between -2147483648 (included) and 2147483647 (included)
- * @remarks Since 0.0.1
- * @public
- */
-function integer(): ArbitraryWithContextualShrink<number>;
-/**
- * For integers between -2147483648 (included) and max (included)
- *
- * @param max - Upper bound for the generated integers (eg.: 2147483647, Number.MAX_SAFE_INTEGER)
- *
- * @deprecated
- * Superceded by `fc.integer({max})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
- *
- * @remarks Since 0.0.1
- * @public
- */
-function integer(max: number): ArbitraryWithContextualShrink<number>;
-/**
  * For integers between min (included) and max (included)
  *
- * @param min - Lower bound for the generated integers (eg.: 0, Number.MIN_SAFE_INTEGER)
- * @param max - Upper bound for the generated integers (eg.: 2147483647, Number.MAX_SAFE_INTEGER)
- *
- * @deprecated
- * Superceded by `fc.integer({min,max})` - see {@link https://github.com/dubzzz/fast-check/issues/992 | #992}.
- * Ease the migration with {@link https://github.com/dubzzz/fast-check/tree/main/codemods/unify-signatures | our codemod script}.
+ * @param constraints - Constraints to apply when building instances (since 2.6.0)
  *
  * @remarks Since 0.0.1
  * @public
  */
-function integer(min: number, max: number): ArbitraryWithContextualShrink<number>;
-/**
- * For integers between min (included) and max (included)
- *
- * @param constraints - Constraints to apply when building instances
- *
- * @remarks Since 2.6.0
- * @public
- */
-function integer(constraints: IntegerConstraints): ArbitraryWithContextualShrink<number>;
-function integer(
-  ...args: [] | [number] | [number, number] | [IntegerConstraints]
-): ArbitraryWithContextualShrink<number> {
-  const constraints = buildCompleteIntegerConstraints(extractIntegerConstraints(args));
-  if (constraints.min > constraints.max) {
+export function integer(constraints: IntegerConstraints = {}): ArbitraryWithContextualShrink<number> {
+  const fullConstraints = buildCompleteIntegerConstraints(constraints);
+  if (fullConstraints.min > fullConstraints.max) {
     throw new Error('fc.integer maximum value should be equal or greater than the minimum one');
   }
-  if (!Number.isInteger(constraints.min)) {
+  if (!Number.isInteger(fullConstraints.min)) {
     throw new Error('fc.integer minimum value should be an integer');
   }
-  if (!Number.isInteger(constraints.max)) {
+  if (!Number.isInteger(fullConstraints.max)) {
     throw new Error('fc.integer maximum value should be an integer');
   }
-  const arb = new IntegerArbitrary(constraints.min, constraints.max);
+  const arb = new IntegerArbitrary(fullConstraints.min, fullConstraints.max);
   return convertFromNextWithShrunkOnce(arb, arb.defaultTarget());
 }
-export { integer };

--- a/test/unit/arbitrary/date.spec.ts
+++ b/test/unit/arbitrary/date.spec.ts
@@ -10,10 +10,7 @@ import {
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/NextArbitraryAssertions';
 
-import * as _IntegerMock from '../../../src/arbitrary/integer';
-import { ArbitraryWithShrink } from '../../../src/check/arbitrary/definition/ArbitraryWithShrink';
-const IntegerMock: { integer: (constraints?: _IntegerMock.IntegerConstraints) => ArbitraryWithShrink<number> } =
-  _IntegerMock;
+import * as IntegerMock from '../../../src/arbitrary/integer';
 
 function beforeEachHook() {
   jest.resetModules();

--- a/test/unit/arbitrary/float.spec.ts
+++ b/test/unit/arbitrary/float.spec.ts
@@ -173,8 +173,8 @@ describe('float', () => {
 
           // Assert
           expect(integer).toHaveBeenCalledTimes(2);
-          const integerConstraintsNoNaN = integer.mock.calls[0][0];
-          const integerConstraintsWithNaN = integer.mock.calls[1][0];
+          const integerConstraintsNoNaN = integer.mock.calls[0][0]!;
+          const integerConstraintsWithNaN = integer.mock.calls[1][0]!;
           if (max > 0) {
             // max > 0  --> NaN will be added as the greatest value
             expect(integerConstraintsWithNaN.min).toBe(integerConstraintsNoNaN.min);
@@ -200,8 +200,8 @@ describe('float', () => {
           float({ ...ct, noNaN: true });
           const arb = float(ct);
           // Extract NaN "index"
-          const { min: minNonNaN } = integer.mock.calls[0][0];
-          const { min: minNaN, max: maxNaN } = integer.mock.calls[1][0];
+          const { min: minNonNaN } = integer.mock.calls[0][0]!;
+          const { min: minNaN, max: maxNaN } = integer.mock.calls[1][0]!;
           const indexForNaN = minNonNaN !== minNaN ? minNaN : maxNaN;
           if (indexForNaN === undefined) throw new Error('No value available for NaN');
           arbitraryGenerated.value = indexForNaN;

--- a/test/unit/arbitrary/integer.spec.ts
+++ b/test/unit/arbitrary/integer.spec.ts
@@ -100,41 +100,6 @@ describe('integer', () => {
       })
     ));
 
-  it('[legacy] should instantiate IntegerArbitrary(-0x80000000, max) for integer(max)', () =>
-    fc.assert(
-      fc.property(fc.integer({ min: -0x80000000, max: Number.MAX_SAFE_INTEGER }), (max) => {
-        // Arrange
-        const instance = fakeIntegerArbitrary();
-        const IntegerArbitrary = jest.spyOn(IntegerArbitraryMock, 'IntegerArbitrary');
-        IntegerArbitrary.mockImplementation(() => instance);
-
-        // Act
-        const arb = integer(max);
-
-        // Assert
-        expect(IntegerArbitrary).toHaveBeenCalledWith(-0x80000000, max);
-        expect(convertToNext(arb)).toBe(instance);
-      })
-    ));
-
-  it('[legacy] should instantiate IntegerArbitrary(min, max) for integer(min, max)', () =>
-    fc.assert(
-      fc.property(fc.maxSafeInteger(), fc.maxSafeInteger(), (a, b) => {
-        // Arrange
-        const [min, max] = a < b ? [a, b] : [b, a];
-        const instance = fakeIntegerArbitrary();
-        const IntegerArbitrary = jest.spyOn(IntegerArbitraryMock, 'IntegerArbitrary');
-        IntegerArbitrary.mockImplementation(() => instance);
-
-        // Act
-        const arb = integer(min, max);
-
-        // Assert
-        expect(IntegerArbitrary).toHaveBeenCalledWith(min, max);
-        expect(convertToNext(arb)).toBe(instance);
-      })
-    ));
-
   it('should throw when minimum value is greater than default maximum one', () =>
     fc.assert(
       fc.property(fc.integer({ min: 0x80000000, max: Number.MAX_SAFE_INTEGER }), (min) => {


### PR DESCRIPTION
Drop any legacy signatures of `fc.integer` as planned in #992.
Any signature marked as deprecated on `fc.integer` will be dropped by this PR.

Originally merged as #1511 for alpha versions.

Dropped signatures:
- `function integer(max: number): ArbitraryWithContextualShrink<number>`
- `function integer(min: number, max: number): ArbitraryWithContextualShrink<number>`

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ Breaking change
