### PR TITLE
💥 No `depthFactor` specified means: use defaulted configuration

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -968,7 +968,7 @@ fc.stringOf(fc.constantFrom('Hello', 'World'), {minLength: 1, maxLength: 3})
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -1017,7 +1017,7 @@ fc.json({depthFactor: 'medium'})
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -2776,7 +2776,7 @@ fc.record({
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `5` — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `size?` — default: `undefined` [more](#size-explained) — _how large should the generated values be?_
@@ -2889,7 +2889,7 @@ fc.object({
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -2991,7 +2991,7 @@ fc.statistics(
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -3029,7 +3029,7 @@ fc.unicodeJsonValue({maxDepth: 1})
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
-- `depthFactor?` — default: `=` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
 - `maxDepth?` — default: `2` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `5` — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `size?` — default: `undefined` [more](#size-explained) — _how large should the generated values be?_
@@ -3502,7 +3502,7 @@ fc.statistics(
 
 ```js
 // Setup the tree structure:
-const tree = fc.memo(n => fc.oneof(node(n), node(n), leaf())); // double the probability of nodes compared to leaves
+const tree = fc.memo(n => fc.oneof(leaf(), node(n)));
 const node = fc.memo(n => {
   if (n <= 1) return fc.record({ left: leaf(), right: leaf() });
   return fc.record({ left: tree(), right: tree() }); // tree() is equivalent to tree(n-1)
@@ -3512,11 +3512,11 @@ const leaf = fc.nat;
 tree(2)
 // Note: Only produce trees having a maximal depth of 2
 // Examples of generated values:
-// • {"left":{"left":23,"right":2},"right":{"left":210148030,"right":283093342}}
-// • 1883170510
-// • 4879206
-// • {"left":{"left":2147483622,"right":2147483643},"right":{"left":1297112406,"right":883126194}}
-// • {"left":{"left":13,"right":2147483635},"right":{"left":1861062539,"right":20}}
+// • {"left":{"left":1034146857,"right":26},"right":{"left":739853254,"right":2147483623}}
+// • {"left":{"left":19,"right":2147483639},"right":{"left":1503072025,"right":2147483633}}
+// • {"left":1,"right":{"left":2147483626,"right":12}}
+// • {"left":2147483619,"right":{"left":279104538,"right":3}}
+// • 1978324282
 // • …
 ```
 </details>
@@ -3772,11 +3772,11 @@ and `+infinity`. It was used to reduce the risk of generating infinite structure
 the higher the depth factor, the higher the chance to build not very deep instances.
 
 Then size came in 2.22.0 and with it an idea: make it simple for users to configure complex things. While depth factor
-was pretty cool, selecting the right value was not trivial from a user point of view. So size has been leverage for both:
+was pretty cool, selecting the right value was not trivial from a user point of view. So size has been leveraged for both:
 number of items defined within an iterable structure and depth. Except very complex and ad-hoc cases, we expect size to
 be the only kind of configuration used to setup depth factors.
 
-Depth factor derived from size works exactly the same way as size, it can rely on Relative Size but also Explicit Size.
+Depth factor derived from size works exactly the same way as size, it can rely on Relative Size but also Explicit Size. By default when not explicitely set it will be defaulted to `=` and will ignore `defaultSizeToMaxWhenMaxSpecified` which has been added for length-based sizes.
 
 Here is how a size translates into depth factors:
 - `xsmall` — `1`

--- a/src/arbitrary/_internals/helpers/MaxLengthFromMinLength.ts
+++ b/src/arbitrary/_internals/helpers/MaxLengthFromMinLength.ts
@@ -148,13 +148,7 @@ export function depthFactorFromSizeForArbitrary(depthFactorOrSize: DepthFactorSi
   if (typeof depthFactorOrSize === 'number') {
     return depthFactorOrSize;
   }
-  const { baseSize } = readConfigureGlobal() || {};
-  if (depthFactorOrSize === undefined && baseSize === undefined) {
-    // This early return is mostly there for legacy reasons in the context of v2
-    // it will be dropped with the release of v3
-    return 0;
-  }
-  const defaultSize = baseSize !== undefined ? baseSize : DefaultSize;
+  const { baseSize: defaultSize = DefaultSize } = readConfigureGlobal() || {};
   const definedSize = depthFactorOrSize !== undefined ? depthFactorOrSize : defaultSize;
   const finalSize = relativeSizeToSize(definedSize, defaultSize);
   switch (finalSize) {

--- a/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
+++ b/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
@@ -118,8 +118,8 @@ export interface ObjectConstraints {
  * Internal wrapper around an `ObjectConstraints`, it adds all the missing pieces in the configuration
  * @internal
  */
-export type QualifiedObjectConstraints = Required<Omit<ObjectConstraints, 'withBoxedValues' | 'size'>> &
-  Pick<ObjectConstraints, 'size'>;
+export type QualifiedObjectConstraints = Required<Omit<ObjectConstraints, 'withBoxedValues' | 'depthFactor' | 'size'>> &
+  Pick<ObjectConstraints, 'depthFactor' | 'size'>;
 
 /** @internal */
 function defaultValues(constraints: { size: SizeForArbitrary }): Arbitrary<unknown>[] {
@@ -157,7 +157,7 @@ export function toQualifiedObjectConstraints(settings: ObjectConstraints = {}): 
       orDefault(settings.values, defaultValues(valueConstraints)),
       orDefault(settings.withBoxedValues, false)
     ),
-    depthFactor: orDefault(settings.depthFactor, '='), // forcing usage of size for depth for v2 (will be the default in v3)
+    depthFactor: settings.depthFactor,
     maxDepth: orDefault(settings.maxDepth, 2),
     maxKeys: orDefault(settings.maxKeys, 5),
     size: settings.size,

--- a/test/e2e/RecursiveStructures.spec.ts
+++ b/test/e2e/RecursiveStructures.spec.ts
@@ -11,7 +11,7 @@ describe(`RecursiveStructures (seed: ${seed})`, () => {
     const failingLength = 2;
     const dataArb = fc.letrec((tie) => ({
       data: fc.frequency(
-        { withCrossShrink: true, depthFactor: 'small' },
+        { withCrossShrink: true },
         { arbitrary: fc.constant([0]), weight: 1 },
         { arbitrary: fc.tuple(tie('data'), tie('data')), weight: 1 }
       ),
@@ -29,11 +29,7 @@ describe(`RecursiveStructures (seed: ${seed})`, () => {
     // Arrange
     const failingLength = 2;
     const dataArb = fc.letrec((tie) => ({
-      data: fc.oneof(
-        { withCrossShrink: true, depthFactor: 'small' },
-        fc.constant([0]),
-        fc.tuple(tie('data'), tie('data'))
-      ),
+      data: fc.oneof({ withCrossShrink: true }, fc.constant([0]), fc.tuple(tie('data'), tie('data'))),
     })).data;
 
     // Act
@@ -48,7 +44,7 @@ describe(`RecursiveStructures (seed: ${seed})`, () => {
     // Arrange
     const failingLength = 2;
     const dataArb = fc.letrec((tie) => ({
-      data: fc.option(fc.tuple(tie('data'), tie('data')), { nil: [0], depthFactor: 'small' }),
+      data: fc.option(fc.tuple(tie('data'), tie('data')), { nil: [0] }),
     })).data;
 
     // Act

--- a/test/e2e/arbitraries/LetRecArbitrary.spec.ts
+++ b/test/e2e/arbitraries/LetRecArbitrary.spec.ts
@@ -15,7 +15,16 @@ describe(`LetRecArbitrary (seed: ${seed})`, () => {
     });
     it('Should be usable to build deep tree instances', () => {
       const { tree } = fc.letrec((tie) => ({
-        tree: fc.oneof(tie('leaf'), tie('node')),
+        tree: fc.frequency(
+          // No depth factor for this test as we want to go as deep as possible.
+          // While using a depth factor does not prevent such structure from being generated,
+          // it may highly reduce their probability to be generated. So for the sake of this test,
+          // we want to manually handle the depth via setting manually our weight so that the structure
+          // will not explode and go too deep.
+          { depthFactor: 0 },
+          { arbitrary: tie('node'), weight: 45 },
+          { arbitrary: tie('leaf'), weight: 55 }
+        ),
         node: fc.tuple(tie('tree'), tie('tree')),
         leaf: fc.nat(),
       }));

--- a/test/e2e/arbitraries/LetRecArbitrary.spec.ts
+++ b/test/e2e/arbitraries/LetRecArbitrary.spec.ts
@@ -15,7 +15,7 @@ describe(`LetRecArbitrary (seed: ${seed})`, () => {
     });
     it('Should be usable to build deep tree instances', () => {
       const { tree } = fc.letrec((tie) => ({
-        tree: fc.frequency({ arbitrary: tie('node'), weight: 45 }, { arbitrary: tie('leaf'), weight: 55 }),
+        tree: fc.oneof(tie('leaf'), tie('node')),
         node: fc.tuple(tie('tree'), tie('tree')),
         leaf: fc.nat(),
       }));

--- a/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
+++ b/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
@@ -1022,7 +1022,6 @@ describe('SchedulerImplem', () => {
               self: fc.record({
                 name: fc.hexaString({ minLength: 4, maxLength: 4 }).noBias(),
                 children: fc.oneof(
-                  { depthFactor: 'small' },
                   fc.constant<ExecutionPlan[]>([]),
                   fc.array(tie('self') as fc.Arbitrary<ExecutionPlan>)
                 ),


### PR DESCRIPTION
For backward compatibility reasons, this behaviour has only be applied on some existing structures for v2. Indeed, applying it to `oneof` or `frequency` would potentially have introduced breaking changes for the end-user. As an example of such issue, the test "_Should be usable to build deep tree instances_" had to be adapted to prevent geenrating too many nodes (nodes being the fallback when the tree goes deep in the legacy code).

For the end-user, the change has one impact: the first arbitrary specified in `frequency` or `oneof` must be the terminal case. In other words, not one triggering another recursion.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
