### PR TITLE
✨ Forward the original `Error` into `RunDetails`

### DIFF
--- a/src/check/runner/RunnerIterator.ts
+++ b/src/check/runner/RunnerIterator.ts
@@ -49,7 +49,7 @@ export class RunnerIterator<Ts> implements IterableIterator<Ts> {
     if (result != null && typeof result === 'object' && !PreconditionFailure.isFailure(result)) {
       // failed run
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.runExecution.fail(this.currentValue!.value_, this.currentIdx, result.errorMessage);
+      this.runExecution.fail(this.currentValue!.value_, this.currentIdx, result);
       this.currentIdx = -1;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.nextValues = this.shrink(this.currentValue!);

--- a/src/check/runner/reporter/RunDetails.ts
+++ b/src/check/runner/reporter/RunDetails.ts
@@ -31,6 +31,7 @@ export interface RunDetailsFailureProperty<Ts> extends RunDetailsCommon<Ts> {
   counterexample: Ts;
   counterexamplePath: string;
   error: string;
+  errorInstance: unknown;
 }
 
 /**
@@ -48,6 +49,7 @@ export interface RunDetailsFailureTooManySkips<Ts> extends RunDetailsCommon<Ts> 
   counterexample: null;
   counterexamplePath: null;
   error: null;
+  errorInstance: null;
 }
 
 /**
@@ -65,6 +67,7 @@ export interface RunDetailsFailureInterrupted<Ts> extends RunDetailsCommon<Ts> {
   counterexample: null;
   counterexamplePath: null;
   error: null;
+  errorInstance: null;
 }
 
 /**
@@ -81,6 +84,7 @@ export interface RunDetailsSuccess<Ts> extends RunDetailsCommon<Ts> {
   counterexample: null;
   counterexamplePath: null;
   error: null;
+  errorInstance: null;
 }
 
 /**
@@ -139,6 +143,11 @@ export interface RunDetailsCommon<Ts> {
    * @remarks Since 0.0.7
    */
   error: string | null;
+  /**
+   * In case of failure: it contains the error that has been thrown if any
+   * @remarks Since 3.0.0
+   */
+  errorInstance: unknown | null;
   /**
    * In case of failure: path to the counterexample
    *

--- a/src/check/runner/reporter/RunExecution.ts
+++ b/src/check/runner/reporter/RunExecution.ts
@@ -3,6 +3,7 @@ import { ExecutionStatus } from './ExecutionStatus';
 import { ExecutionTree } from './ExecutionTree';
 import { RunDetails } from './RunDetails';
 import { QualifiedParameters } from '../configuration/QualifiedParameters';
+import { PropertyFailure } from '../../property/IRawProperty';
 
 /**
  * Report the status of a run
@@ -16,7 +17,7 @@ export class RunExecution<Ts> {
   currentLevelExecutionTrees: ExecutionTree<Ts>[];
   pathToFailure?: string;
   value?: Ts;
-  failure: string | null;
+  failure: PropertyFailure | null;
   numSkips: number;
   numSuccesses: number;
   interrupted: boolean;
@@ -36,7 +37,7 @@ export class RunExecution<Ts> {
     return currentTree;
   }
 
-  fail(value: Ts, id: number, message: string): void {
+  fail(value: Ts, id: number, failure: PropertyFailure): void {
     if (this.verbosity >= VerbosityLevel.Verbose) {
       const currentTree = this.appendExecutionTree(ExecutionStatus.Failure, value);
       this.currentLevelExecutionTrees = currentTree.children;
@@ -44,7 +45,7 @@ export class RunExecution<Ts> {
     if (this.pathToFailure == null) this.pathToFailure = `${id}`;
     else this.pathToFailure += `:${id}`;
     this.value = value;
-    this.failure = message;
+    this.failure = failure;
   }
   skip(value: Ts): void {
     if (this.verbosity >= VerbosityLevel.VeryVerbose) {
@@ -115,7 +116,9 @@ export class RunExecution<Ts> {
         // Rq: Same as this.value
         // =>  this.failure !== undefined
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        error: this.failure!,
+        error: this.failure!.errorMessage,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        errorInstance: this.failure!.error,
         failures: this.extractFailures(),
         executionSummary: this.rootExecutionTrees,
         verbose: this.verbosity,
@@ -147,6 +150,7 @@ export class RunExecution<Ts> {
       counterexample: null,
       counterexamplePath: null,
       error: null,
+      errorInstance: null,
       failures: [],
       executionSummary: this.rootExecutionTrees,
       verbose: this.verbosity,


### PR DESCRIPTION
Passing the original instance of `Error` into `RunDetails` can make users wanting to read from the original error to compute their error message able to do that.

On fast-check's side it will unlock the ability to add more details onto the error produced by the framework.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
