### PR TITLE
💥 Stop defaulting `maxCount` on `lorem`

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -1063,7 +1063,7 @@ fc.unicodeJson({depthFactor: 'medium'})
 
 *&#8195;with:*
 
-- `maxCount?` — default: `5` — if `sentenceMode` is `true`: lorem ipsum sentence containing at most `maxCount` sentences, otherwise: containing at most `maxCount` words_
+- `maxCount?` — default: `0x7fffffff` [more](#size-explained) — if `mode` is `"words"`: lorem ipsum sentence containing at most `maxCount` sentences, otherwise: containing at most `maxCount` words_
 - `mode?` — default: `"words"` — _enable sentence mode by setting its value to `"sentences"`_
 - `size?` — default: `undefined` [more](#size-explained) — _how large should the generated values be?_
 
@@ -1071,7 +1071,13 @@ fc.unicodeJson({depthFactor: 'medium'})
 
 ```js
 fc.lorem()
-// Examples of generated values: "arcu fusce", "dolor mi dignissim", "felis lacus", "ligula nec curae sed enim", "tincidunt vivamus massa"…
+// Examples of generated values:
+// • "arcu fusce lorem fermentum in consectetur enim praesent convallis pede"
+// • "dolor mi dignissim cubilia"
+// • "felis lacus suscipit ipsum"
+// • "ligula nec curae sed enim est"
+// • "tincidunt vivamus massa tempus in et iaculis amet placerat at"
+// • …
 
 fc.lorem({maxCount: 3})
 // Examples of generated values: "praesent libero sodales", "mi adipiscing", "ut duis vitae", "mi elementum gravida", "non"…

--- a/src/arbitrary/lorem.ts
+++ b/src/arbitrary/lorem.ts
@@ -23,8 +23,6 @@ export interface LoremConstraints {
    * - maximal number of words in case mode is 'words'
    * - maximal number of sentences in case mode is 'sentences'
    *
-   * @defaultValue 5
-   *
    * @remarks Since 2.5.0
    */
   maxCount?: number;
@@ -237,8 +235,8 @@ function loremWord() {
  * @public
  */
 export function lorem(constraints: LoremConstraints = {}): Arbitrary<string> {
-  const { maxCount = 5, mode = 'words', size } = constraints;
-  if (maxCount < 1) {
+  const { maxCount, mode = 'words', size } = constraints;
+  if (maxCount !== undefined && maxCount < 1) {
     throw new Error(`lorem has to produce at least one word/sentence`);
   }
   const wordArbitrary = loremWord();

--- a/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -2610,17 +2610,21 @@ Execution summary:
 `;
 
 exports[`NoRegression lorem 1`] = `
-"Property failed after 1 tests
-{ seed: 42, path: \\"0:1\\", endOnFailure: true }
-Counterexample: [\\"ullamcorper morbi\\"]
-Shrunk 1 time(s)
+"Property failed after 2 tests
+{ seed: 42, path: \\"1:1:0:0:0\\", endOnFailure: true }
+Counterexample: [\\"ullamcorper leo\\"]
+Shrunk 4 time(s)
 Got error: Property failed by returning false
 
 Execution summary:
-[31m×[0m [\\"tristique ullamcorper morbi\\"]
-. [32m√[0m [\\"morbi\\"]
-. [31m×[0m [\\"ullamcorper morbi\\"]
-. . [32m√[0m [\\"morbi\\"]"
+[32m√[0m [\\"tristique\\"]
+[31m×[0m [\\"quam gravida nulla non blandit proin congue lobortis in ullamcorper leo\\"]
+. [32m√[0m [\\"leo\\"]
+. [31m×[0m [\\"proin congue lobortis in ullamcorper leo\\"]
+. . [31m×[0m [\\"lobortis in ullamcorper leo\\"]
+. . . [31m×[0m [\\"in ullamcorper leo\\"]
+. . . . [31m×[0m [\\"ullamcorper leo\\"]
+. . . . . [32m√[0m [\\"leo\\"]"
 `;
 
 exports[`NoRegression mapToConstant 1`] = `


### PR DESCRIPTION
Just stop specifying an unneeded default value for the maximal number of items to be generated by `lorem`. Let users fully control the constraints they want to apply or not.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
