### PR TITLE
🏷️ Better typings for `letrec`

### DIFF
--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -70,7 +70,7 @@ export type LetrecLooselyTypedBuilder<T> = (tie: LetrecLooselyTypedTie) => Letre
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function letrec<T>(builder: T extends {} ? LetrecTypedBuilder<T> : never): LetrecValue<T>;
+export function letrec<T>(builder: T extends Record<string, unknown> ? LetrecTypedBuilder<T> : never): LetrecValue<T>;
 /**
  * For mutually recursive types
  *

--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -17,7 +17,10 @@ export type LetrecValue<T> = {
  * @remarks Since 3.0.0
  * @public
  */
-export type LetrecTypedTie<T> = <K extends keyof T>(key: K) => Arbitrary<T[K]>;
+export interface LetrecTypedTie<T> {
+  <K extends keyof T>(key: K): Arbitrary<T[K]>;
+  (key: string): Arbitrary<unknown>;
+}
 /**
  * Strongly typed type for the `builder` function passed to {@link letrec}.
  * You may want also want to use its loosely typed version {@link LetrecLooselyTypedBuilder}.

--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -69,7 +69,6 @@ export type LetrecLooselyTypedBuilder<T> = (tie: LetrecLooselyTypedTie) => Letre
  * @remarks Since 1.16.0
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
 export function letrec<T>(builder: T extends Record<string, unknown> ? LetrecTypedBuilder<T> : never): LetrecValue<T>;
 /**
  * For mutually recursive types

--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -2,6 +2,52 @@ import { LazyArbitrary } from './_internals/LazyArbitrary';
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 
 /**
+ * Type of the value produced by {@link letrec}
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type LetrecValue<T> = {
+  [K in keyof T]: Arbitrary<T[K]>;
+};
+
+/**
+ * Strongly typed type for the `tie` function passed by {@link letrec} to the `builder` function we pass to it.
+ * You may want also want to use its loosely typed version {@link LetrecLooselyTypedTie}.
+ *
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type LetrecTypedTie<T> = <K extends keyof T>(key: K) => Arbitrary<T[K]>;
+/**
+ * Strongly typed type for the `builder` function passed to {@link letrec}.
+ * You may want also want to use its loosely typed version {@link LetrecLooselyTypedBuilder}.
+ *
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type LetrecTypedBuilder<T> = (tie: LetrecTypedTie<T>) => LetrecValue<T>;
+
+/**
+ * Loosely typed type for the `tie` function passed by {@link letrec} to the `builder` function we pass to it.
+ * You may want also want to use its strongly typed version {@link LetrecTypedTie}.
+ *
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type LetrecLooselyTypedTie = (key: string) => Arbitrary<unknown>;
+/**
+ * Loosely typed type for the `builder` function passed to {@link letrec}.
+ * You may want also want to use its strongly typed version {@link LetrecTypedBuilder}.
+ *
+ * @remarks Since 3.0.0
+ * @public
+ */
+export type LetrecLooselyTypedBuilder<T> = (tie: LetrecLooselyTypedTie) => LetrecValue<T>;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function letrec<T>(builder: T extends {} ? LetrecTypedBuilder<T> : never): LetrecValue<T>;
+export function letrec<T>(builder: LetrecLooselyTypedBuilder<T>): LetrecValue<T>;
+/**
  * For mutually recursive types
  *
  * @example
@@ -20,9 +66,8 @@ import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
  * @remarks Since 1.16.0
  * @public
  */
