### PR TITLE
💥 Change the output of `Property::run` to return the original error

### DIFF
--- a/src/check/property/IRawProperty.ts
+++ b/src/check/property/IRawProperty.ts
@@ -4,6 +4,25 @@ import { Value } from '../arbitrary/definition/Value';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
 
 /**
+ * Represent failures of the property
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type PropertyFailure = {
+  /**
+   * The original error that has been intercepted.
+   * Possibly not an instance Error as users can throw anything.
+   * @remarks Since 3.0.0
+   */
+  error: unknown;
+  /**
+   * The error message extracted from the error
+   * @remarks Since 3.0.0
+   */
+  errorMessage: string;
+};
+
+/**
  * Property
  *
  * A property is the combination of:
@@ -49,8 +68,8 @@ export interface IRawProperty<Ts, IsAsync extends boolean = boolean> {
   run(
     v: Ts
   ):
-    | (IsAsync extends true ? Promise<PreconditionFailure | string | null> : never)
-    | (IsAsync extends false ? PreconditionFailure | string | null : never);
+    | (IsAsync extends true ? Promise<PreconditionFailure | PropertyFailure | null> : never)
+    | (IsAsync extends false ? PreconditionFailure | PropertyFailure | null : never);
 }
 
 /**

--- a/src/check/property/Property.generic.ts
+++ b/src/check/property/Property.generic.ts
@@ -1,7 +1,7 @@
 import { Random } from '../../random/generator/Random';
 import { Arbitrary } from '../arbitrary/definition/Arbitrary';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
-import { IRawProperty, runIdToFrequency } from './IRawProperty';
+import { PropertyFailure, IRawProperty, runIdToFrequency } from './IRawProperty';
 import { readConfigureGlobal, GlobalPropertyHookFunction } from '../runner/configuration/GlobalParameters';
 import { Value } from '../arbitrary/definition/Value';
 import { Stream } from '../../stream/Stream';
@@ -116,17 +116,21 @@ export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
     return this.arb.shrink(value.value_, safeContext).map(noUndefinedAsContext);
   }
 
-  run(v: Ts): PreconditionFailure | string | null {
+  run(v: Ts): PreconditionFailure | PropertyFailure | null {
     this.beforeEachHook();
     try {
       const output = this.predicate(v);
-      return output == null || output === true ? null : 'Property failed by returning false';
+      return output == null || output === true
+        ? null
+        : { error: undefined, errorMessage: 'Property failed by returning false' };
     } catch (err) {
       // precondition failure considered as success for the first version
       if (PreconditionFailure.isFailure(err)) return err;
-      // exception as string in case of real failure
-      if (err instanceof Error && err.stack) return `${err}\n\nStack trace: ${err.stack}`;
-      return `${err}`;
+      // exception as PropertyFailure in case of real failure
+      if (err instanceof Error && err.stack) {
+        return { error: err, errorMessage: `${err}\n\nStack trace: ${err.stack}` };
+      }
+      return { error: err, errorMessage: `${err}` };
     } finally {
       this.afterEachHook();
     }

--- a/src/check/property/TimeoutProperty.ts
+++ b/src/check/property/TimeoutProperty.ts
@@ -2,14 +2,14 @@ import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
 import { Value } from '../arbitrary/definition/Value';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
-import { IRawProperty } from './IRawProperty';
+import { PropertyFailure, IRawProperty } from './IRawProperty';
 
 /** @internal */
 const timeoutAfter = (timeMs: number) => {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  const promise = new Promise<string>((resolve) => {
+  const promise = new Promise<PropertyFailure>((resolve) => {
     timeoutHandle = setTimeout(() => {
-      resolve(`Property timeout: exceeded limit of ${timeMs} milliseconds`);
+      resolve({ error: undefined, errorMessage: `Property timeout: exceeded limit of ${timeMs} milliseconds` });
     }, timeMs);
   });
   return {
@@ -36,7 +36,7 @@ export class TimeoutProperty<Ts> implements IRawProperty<Ts, true> {
     return this.property.shrink(value);
   }
 
-  async run(v: Ts): Promise<string | PreconditionFailure | null> {
+  async run(v: Ts): Promise<PreconditionFailure | PropertyFailure | null> {
     const t = timeoutAfter(this.timeMs);
     const propRun = Promise.race([this.property.run(v), t.promise]);
     propRun.then(t.clear, t.clear); // always clear timeout handle - catch should never occur

--- a/src/check/runner/Runner.ts
+++ b/src/check/runner/Runner.ts
@@ -1,6 +1,6 @@
 import { Stream, stream } from '../../stream/Stream';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
-import { IRawProperty } from '../property/IRawProperty';
+import { PropertyFailure, IRawProperty } from '../property/IRawProperty';
 import { readConfigureGlobal } from './configuration/GlobalParameters';
 import { Parameters } from './configuration/Parameters';
 import { QualifiedParameters } from './configuration/QualifiedParameters';
@@ -27,7 +27,7 @@ function runIt<Ts>(
 ): RunExecution<Ts> {
   const runner = new RunnerIterator(sourceValues, shrink, verbose, interruptedAsFailure);
   for (const v of runner) {
-    const out = property.run(v) as PreconditionFailure | string | null;
+    const out = property.run(v) as PreconditionFailure | PropertyFailure | null;
     runner.handleResult(out);
   }
   return runner.runExecution;

--- a/src/check/runner/RunnerIterator.ts
+++ b/src/check/runner/RunnerIterator.ts
@@ -1,5 +1,6 @@
 import { Value } from '../arbitrary/definition/Value';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
+import { PropertyFailure } from '../property/IRawProperty';
 import { VerbosityLevel } from './configuration/VerbosityLevel';
 import { RunExecution } from './reporter/RunExecution';
 import { SourceValuesIterator } from './SourceValuesIterator';
@@ -41,14 +42,14 @@ export class RunnerIterator<Ts> implements IterableIterator<Ts> {
     ++this.currentIdx;
     return { done: false, value: nextValue.value.value_ };
   }
-  handleResult(result: PreconditionFailure | string | null): void {
+  handleResult(result: PreconditionFailure | PropertyFailure | null): void {
     // WARNING: This function has to be called after a call to next
     //          Otherwise it will not be able to execute with the right currentShrinkable (or crash)
     // As a consequence: currentShrinkable is always defined in the code below
-    if (result != null && typeof result === 'string') {
+    if (result != null && typeof result === 'object' && !PreconditionFailure.isFailure(result)) {
       // failed run
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.runExecution.fail(this.currentValue!.value_, this.currentIdx, result);
+      this.runExecution.fail(this.currentValue!.value_, this.currentIdx, result.errorMessage);
       this.currentIdx = -1;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.nextValues = this.shrink(this.currentValue!);

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -6,7 +6,7 @@ import {
   AsyncPropertyHookFunction,
 } from './check/property/AsyncProperty';
 import { property, IProperty, IPropertyWithHooks, PropertyHookFunction } from './check/property/Property';
-import { IRawProperty } from './check/property/IRawProperty';
+import { IRawProperty, PropertyFailure } from './check/property/IRawProperty';
 import { Parameters } from './check/runner/configuration/Parameters';
 import {
   RunDetails,
@@ -221,6 +221,7 @@ export {
   IAsyncPropertyWithHooks,
   AsyncPropertyHookFunction,
   PropertyHookFunction,
+  PropertyFailure,
   // pre-built arbitraries
   boolean,
   falsy,

--- a/test/unit/check/property/TimeoutProperty.spec.ts
+++ b/test/unit/check/property/TimeoutProperty.spec.ts
@@ -66,12 +66,13 @@ describe('TimeoutProperty', () => {
 
   it('should not timeout if it fails in time', async () => {
     // Arrange
+    const errorFromUnderlying = { error: undefined, errorMessage: 'plop' };
     jest.useFakeTimers();
     const { instance: decoratedProperty, run } = fakeProperty(true);
     run.mockReturnValueOnce(
       new Promise(function (resolve) {
         // underlying property is not supposed to throw (reject)
-        setTimeout(() => resolve('plop'), 10);
+        setTimeout(() => resolve(errorFromUnderlying), 10);
       })
     );
 
@@ -82,7 +83,7 @@ describe('TimeoutProperty', () => {
     await runPromise;
 
     // Assert
-    expect(await runPromise).toBe('plop');
+    expect(await runPromise).toBe(errorFromUnderlying);
   });
 
   it('should clear all started timeouts on success', async () => {
@@ -104,11 +105,12 @@ describe('TimeoutProperty', () => {
 
   it('should clear all started timeouts on failure', async () => {
     // Arrange
+    const errorFromUnderlying = { error: undefined, errorMessage: 'plop' };
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');
     jest.spyOn(global, 'clearTimeout');
     const { instance: decoratedProperty, run } = fakeProperty(true);
-    run.mockResolvedValueOnce('plop');
+    run.mockResolvedValueOnce(errorFromUnderlying);
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 100);
@@ -135,7 +137,10 @@ describe('TimeoutProperty', () => {
     jest.advanceTimersByTime(10);
 
     // Assert
-    expect(await runPromise).toEqual(`Property timeout: exceeded limit of 10 milliseconds`);
+    expect(await runPromise).toEqual({
+      error: undefined,
+      errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
+    });
   });
 
   it('Should timeout if it never ends', async () => {
@@ -150,6 +155,9 @@ describe('TimeoutProperty', () => {
     jest.advanceTimersByTime(10);
 
     // Assert
-    expect(await runPromise).toEqual(`Property timeout: exceeded limit of 10 milliseconds`);
+    expect(await runPromise).toEqual({
+      error: undefined,
+      errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
+    });
   });
 });

--- a/test/unit/check/runner/Runner.spec.ts
+++ b/test/unit/check/runner/Runner.spec.ts
@@ -168,7 +168,8 @@ describe('Runner', () => {
               run: (value: [number]) => {
                 ++numCallsRun;
                 const successId = successIds.indexOf(value[0]);
-                if (successId !== -1) return successId === failAtId ? 'failed' : null;
+                if (successId !== -1)
+                  return successId === failAtId ? { error: new Error(), errorMessage: 'failed' } : null;
                 return new PreconditionFailure();
               },
             };
@@ -258,7 +259,7 @@ describe('Runner', () => {
             },
             shrink: () => Stream.nil(),
             run: (_value: [number]) => {
-              return ++numCallsRun < num ? null : 'error';
+              return ++numCallsRun < num ? null : { error: new Error(), errorMessage: 'error' };
             },
           };
           const out = check(p, { seed: seed }) as RunDetails<[number]>;
@@ -329,7 +330,7 @@ describe('Runner', () => {
           throw 'Not implemented';
         },
         run: (_value: [number]) => {
-          return 'failure';
+          return { error: new Error(), errorMessage: 'failure' };
         },
       };
       const out = check(p, { endOnFailure: true }) as RunDetails<[number]>;
@@ -349,7 +350,7 @@ describe('Runner', () => {
           return Stream.of(new Value([42], undefined));
         },
         run: (value: [number]) => {
-          return value[0] === 42 ? 'failure' : null;
+          return value[0] === 42 ? { error: new Error(), errorMessage: 'failure' } : null;
         },
       };
       const out = check(p, { path: '0:0', endOnFailure: true }) as RunDetails<[number]>;
@@ -361,7 +362,7 @@ describe('Runner', () => {
         isAsync: () => false,
         generate: () => new Value([42], undefined),
         shrink: () => Stream.nil(),
-        run: () => 'failure',
+        run: () => ({ error: new Error(), errorMessage: 'failure' }),
       };
       const out = check(p) as RunDetails<[number]>;
       expect(out.failures).toHaveLength(0);
@@ -375,7 +376,7 @@ describe('Runner', () => {
             ? Stream.of(new Value([48], undefined), new Value([12], undefined))
             : Stream.nil();
         },
-        run: () => 'failure',
+        run: () => ({ error: new Error(), errorMessage: 'failure' }),
       };
       const out = check(p, { verbose: true }) as RunDetails<[number]>;
       expect(out.failures).not.toHaveLength(0);
@@ -407,7 +408,7 @@ describe('Runner', () => {
             run: (_value: [number]) => {
               if (--remainingBeforeFailure >= 0) return null;
               remainingBeforeFailure = failurePoints[++idx];
-              return 'failure';
+              return { error: new Error(), errorMessage: 'failure' };
             },
           };
           const expectedFailurePath = failurePoints.join(':');
@@ -441,7 +442,7 @@ describe('Runner', () => {
               await new Promise<void>((resolve) => {
                 waitingResolve.push(resolve);
               });
-              return ++numCallsRun < num ? null : 'error';
+              return ++numCallsRun < num ? null : { error: new Error(), errorMessage: 'error' };
             },
           };
           const checker = check(p, { seed: seed }) as Promise<RunDetails<[number]>>;
@@ -519,13 +520,13 @@ describe('Runner', () => {
       isAsync: () => false,
       generate: () => new Value([v1, v2], undefined),
       shrink: () => Stream.nil(),
-      run: (_v: [any, any]) => 'error in failingProperty',
+      run: (_v: [any, any]) => ({ error: new Error(), errorMessage: 'error in failingProperty' }),
     };
     const failingComplexProperty: IRawProperty<[any, any, any]> = {
       isAsync: () => false,
       generate: () => new Value([[v1, v2], v2, v1], undefined),
       shrink: () => Stream.nil(),
-      run: (_v: [any, any, any]) => 'error in failingComplexProperty',
+      run: (_v: [any, any, any]) => ({ error: new Error(), errorMessage: 'error in failingComplexProperty' }),
     };
     const successProperty: IRawProperty<[any, any]> = {
       isAsync: () => false,
@@ -578,7 +579,7 @@ describe('Runner', () => {
             ? Stream.of(new Value([48], undefined), new Value([12], undefined))
             : Stream.nil();
         },
-        run: () => 'failure',
+        run: () => ({ error: new Error(), errorMessage: 'failure' }),
       };
       it('Should throw with base message by default (no verbose)', () => {
         expect(() => rAssert(p)).toThrowError(baseErrorMessage);

--- a/test/unit/check/runner/Tosser.spec.ts
+++ b/test/unit/check/runner/Tosser.spec.ts
@@ -16,7 +16,7 @@ const wrap = <T>(arb: Arbitrary<T>): IRawProperty<T> =>
     isAsync = () => false;
     generate = (rng: Random) => new Value(this.arb.generate(rng, undefined).value_, undefined);
     shrink = () => Stream.nil<Value<T>>();
-    run = () => '';
+    run = () => ({ error: new Error(), errorMessage: 'failure' });
   })(arb);
 
 describe('Tosser', () => {


### PR DESCRIPTION
Up-to-now any Error intercepted by fast-check got intercepted by Property and translated immediately to strings. Unfortunately it means that we lose all the details linked to the original error.

While not really required for fast-check itself, those details converning the original thrown Error can be pretty useful for reporting tools like WallabyJS (see #660) and probably many others.

This PR introduces abreaking change in the existing API of property that will unlock the ability to enrich the Error produced by fast-check with details coming from the original Error whenever needed or requested. It would potentially unlock things like adding back attributes as expected or actual onto the Error or just put it as the cause of the Error produced by fast-check.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Breaking change
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
