### PR TITLE
✅ Ensure `fc.sample` can run against properties and arbitraries

### DIFF
--- a/test/e2e/Sampler.spec.ts
+++ b/test/e2e/Sampler.spec.ts
@@ -1,0 +1,55 @@
+import * as fc from '../../src/fast-check';
+import { seed } from './seed';
+
+describe(`Sampler (seed: ${seed})`, () => {
+  it('should be able to sample an Arbitrary', () => {
+    // Arrange
+    const numRuns = 42;
+
+    // Act
+    const values = fc.sample(fc.integer(), { numRuns });
+
+    // Assert
+    expect(values).toHaveLength(numRuns);
+    for (const value of values) {
+      expect(typeof value).toBe('number');
+      expect(Number.isInteger(value)).toBe(true);
+    }
+  });
+
+  it('should be able to sample a synchronous property', () => {
+    // Arrange
+    const numRuns = 42;
+
+    // Act
+    const values = fc.sample(
+      fc.property(fc.integer(), (_ignored) => true),
+      { numRuns }
+    );
+
+    // Assert
+    expect(values).toHaveLength(numRuns);
+    for (const [value] of values) {
+      expect(typeof value).toBe('number');
+      expect(Number.isInteger(value)).toBe(true);
+    }
+  });
+
+  it('should be able to sample an asynchronous property', () => {
+    // Arrange
+    const numRuns = 42;
+
+    // Act
+    const values = fc.sample(
+      fc.asyncProperty(fc.integer(), async (_ignored) => true),
+      { numRuns }
+    );
+
+    // Assert
+    expect(values).toHaveLength(numRuns);
+    for (const [value] of values) {
+      expect(typeof value).toBe('number');
+      expect(Number.isInteger(value)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
The move from fast-check old engine to its new version in v2 broke `fc.sample` when called on properties. While it has been fixed for v3, we still want such regression from occuring again in the future.

This test will avoid such bug from being unseen for so long. Error has been reported by #2736

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