-export function letrec<T>(builder: (tie: (key: string) => Arbitrary<unknown>) => { [K in keyof T]: Arbitrary<T[K]> }): {
-  [K in keyof T]: Arbitrary<T[K]>;
-} {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function letrec<T>(builder: LetrecLooselyTypedBuilder<T> | LetrecTypedBuilder<T>): LetrecValue<T> {
   const lazyArbs: { [K in keyof T]?: LazyArbitrary<unknown> } = Object.create(null);
   const tie = (key: keyof T): Arbitrary<any> => {
     if (!Object.prototype.hasOwnProperty.call(lazyArbs, key)) {

--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -47,9 +47,30 @@ export type LetrecLooselyTypedTie = (key: string) => Arbitrary<unknown>;
  */
 export type LetrecLooselyTypedBuilder<T> = (tie: LetrecLooselyTypedTie) => LetrecValue<T>;
 
+/**
+ * For mutually recursive types
+ *
+ * @example
+ * ```typescript
+ * type Leaf = number;
+ * type Node = [Tree, Tree];
+ * type Tree = Node | Leaf;
+ * const { tree } = fc.letrec<{ tree: Tree, node: Node, leaf: Leaf }>(tie => ({
+ *   tree: fc.oneof({depthFactor: 'small'}, tie('leaf'), tie('node')),
+ *   node: fc.tuple(tie('tree'), tie('tree')),
+ *   leaf: fc.nat()
+ * }));
+ * // tree is 50% of node, 50% of leaf
+ * // the ratio goes in favor of leaves as we go deeper in the tree (thanks to depthFactor)
+ * ```
+ *
+ * @param builder - Arbitraries builder based on themselves (through `tie`)
+ *
+ * @remarks Since 1.16.0
+ * @public
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function letrec<T>(builder: T extends {} ? LetrecTypedBuilder<T> : never): LetrecValue<T>;
-export function letrec<T>(builder: LetrecLooselyTypedBuilder<T>): LetrecValue<T>;
 /**
  * For mutually recursive types
  *
@@ -69,6 +90,7 @@ export function letrec<T>(builder: LetrecLooselyTypedBuilder<T>): LetrecValue<T>
  * @remarks Since 1.16.0
  * @public
  */
+export function letrec<T>(builder: LetrecLooselyTypedBuilder<T>): LetrecValue<T>;
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function letrec<T>(builder: LetrecLooselyTypedBuilder<T> | LetrecTypedBuilder<T>): LetrecValue<T> {
   const lazyArbs: { [K in keyof T]?: LazyArbitrary<unknown> } = Object.create(null);

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -53,7 +53,14 @@ import { nat, NatConstraints } from './arbitrary/nat';
 import { ipV4 } from './arbitrary/ipV4';
 import { ipV4Extended } from './arbitrary/ipV4Extended';
 import { ipV6 } from './arbitrary/ipV6';
-import { letrec } from './arbitrary/letrec';
+import {
+  letrec,
+  LetrecValue,
+  LetrecLooselyTypedBuilder,
+  LetrecLooselyTypedTie,
+  LetrecTypedBuilder,
+  LetrecTypedTie,
+} from './arbitrary/letrec';
 import { lorem, LoremConstraints } from './arbitrary/lorem';
 import { mapToConstant } from './arbitrary/mapToConstant';
 import { memo, Memo } from './arbitrary/memo';
@@ -383,11 +390,16 @@ export {
   WebUrlConstraints,
   MaybeWeightedArbitrary,
   WeightedArbitrary,
+  LetrecTypedTie,
+  LetrecTypedBuilder,
+  LetrecLooselyTypedTie,
+  LetrecLooselyTypedBuilder,
   // produced values
   CloneValue,
   ContextValue,
   FalsyValue,
   JsonValue,
+  LetrecValue,
   OneOfValue,
   RecordValue,
   // arbitrary types (mostly when produced values are difficult to formalize)

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -379,11 +379,13 @@ expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
   })),
   'Invalid recursion "letrec"'
 ); // TODO Typings should be improved: referencing an undefined key should failed
-fc.letrec<{ a: number; b: unknown }>((tie) => ({
-  a: fc.nat(),
-  // @ts-expect-error - reject builders implying 'invalid recursion' when type declared
-  b: tie('c'),
-}));
+expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
+  fc.letrec<{ a: number; b: unknown }>((tie) => ({
+    a: fc.nat(),
+    b: tie('c'),
+  })),
+  'Invalid recursion "letrec" with types manually defined'
+); // TODO Even when fully typed we accept undeclared keys from being used on tie (see why PR-2968)
 expectType<{ a: fc.Arbitrary<number> }>()(
   fc.letrec<{ a: number }>((tie) => ({
     a: fc.nat(),
@@ -391,12 +393,6 @@ expectType<{ a: fc.Arbitrary<number> }>()(
   })),
   'Accept additional keys within "letrec" but do not expose them outside'
 );
-fc.letrec<{ a: number }>((tie) => ({
-  a: fc.nat(),
-  b: fc.nat(),
-  // @ts-expect-error - reject builders implying 'usages of shadowed keys' when type declared
-  c: tie('b'),
-}));
 fc.letrec<{ a: string }>((tie) => ({
   // @ts-expect-error - reject builders implying 'wrongly typed keys' when type declared
   a: fc.nat(),

--- a/test/type/main.ts
+++ b/test/type/main.ts
@@ -340,12 +340,23 @@ expectType<{}>()(
   fc.letrec((tie) => ({})),
   'Empty "letrec"'
 );
+expectType<{}>()(
+  fc.letrec<{}>((tie) => ({})),
+  'Empty "letrec" with types manually defined'
+);
 expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<string> }>()(
   fc.letrec((tie) => ({
     a: fc.nat(),
     b: fc.string(),
   })),
   'No recursion "letrec"'
+);
+expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<string> }>()(
+  fc.letrec<{ a: number; b: string }>((tie) => ({
+    a: fc.nat(),
+    b: fc.string(),
+  })),
+  'No recursion "letrec" with types manually defined'
 );
 expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
   fc.letrec((tie) => ({
@@ -354,6 +365,13 @@ expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
   })),
   'Recursive "letrec"'
 ); // TODO Typings should be improved: b type might be infered from a
+expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<number> }>()(
+  fc.letrec<{ a: number; b: number }>((tie) => ({
+    a: fc.nat(),
+    b: tie('a'),
+  })),
+  'Recursive "letrec" with types manually defined'
+);
 expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
   fc.letrec((tie) => ({
     a: fc.nat(),
@@ -361,6 +379,28 @@ expectType<{ a: fc.Arbitrary<number>; b: fc.Arbitrary<unknown> }>()(
   })),
   'Invalid recursion "letrec"'
 ); // TODO Typings should be improved: referencing an undefined key should failed
+fc.letrec<{ a: number; b: unknown }>((tie) => ({
+  a: fc.nat(),
+  // @ts-expect-error - reject builders implying 'invalid recursion' when type declared
+  b: tie('c'),
+}));
+expectType<{ a: fc.Arbitrary<number> }>()(
+  fc.letrec<{ a: number }>((tie) => ({
+    a: fc.nat(),
+    b: fc.nat(),
+  })),
+  'Accept additional keys within "letrec" but do not expose them outside'
+);
+fc.letrec<{ a: number }>((tie) => ({
+  a: fc.nat(),
+  b: fc.nat(),
+  // @ts-expect-error - reject builders implying 'usages of shadowed keys' when type declared
+  c: tie('b'),
+}));
+fc.letrec<{ a: string }>((tie) => ({
+  // @ts-expect-error - reject builders implying 'wrongly typed keys' when type declared
+  a: fc.nat(),
+}));
 
 // clone arbitrary
 expectType<fc.Arbitrary<[]>>()(fc.clone(fc.nat(), 0), '"clone" 0-time');


### PR DESCRIPTION
As suggested in issue #1164 and then in the PR #1572, typings of `letrec` could have been improved a lot. And this is basically the idea of this PR that was highly inspired by #1572 and fixed the few last remaining issues.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [x] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [x] Typings
- [ ] _Other(s):_ ...
