### PR TITLE
✨ Add the ability to define use max as depth factor

### DIFF
--- a/src/arbitrary/_internals/helpers/MaxLengthFromMinLength.ts
+++ b/src/arbitrary/_internals/helpers/MaxLengthFromMinLength.ts
@@ -55,10 +55,12 @@ export type SizeForArbitrary = RelativeSize | Size | 'max' | undefined;
  * When used with numeric values, the smaller the number (floating point number &gt;= 0),
  * the deeper the structure. 0 meaning "depth has no impact".
  *
+ * Using `max` or `0` is fully equivalent.
+ *
  * @remarks Since 2.25.0
  * @public
  */
-export type DepthFactorSizeForArbitrary = RelativeSize | Size | number | undefined;
+export type DepthFactorSizeForArbitrary = RelativeSize | Size | 'max' | number | undefined;
 
 /**
  * The default size used by fast-check
@@ -147,6 +149,9 @@ export function maxGeneratedLengthFromSizeForArbitrary(
 export function depthFactorFromSizeForArbitrary(depthFactorOrSize: DepthFactorSizeForArbitrary): number {
   if (typeof depthFactorOrSize === 'number') {
     return depthFactorOrSize;
+  }
+  if (depthFactorOrSize === 'max') {
+    return 0;
   }
   const { baseSize: defaultSize = DefaultSize } = readConfigureGlobal() || {};
   const definedSize = depthFactorOrSize !== undefined ? depthFactorOrSize : defaultSize;

--- a/test/e2e/arbitraries/LetRecArbitrary.spec.ts
+++ b/test/e2e/arbitraries/LetRecArbitrary.spec.ts
@@ -16,12 +16,12 @@ describe(`LetRecArbitrary (seed: ${seed})`, () => {
     it('Should be usable to build deep tree instances', () => {
       const { tree } = fc.letrec((tie) => ({
         tree: fc.frequency(
-          // No depth factor for this test as we want to go as deep as possible.
-          // While using a depth factor does not prevent such structure from being generated,
+          // Depth factor is 'max' for this test as we want to go as deep as possible.
+          // While using non-maxed depth factor does not prevent such structure from being generated,
           // it may highly reduce their probability to be generated. So for the sake of this test,
           // we want to manually handle the depth via setting manually our weight so that the structure
           // will not explode and go too deep.
-          { depthFactor: 0 },
+          { depthFactor: 'max' },
           { arbitrary: tie('node'), weight: 45 },
           { arbitrary: tie('leaf'), weight: 55 }
         ),

--- a/test/unit/arbitrary/_internals/helpers/MaxLengthFromMinLength.spec.ts
+++ b/test/unit/arbitrary/_internals/helpers/MaxLengthFromMinLength.spec.ts
@@ -308,6 +308,18 @@ describe('depthFactorFromSizeForArbitrary', () => {
       })
     );
   });
+
+  it('should always return 0 if size is max whatever the global configuration', () => {
+    fc.assert(
+      fc.property(sizeRelatedGlobalConfigArb, (config) => {
+        // Arrange / Act
+        const computedDepthFactor = withConfiguredGlobal(config, () => depthFactorFromSizeForArbitrary('max'));
+
+        // Assert
+        expect(computedDepthFactor).toBe(0);
+      })
+    );
+  });
 });
 
 describe('relativeSizeToSize', () => {


### PR DESCRIPTION
Up-to-now the size of 'max' has been reserved to length-related sizes. We want to extend its support to depth-related sizes too.

This PR adds the ability to set the depth factor as 'max'. Setting it as max is fully equivalent to setting it as 0 (we have potential plans to change this 0 into a +infinity so that max means the highest value and not the smallest one as it is the case for the moment).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
