### PR TITLE
🐛 Allow property to intercept thrown symbols

### DIFF
--- a/src/check/property/AsyncProperty.generic.ts
+++ b/src/check/property/AsyncProperty.generic.ts
@@ -114,7 +114,7 @@ export class AsyncProperty<Ts> implements IAsyncPropertyWithHooks<Ts> {
       if (err instanceof Error && err.stack) {
         return { error: err, errorMessage: `${err}\n\nStack trace: ${err.stack}` };
       }
-      return { error: err, errorMessage: `${err}` };
+      return { error: err, errorMessage: String(err) };
     } finally {
       await this.afterEachHook();
     }

--- a/src/check/property/Property.generic.ts
+++ b/src/check/property/Property.generic.ts
@@ -130,7 +130,7 @@ export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
       if (err instanceof Error && err.stack) {
         return { error: err, errorMessage: `${err}\n\nStack trace: ${err.stack}` };
       }
-      return { error: err, errorMessage: `${err}` };
+      return { error: err, errorMessage: String(err) };
     } finally {
       this.afterEachHook();
     }

--- a/test/unit/check/property/AsyncProperty.spec.ts
+++ b/test/unit/check/property/AsyncProperty.spec.ts
@@ -10,6 +10,7 @@ import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeArbitrary } from '../../arbitrary/__test-helpers__/ArbitraryHelpers';
 import { Stream } from '../../../../src/stream/Stream';
 import { PropertyFailure } from '../../../../src/check/property/IRawProperty';
+import fc from '../../../../lib/fast-check';
 
 describe('AsyncProperty', () => {
   afterEach(() => resetConfigureGlobal());
@@ -20,25 +21,53 @@ describe('AsyncProperty', () => {
     });
     expect(await p.run(p.generate(stubRng.mutable.nocall()).value)).not.toBe(null); // property fails
   });
-  it('Should fail if predicate throws', async () => {
-    const p = asyncProperty(stubArb.single(8), async (_arg: number) => {
-      throw 'predicate throws';
-    });
-    expect(await p.run(p.generate(stubRng.mutable.nocall()).value)).toEqual({
-      error: 'predicate throws', // the original error is a string in this test
-      errorMessage: 'predicate throws', // the original error results in this message
-    });
-  });
   it('Should fail if predicate throws an Error', async () => {
+    // Arrange
     let originalError: Error | null = null;
     const p = asyncProperty(stubArb.single(8), async (_arg: number) => {
       originalError = new Error('predicate throws');
       throw originalError;
     });
+
+    // Act
     const out = await p.run(p.generate(stubRng.mutable.nocall()).value);
+
+    // Assert
     expect((out as PropertyFailure).errorMessage).toContain('predicate throws');
     expect((out as PropertyFailure).errorMessage).toContain('\n\nStack trace:');
     expect((out as PropertyFailure).error).toBe(originalError);
+  });
+  it('Should fail if predicate throws a raw string', async () => {
+    // Arrange
+    const p = asyncProperty(stubArb.single(8), async (_arg: number) => {
+      throw 'predicate throws';
+    });
+
+    // Act
+    const out = await p.run(p.generate(stubRng.mutable.nocall()).value);
+
+    // Assert
+    expect(out).toEqual({
+      error: 'predicate throws', // the original error is a string in this test
+      errorMessage: 'predicate throws', // the original error results in this message
+    });
+  });
+  it('Should fail if predicate throws anything', () => {
+    fc.assert(
+      fc.asyncProperty(fc.anything(), async (stuff) => {
+        // Arrange
+        fc.pre(stuff === null || typeof stuff !== 'object' || !('toString' in stuff));
+        const p = asyncProperty(stubArb.single(8), (_arg: number) => {
+          throw stuff;
+        });
+
+        // Act
+        const out = await p.run(p.generate(stubRng.mutable.nocall()).value);
+
+        // Assert
+        expect(out).toEqual({ error: stuff, errorMessage: expect.any(String) });
+      })
+    );
   });
   it('Should forward failure of runs with failing precondition', async () => {
     let doNotResetThisValue = false;


### PR DESCRIPTION
The previous implementation would have crashed if user threw a Symbol. While the case is rare and can even be considered fully unexpected, we want to prevent the crash as much as possible just in case.

But we explicitely do not handle the case of an object being thrown with a custom toString.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
