### PR TITLE
💥 Rename `depthFactor` into `depthSize` and invert numeric

### DIFF
--- a/documentation/Arbitraries.md
+++ b/documentation/Arbitraries.md
@@ -964,11 +964,11 @@ fc.stringOf(fc.constantFrom('Hello', 'World'), {minLength: 1, maxLength: 3})
 *&#8195;Signatures*
 
 - `fc.json()`
-- `fc.json({depthFactor?, maxDepth?})`
+- `fc.json({depthSize?, maxDepth?})`
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -995,13 +995,13 @@ fc.json({maxDepth: 1})
 // • "[1.73e-322,-2.043903585838636e-34,null,true,null,null,\"8+~U`\"]"
 // • …
 
-fc.json({depthFactor: 'medium'})
+fc.json({depthSize: 'medium'})
 // Examples of generated values:
-// • "[[\"E/M`|H\"],\"w=j>E63\",{\"fGTe[}9\":true,\"l+H\\\\=\":\"-A0dV?\",\"Fx/pG,M-\":\"\",\"q\":\"VKD85!:.\",\"x6IPY'*\":1.0586997023011108e+144,\"\":null,\"Wv[~7[gb\":[-5.494529207999025e-218,\">:I)p(5y=m\",null,-5.282685484261878e-29,2.5225141404063995e+207],\"|)EdJV\":4.000621316499043e+111},1.1135184696556912e-107,\".\",2.774587251307129e-289]"
-// • "{}"
-// • "[null,-1.7054642294306804e+86,3.678514250005814e-198,{\"0\":\"wo}mz{RUzl\",\"B*`s\":true,\"!;\":false,\"173@]\\\"1o\":\"Z\\\\k\",\"ZbFIgI$)\":null,\"`*-&\":{\"xorJg%7nW\":5.125024613939163e+90,\"<\":false,\".z#/tm\":null,\"ZW@ZMK\":-1.0301077279774283e-286,\"{INW\\\\} gc\":false,\"H5|X6bp|)\\\"\":null,\"\":\"_jTyP\",\"Gg2k\":26452736861.022823,\"=1\":\"gB4BszMOd\",\"oI\":null},\";^j{q\":null},1.5692401810006336e+278,null,\"{CGRo71\",\"Ke}_wpt\",\"#1F/nb\"]"
-// • "[[3.966231748135636e+261],\":`*c@K\",null]"
-// • "-1.8e-322"
+// • "1.1084525170506737e-156"
+// • "[\"&]\",{\"r*,M9|W?c\":[false,null,\"bxV\",null,false,7.171087774329574e+120,true,2.122763095763206e-112,5.371783952168317e-166,false]},{\"XLL8w\":null}]"
+// • "[{\"4\":null,\"Dn\":2.4426060849173823e-107,\"1pISp\":false,\"*_BU-!U\":1.300167092106387e+131,\":\":-5.1320442429180716e-297,\"y\":\"\",\"lY\":2.196066668993201e-230,\"[|Q\\\\G-=K?Y\":\"HZ\",\"ikX?aw\":null,\"-y@`)3mh\":\"f|M\"},[]]"
+// • "[\"_\",\" {_xR<tiQ\",null,{\"uc2~2XP0\":null,\"6Y\\\\j|g/DhM\":\")1yN\",\"%\\\\!K4qL!}\":false,\"^%79'x3\":null,\"x3(>2 \":null,\"+\":-1.345402215261541e-31,\"\\\"{Xb.&4d_u\":{\"$ D^DE2V33\":false,\"P\":true},\"s\":\"(!>\"},false,\"B\"]"
+// • "true"
 // • …
 ```
 </details>
@@ -1019,11 +1019,11 @@ fc.json({depthFactor: 'medium'})
 *&#8195;Signatures*
 
 - `fc.unicodeJson()`
-- `fc.unicodeJson({depthFactor?, maxDepth?})`
+- `fc.unicodeJson({depthSize?, maxDepth?})`
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — _maximal depth of generated objects_
 
 *&#8195;Usages*
@@ -1050,13 +1050,13 @@ fc.unicodeJson({maxDepth: 1})
 // • "-2.787348602876926e-78"
 // • …
 
-fc.unicodeJson({depthFactor: 'medium'})
+fc.unicodeJson({depthSize: 'medium'})
 // Examples of generated values:
-// • "{\"苚뎃쮞불힓蹎❄袁㸩軜\":null,\"\":[{\"\":\"ର悧럾\",\"ᦇ曤怬뀰尔箃颱梁끂睮\":true,\"蓱ᡱ䬌튚⮀⡆唣悡쿍챐\":2.3440677897406024e+167,\"ᶱ콈㒗ꑢ綸춙Ꜯ\":true,\"ı醞胊﫰돺䷖﯉띥\":\"娲嬰銚髡Ⲙ᧮귚\",\"嘿ꏟ懝໗둍☲๼㓏룉\":{\"㸳乥員㝸깉\":\"樢ⅻ⌎횖㝘陟\",\"﹖쪸娮̳\":-6.210606047013686e+79,\"욨櫏恫\":3.516972800479063e-111,\"â殻픤淙㞴鸃똽틽\":null,\"\":true,\"袬쟉韭䆧롅練谅\":-1.3040974809842527e+231,\"⁲ৼ粴\":\"풰꬝\",\"蛪⍁캕峐聿譮깦㭍勃誛\":59862185631231940,\"ﮱ魯\":\"\",\"捴Ầ隟\":\"떀详ষ윓짵쥱猫\"}},null]}"
-// • "{\"飭\":null,\"휺荃䫐음䉷ꙅ낱Ḯ嶑\":\"㴃蛧暪䴿城뛛黔䟧\",\"쪙秓\":-1.7747824624786926e-217,\"䜶时ਪ\":null,\"뢍㻧؊籺樝ᓐ꿋✬\":false}"
-// • "{\"뀷\":null,\"෶ⴜ窼\":-1.4521726793581816e-304,\"%\":1.8966585788571038e+304,\"(鼎)￹\":{\"痕닉ᗤ罷煮\":null,\"巠ꕻग़咨욇砿㨷\":\"硍꩘鈲췟ᒙⶮ\",\"竦ᝡ쏛㿩삡慘歯彩㠀철\":\"ὄ裌࿶팁ꎫ⇯媞盎\",\"慘䡆癜\":null},\"ಢȾ\":{\"菀壀훺哿 ┹,.\":1.7e-322},\"䊷왮隥\":null,\"蠖伈\":[\"ꂸȊ솛䇌\"],\"행縉爳몆䇀혇\":null}"
-// • "{\"䖇셧ࢼꗀ䃳곤팂\":{\"\":{\"\":null,\"剱怉⮆녞戸ၗ\":-2.4442554653610987e-198,\"爓䮕ퟪ▬9芆谐ᓯ\":\"⬤귘늖俐菡ꢠᅘꨟ\",\"åߙ䀹\":-2.0450928389197086e+263,\"␯挵\":-4.898368216993357e-297,\"讋쫝䠤澔⿂돌㯛\":1.230887568364176e-99,\"䤽䨤聯ꁔ靶偅娮멡㱤瀰\":-3.4061927272848294e+281,\"蟠揱스䖤\":false},\"젙놸ᕴ禲̦㗡円ꁍ飔\":\"\",\"አ芒Ⰸо嚚嘉盷锁迵胂\":-2.068198291002804e-134,\"₉鼪挹䐸譻㔠\":[1.2293336805455684e-202],\"梯폮\":null,\"ꄏ孥\":-1.85502609612576e+29,\"⃊挝ᛢ\":false,\"임쀛\":{\"骃嚭䅱㺯షṄ\":null,\"燀靼萋↲㛞鞭췃쌧\":null,\"\":false,\"狘券\":true,\"쫂═䩧\":false,\"佪\":\"뇟퍳घਨ꽽㌺鐞s\",\"դᄶⱺਖ겟룡舄ʶ댣\":-3.313289229894712e-42,\"᳟๺⃐\":\"댰麓቙斶ꢫࠥ\"}}}"
-// • "[true,{\"\":null,\"ᥙ㭽멪⊛矁㷝穛塈ㆅ\":null,\"슭뫮\":\"꿵\",\"ꙴ鰈鿊駓돕倶\":1.2189214074886491e+290,\"龸愳써㻶䁟◂⡯笿⚨梒\":[null,null,[false,7.170172673247772e-132,\"쩳悩刈ꤗ῀縗\",\"繮騶\",null,null,null,-2.0709037689410663e-218,true],\"諎훸Š\",[null,null,true,false,true,null,3.0307341474913784e+301],false,false,\"ᜌ″೿政齥ʌ࿄祜沀\",\"\"],\"ꯇ\":1.5e-322,\"ഩ旅詋䅎駗ࣻ獳뱒\":\"잻齂ڤ恄｣渻ﺑॱ\",\"溰㓜룖燫矬Ἲ険┓ᘕ\":[null,null,null,false,\"ꥀ᪋䭦쌑ᢠ鈹៽\",false,null,false,true,-2.2947855499398797e+271]},{\"웲嫶菞ꍁ쒗緒\":true,\"꽃ឿ쒀飱ꇄ뉛地\":false,\"㽝ᄽ홫邩去荸\":\"\",\"䀀䷀떞뭥⌙\":true,\"筽઩鏦ꉊ⯝㕩῿蒓빜\":null,\"⺘ᖛ觉࡬슳\":true,\"ବ빏겂䕫틪훣죵棖\":\"⸊鞿괃偼쵖ᐧ낈\"}]"
+// • "{\"讆層ꦍ쩖䊼\":6.422585986069521e+229,\"\":[null,true,true,false,null,null,false],\"톙띨ᓘ箜\":\"景\",\"犟ﯼ⛺㴞撟㨕\":[1.502368761936634e+269,true,false],\"脓境鲖㽾抳뫞ຳ\":false,\"阠\":-3.440279645467618e+252,\"髇૱ꩀ杨垹佡⍳\":false,\"꦳\":null,\"悪뤶⛬厕놳鑤䴆뛰稾\":\"刕䥮鋅舻쓋\"}"
+// • "1.7398076905782003e-265"
+// • "\"/㩵羣\""
+// • "[]"
+// • "{\"햧ཧ觌♘䣯Ⓖ崊䏓䵊\":{},\"㋄ǋ膮朲㌦냔ℋፋ\":{\"㋂\":{\"戹⾤礓\":2.1056912914512038e+48},\"\":false,\"絉泤璱鱾ق媀\":-4.1425806591889986e+212,\"샭 隆ἑ킷받붇ᡡ\":-3.3861837092165883e-127,\"ꪞ쳍爽\":true,\"⍚뮚䑥ᝳ륿ಒ菑\":\"挩聆ᝮ櫸树ޞ\"}}"
 // • …
 ```
 </details>
@@ -2134,14 +2134,14 @@ fc.constantFrom(1, 'string', {})
 *&#8195;Signatures*
 
 - `fc.option(arb)`
-- `fc.option(arb, {freq?, nil?, depthFactor?, maxDepth?, depthIdentifier?})`
+- `fc.option(arb, {freq?, nil?, depthSize?, maxDepth?, depthIdentifier?})`
 
 *&#8195;with:*
 
 - `arb` — _arbitrary that will be called to generate normal values_
 - `freq?` — default: `5` — _probability to build the nil value is of 1 / freq_
 - `nil?` — default: `null` — _nil value_
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _this factor will be used to increase the probability to generate nil values as we go deeper in a recursive structure_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep? The chance to select the nil value will increase as we go deeper in the structure_
 - `maxDepth?` — default: `Number.POSITIVE_INFINITY` — _when reaching maxDepth, only nil could be produced_
 - `depthIdentifier?` — default: `undefined` — _share the depth between instances using the same `depthIdentifier`_
 
@@ -2174,19 +2174,19 @@ fc.option(fc.string(), { nil: undefined })
 >
 > Randomly chooses an arbitrary at each new generation. Should be provided with at least one arbitrary. Probability to select a specific arbitrary is based on its weight: `weight(instance) / sumOf(weights)` (for depth=0). For higher depths, the probability to select the first arbitrary will increase as we go deeper in the tree so the formula is not applicable as-is. It preserves the shrinking capabilities of the underlying arbitrary. `fc.oneof` is able to shrink inside the failing arbitrary but not across arbitraries (contrary to `fc.constantFrom` when dealing with constant arbitraries) except if called with `withCrossShrink`.
 >
-> **Warning:** The first arbitrary specified on `oneof` will have a privileged position. Constraints like `withCrossShrink` or `depthFactor` tend to favor it over others.
+> **Warning:** The first arbitrary specified on `oneof` will have a privileged position. Constraints like `withCrossShrink` or `depthSize` tend to favor it over others.
 
 *&#8195;Signatures*
 
 - `fc.oneof(...arbitraries)`
-- `fc.oneof({withCrossShrink?, maxDepth?, depthFactor?, depthIdentifier?}, ...arbitraries)`
+- `fc.oneof({withCrossShrink?, maxDepth?, depthSize?, depthIdentifier?}, ...arbitraries)`
 
 *&#8195;with:*
 
 - `...arbitraries` — _arbitraries that could be used to generate a value. The received instances can either be raw instances of arbitraries (meaning weight is 1) or objects containing the arbitrary and its associated weight (integer value ≥0)_
 - `withCrossShrink?` — default: `false` — _in case of failure the shrinker will try to check if a failure can be found by using the first specified arbitrary. It may be pretty useful for recursive structures as it can easily help reducing their depth in case of failure_
 - `maxDepth?` — default: `Number.POSITIVE_INFINITY` — _when reaching maxDepth, the first arbitrary will be used to generate the value_
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _this factor will be used to increase the probability to generate instances of the first passed arbitrary_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep? The chance to select the first specified arbitrary will increase as we go deeper in the structure_
 - `depthIdentifier?` — default: `undefined` — _share the depth between instances using the same `depthIdentifier`_
 
 *&#8195;Usages*
@@ -2400,7 +2400,7 @@ fc.letrec((tie) => ({
   self: fc.record({
     value: fc.nat(),
     children: fc.oneof(
-      { depthFactor: 'small', depthIdentifier: 'id:self' },
+      { depthSize: 'small', depthIdentifier: 'id:self' },
       fc.constant([]),
       fc.array(tie('self'), { depthIdentifier: 'id:self' })
     ),
@@ -2412,11 +2412,11 @@ fc.letrec((tie) => ({
 // Note: For the moment, `fc.array` cannot stop the recursion alone and need to be combined with `fc.oneof` or any other
 // helper being able to fallback to base cases with an higher probability as we go deeper in the recursion.
 // Examples of generated values:
-// • {"value":424778306,"children":[]}
-// • {"value":27,"children":[{"value":314632820,"children":[]},{"value":494880843,"children":[]},{"value":241922623,"children":[]},{"value":1909847367,"children":[]},{"value":955571083,"children":[]},{"value":96082336,"children":[]},{"value":56407905,"children":[]},{"value":1286754465,"children":[]},{"value":188039153,"children":[]},{"value":853104761,"children":[]}]}
-// • {"value":7,"children":[]}
-// • {"value":2147483619,"children":[]}
-// • {"value":15,"children":[{"value":1009275606,"children":[]},{"value":2147483630,"children":[{"value":1715614519,"children":[]}]}]}
+// • {"value":2147483632,"children":[{"value":1992569519,"children":[]},{"value":2096527253,"children":[]},{"value":938601579,"children":[]},{"value":902729389,"children":[]},{"value":379651943,"children":[]},{"value":1874018152,"children":[]},{"value":1804993568,"children":[{"value":2106714633,"children":[]},{"value":840697357,"children":[]},{"value":1804459986,"children":[]},{"value":989811118,"children":[]}]},{"value":999615087,"children":[]},{"value":2091585907,"children":[]},{"value":1646402104,"children":[]}]}
+// • {"value":1056088736,"children":[]}
+// • {"value":1227733267,"children":[]}
+// • {"value":17,"children":[]}
+// • {"value":17,"children":[{"value":2098901561,"children":[{"value":1194594458,"children":[]}]}]}
 // • …
 ```
 </details>
@@ -2834,12 +2834,12 @@ fc.record({
 *&#8195;Signatures*
 
 - `fc.object()`
-- `fc.object({key?, depthFactor?, maxDepth?, maxKeys?, size?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
+- `fc.object({key?, depthSize?, maxDepth?, maxKeys?, size?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
 
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — default: `undefined` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `0x7fffffff` [more](#size-explained) — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `size?` — default: `undefined` [more](#size-explained) — _how large should the generated values be?_
@@ -2919,16 +2919,16 @@ fc.object({
 // • …
 
 fc.object({
-  depthFactor: 'medium',
+  depthSize: 'medium',
   maxDepth: 1000,
 })
 // Note: For the moment, we have to specify maxDepth to avoid falling back onto its default value
 // Examples of generated values:
-// • {"H}":{"U,3kWU44":"a7:KA","Ih":["hJ\"rqM~i",6307881588517151,"Avm>",-6531689624703797,2821132006609535,true,"=>6[ZQu",6873487061489721,null],"Y'":["+.tD\"Il8u",true,"l4b&&lLe",undefined,"",-6.846640710601311e+276,2440452332583477,6.506926986419051e-91],"GV":true,"ja":2660434511003057,"Hz$o":undefined},"$!":{"\"BH%":null,"#ka>":[{"Qv,w":-2475351392901800,"^1V3xSMoJ":"KDt8","(":"ZznG","}":-3042075132133196,"9GAy<":null,"N\"+v":".&2^{"},-49277427245748,2.168032501579433e+28,null,{"swHi4":"w\\4h[Y.sus","E$qMe4Z@":-2393229427346512,"]4A)d;<4 ":7462354073420317,"Ch(CKu":3.765291472347861e-131,"QEt0'9\\ka":true,",WvgBX9p*":false,",>5abchD,i":-3131787083353861}]}}
-// • {"K":"cP<5:","(y":{"!\"2a":false,"":["2+^,Yq7~tK",[false,-778241165263894,null,undefined,4.658687695645282e+135,7.123276087965761e+27,-22960315548.14952],undefined,undefined,-3.484584468220125e+280],"$+6I4eI:BR":{"DGyCIs":"\\(\"","5;":"f%?+vF/#\"T","C":"DK3l","{zV3J&l!3":"-","RfE}Fv$@5":-3.5779583237385387e+27,"":undefined,"Y~F_":-4986592102095123,"[":-1.161160663898531e-109},"<$1HvxfX-":["=\\/-.",null,{"x3R":false,"l&l0-":"O^]2"},"hn$L/!-",3004507120951339,-4.786343999267118e+63,true]},"gZh":{"}":null,"":{"Q>WQaJ`":{"6":false,"F@X:(Gr`-":-1.5019132192401619e-294,"ZQROTr6":"","":undefined,",I?h":[true,-999843515630869,"e&1bF*K,sG",-2.971386520300037e-307,false,"T60;S:+}yL","Wq",undefined],"T7":[1.162621219218451e-83,"x,*}A",null,false,1.6281441988455045e-213,"Cmbd-\"-",true,true]},"8\\d}`&'":{"tI/a>5":-9.347728599977913e-271},"s)SM<u_":undefined},"^xq=S%a$3":{"yQ]\\go":"#_qG%/]4O","u/T-WS":-1.4113731319270642e+76,"":{"":-1.7201589721071257e+215,"/{+":-1.0777340386200093e+231,"&12\\":[8.897953723152718e-153,"0EBD",-2493791356277961,"foR"],"nYu/}":true},",1d?|R":1.6440648588394306e+104,"j":-1.6897851635630378e+99,")":".ly%","41EPM$<lO":["v",-5.920817903190163e+252,true]},"%o\"{PWc":[-9005462604062500,[7.554711813398084e-82,4.675475619695211e-243,null,undefined,"yK",1.8298144372499424e+174,null],{"+OiZo_":true,"U":undefined,"SR[awh~9p":undefined,"=h\\":true,";":-611201721774092,"\\c'd3L":null,"]D)XN% $[":null,"#T{u":"@vB'","*l":-3270755317220949},{}]},"mn":[undefined,-8219197699717377,4902163434225719,-2.00808334344315e+34,"JG",false,null,7485439830476501,2.6646105004024336e+24,true],"@T9|Qi?|eS":{"g":undefined,"}GM1R]OkxF":-6800411437220886,":LuhV+;":["+f.oOsuA","d*g",null,-2.3036122134821016e-295,"<#@MGoj",undefined,-5840646970632276,8701177406144795],"B~c}7":{"G>RsmS":"","e{;q@'":"`","hU":null,"|":undefined,"P(x}UJ_\"":"{","mw{}":[null,-8112190356539678,true,false,null,undefined,true,false,-1.1802516773660513e-206,">|)A#\""],"":2854670740485249},"":undefined},"-Oh":{},"')!D;<":false,"3t;nS'tn(":null,";y2y'~%0":-6180260529814714,"":-2.587864949178702e-301}
-// • {"NfXclS":{"*.":{"o4N|>MDG":7458703095627481}},"b":"Cx3B*-QdHW","wYEu!8":"D=7)-L","":[false,true,-392234495883237,false,-7556835878382638,undefined,"rC)%A|>f","FW@CfU"]}
-// • {"% z ~!":"!{"}
-// • {">YTN<Tt":[[{"":[".i!$2"],"kmC":[3396245325125853,null,"6v9aGjv8n\"",false,false,"^",false],"_D7/R!":".ukU /mQ","ej<%5":1.7259654282026136e+277,"4ZM;}":{"VV`'ug":-4989474017815283,"w~>":6.2255969832125545e-164,"gN8vW,":"qhJ3xJ","#J":-7.776404213211904e+59,"2UlO<:{@/A":-3.8659798319369648e+118,"y?K]":false,"wN7":-3746080234030558,"=E;Z}":false},"t":-2937644115890368,"TPg":false,"+_<gIOw*":null,"(\"W\"":"5Tlfd"},{"WQ`":true,"?^J":null,"D4Zl":"x|M[d{-","{Va}f":[-8.58111327529814e+48,false,-7064012021756318,-1508001809134475,-2296109926680143,undefined,"w9?B",3647861219441353,5767925612122809],"<!;6}5k1":null,"C`OI{":"O#Z@\\","/Hr{K~T_m":[3.76857210160905e-154,"H1Pb,r8sZ#"],"g=]~%":-3919510632762862}],false]}
+// • {"":{"~?WDIxqj":6219704217632073}}
+// • {"}h\"":{"":undefined,"Y":[3266602324127889,null,true,-1.5448801378255266e+273,-1.159284631999241e+67,-8482811971832566,[5744662626420023],1.881925480738678e+109,2.3481906442263375e-204,415112446291073],"zlE3W9-7b":[false,[5.859235261897208e-257,false],"jN",undefined,-1074420931785765,6285862071843851,-1.3296235488421415e+73,["HY(bVzp0I&",2063892402696201,null,"L28I","YJ/XB/$\\*",undefined,undefined]]}}
+// • {"":true,"~#8}Z\"$<>b":[3.05066817432267e-222,[[-402040690031456],"","X3Xj",undefined,"Fwc8-KTbDs",[7413771313986293,-5525759939773108,3.2141717692547117e-206,7.54265233206461e-153,"(X'U+z"]]]}
+// • {"":{".,":[],"\"S&%x8R":{"aM2KQJMd!p":{"XU#[1kF\"":1.2674907938049296e-227},"(]!$vI\\m7#":[1166197889192629]},"R":[["!kW",undefined,"=]KM}dNa@",undefined,"|M0Ij","h`}m.)",true,"Po#w|d"],-1.9791919370054266e+92,false,1243207589776073,4788105806149147,null,true,{">sCQd|":false,"Y":"","d~PM}AH":-5.5883714696764115e+181,"":-1.6323744640205306e+110,"fN2d'":"+'mF8BLauB","{5NnJUU":"\",y","66|P=Bc8Sw":false,"%~rAS%9|":null,"Gb<<":8.35569451721779e+200,"c~4v)x*=":"YSY-.vC(t~"},false],"5a}!x&l":-51},"B":[{"GRm<bLt":[[true,false,null,1.8448062036331595e+49,"afsV\"p4","=>0_gmW",-2.183227734435476e-131,null,"SDo:fvR"],[],4419884958997989,568181361041021,[{"ED`r":false,"Oi{G%11#J":3819384040595029,"":5596150827835309,"Z2I<}^>":1553143993338437},36636751060818182000]],"%q6~R":true,"{_q8I{0Tbu":undefined,"jCq":{"Y]t9Q":{"^#~.1`":-3.905904144329039e-144,"Ci%8":false,"g$IwKNq8DH":638602134381873,"OiQe":7613547781660793,"eLmky1xV":6368664655449581,"ZX":undefined},"CIJs{hipTW":"=1",")C[\\~25JqG":false,"":false,"{TgiuO":1.5019085639523795e+143,"zs*lF":"zuQS%","KB?J>a6?}{":1.2735551531936247e+59}}],"$Jy&":[{"z{KaQG+LT":{"6|ghiqB":{},"8)g9^i3s":[],"Z":undefined},"":{"is}g+!rK":"|%|*","Sp>":"S%=","wS9:":{"==1JB":[],"um":{"]:t.M8jX#":3.4228349725309693e+22,"6IM\"C":-1141887726399903,"j8XA,mP":"Y","}[W":null},"'RE_v{$*L":"(iw{)1,@","##":"ZSJrO2eS^","LR51vql":1403215317636985,"":undefined,"fOz\"+Pl,7":null},"J2FqJ/q{+":undefined,"R'=#W5-Z":396177444961801,"UN":null,"{B":-993081575959169,"J%*v6":4682658003308353},"IaCt\"HE":{"JI2zmWH":false,":\"_":true,"2t%z":-1.2218497609618295e+70,"t":6.833288509381854e+219,"-":"C"}},true,["5d]",":",-9.935966067628939e-179,null,[-8.251112422518682e-12,false,true,true,null],false,"aMkyu`[4-}",8260395271834733,5.798719645486476e-85,null],{"<hc1ZNLN":"GI\\2[fx$G","rTF]Wi":"J{p","i":["",3053775232181945,"<)[V&pN","`#Ar3",null],"m0A8#6T":"cK3$","0k}&3&y%8H":"&U","nrz|l":undefined,"HP0U>POQ&":-4292282062994742,"%f+L,?~":undefined}],"r":"x\"","`&#":"","JM<Vx;+bno":"b1<l%{","^U'yS*y`.":"Ly'","x\"":[-29]}
+// • {}
 // • …
 ```
 </details>
@@ -2948,11 +2948,11 @@ fc.object({
 *&#8195;Signatures*
 
 - `fc.jsonValue()`
-- `fc.jsonValue({depthFactor?, maxDepth?})`
+- `fc.jsonValue({depthSize?, maxDepth?})`
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — default: `undefined` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -3059,11 +3059,11 @@ fc.statistics(
 *&#8195;Signatures*
 
 - `fc.unicodeJsonValue()`
-- `fc.unicodeJsonValue({depthFactor?, maxDepth?})`
+- `fc.unicodeJsonValue({depthSIze?, maxDepth?})`
 
 *&#8195;with:*
 
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — default: `undefined` — _maximal depth for generated objects (Map and Set included into objects)_
 
 *&#8195;Usages*
@@ -3096,12 +3096,12 @@ fc.unicodeJsonValue({maxDepth: 1})
 *&#8195;Signatures*
 
 - `fc.anything()`
-- `fc.anything({key?, depthFactor?, maxDepth?, maxKeys?, size?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
+- `fc.anything({key?, depthSize?, maxDepth?, maxKeys?, size?, withBigInt?, withBoxedValues?, withDate?, withMap?, withNullPrototype?, withObjectString?, withSet?, withTypedArray?, values?})`
 
 *&#8195;with:*
 
 - `key?` — default: `fc.string()` — _arbitrary responsible to generate keys used for instances of objects_
-- `depthFactor?` — default: `undefined` [more](#depth-factor-explained) — _factor to increase the probability to generate leaf values as we go deeper in the structure, numeric value >=0 (eg.: 0.1)_
+- `depthSize?` — default: `undefined` [more](#depth-size-explained) — _how much we allow our recursive structures to be deep?_
 - `maxDepth?` — default: `undefined` — _maximal depth for generated objects (Map and Set included into objects)_
 - `maxKeys?` — default: `0x7fffffff` [more](#size-explained) — _maximal number of keys in generated objects (Map and Set included into objects)_
 - `size?` — default: `undefined` [more](#size-explained) — _how large should the generated values be?_
@@ -3177,16 +3177,16 @@ fc.anything({
 // • …
 
 fc.anything({
-  depthFactor: 'medium',
+  depthSize: 'medium',
   maxDepth: 1000,
 })
 // Note: For the moment, we have to specify maxDepth to avoid falling back onto its default value
 // Examples of generated values:
-// • false
-// • [{"v[fA#3;&DU":3.2932366570224366e-98,"@*XC;":false,"":"mdR_b","&;":undefined,"$":[6581400433697677],"_5$G[:;=Ec":">",".f0Mu\\":null,"FS#":undefined,"&2Nlfrs_":976864498631781,"%)vX":"@0H(|BO7"}]
-// • [-19,[[[-6069954512283748],{"9":undefined,"HF8)l{u%m[":"DdNT\"qc;,w",",1|55lE9E":-2.8855778479631266e-131,"f( |SRR":[],"C8KX*":[2.2568601504247433e-306]}]]]
-// • [undefined,"",{"":"8r6piZ","!]~!0F":"Fr\"","*QK":[null,"{#i25",")"]},10,-2450231097665564,false,{"|,&":-1.399311342293897e+108}]
 // • {}
+// • ["&cP<5:e(y\""]
+// • {"clSk1?*.":false,"N|":[],"0u?brKlCx":" ~&","R~D=7)-L":1.73e-322,"9q$":-1.6e-322,"yQi^":[4.245069988475282e-293],"\"":false,"y4Or9yi":true,"I\"":3664919048283755}
+// • {"m#e:2@":false,"~eO#":-1.7976931348623127e+308,"#":-6.605264288095509e-34,"$Dk\"":"]Lz%;\" ","Y)H":5198969899037559,"v":"^%&","#ok":"$","Dej97Y9?eO":-1.2889696386603489e+306,"@Pm n|kPLT":false,"H7":false}
+// • 1.022676058193833e-127
 // • …
 ```
 </details>
@@ -3381,10 +3381,10 @@ fc.func(fc.nat())
 // Setup the tree structure:
 const { tree } = fc.letrec(tie => ({
   // Warning: In version 2.x and before, there is no automatic control over the depth of the generated data-structures.
-  //   As a consequence to avoid your data-structures to be too deep, it is highly recommended to add the constraint `depthFactor`
-  //   onto your usages of `option` and `oneof` and to put the arbitrary without recursion first.
-  // In version 3.x, `depthFactor` and `withCrossShrink` will be enabled by default.
-  tree: fc.oneof({depthFactor: 'small', withCrossShrink: true}, tie('leaf'), tie('node')),
+  // As a consequence to avoid your data-structures to be too deep, it is highly recommended to add the constraint `depthFactor`
+  // onto your usages of `option` and `oneof` and to put the arbitrary without recursion first.
+  // In version 3.x, `depthSize` (previously `depthFactor`) and `withCrossShrink` will be enabled by default.
+  tree: fc.oneof({depthSize: 'small', withCrossShrink: true}, tie('leaf'), tie('node')),
   node: fc.record({
     left: tie('tree'),
     right: tie('tree'),
@@ -3394,11 +3394,11 @@ const { tree } = fc.letrec(tie => ({
 // Use the arbitrary:
 tree
 // Examples of generated values:
-// • 27
-// • {"left":{"left":{"left":1843411184,"right":764752372},"right":335246526},"right":{"left":1030366244,"right":2147483617}}
-// • {"left":{"left":892431995,"right":8},"right":{"left":1,"right":{"left":{"left":2113259047,"right":6},"right":2147483625}}}
-// • 2147483641
-// • {"left":{"left":2147483632,"right":1737313089},"right":{"left":{"left":15,"right":{"left":1512608453,"right":24}},"right":{"left":1592991095,"right":2147483633}}}
+// • 651398136
+// • 2
+// • {"left":414067972,"right":{"left":{"left":4,"right":2147483629},"right":{"left":720570539,"right":1174859322}}}
+// • 2147483640
+// • 650384173
 // • …
 
 fc.letrec(tie => ({
@@ -3835,33 +3835,34 @@ Here is a quick overview of how we use the `size` parameter associated to a mini
 - `large` — `min + (100 * min + 1000)`
 - `xlarge` — `min + (1000 * min + 10000)`
 
-### Depth factor explained
+### Depth size explained
 
-Since version 2.25.0, there is a tied link between [size](#size-explained) and depth factor.
+Since version 2.25.0, there is a tied link between [size](#size-explained) and depth of recursive structures.
 
-Depth factor has been introduced in version 2.14.0. It was initially a numeric floating point value between `0`
-and `+infinity`. It was used to reduce the risk of generating infinite structures when relying on recursive arbitraries:
-the higher the depth factor, the higher the chance to build not very deep instances.
+`depthFactor` (aka `depthSize` since 3.0.0) has been introduced in version 2.14.0 as a numeric floating point value between `0`
+and `+infinity`. It was used to reduce the risk of generating infinite structures when relying on recursive arbitraries.
 
 Then size came in 2.22.0 and with it an idea: make it simple for users to configure complex things. While depth factor
 was pretty cool, selecting the right value was not trivial from a user point of view. So size has been leveraged for both:
 number of items defined within an iterable structure and depth. Except very complex and ad-hoc cases, we expect size to
 be the only kind of configuration used to setup depth factors.
 
-Depth factor derived from size works exactly the same way as size, it can rely on Relative Size but also Explicit Size. As for length, if not specified the size will either be defaulted to `"="` or to `"max"` depending on the flag `defaultSizeToMaxWhenMaxSpecified` and on the fact that the user specified a maximal depth or not. The only case defaulting to `"max"` is: user specified a maximal depth onto the instance but not size and `defaultSizeToMaxWhenMaxSpecified` is set to `true`. Any other setup will fallback to `"="`.
+So starting in 3.0.0, we relabelled `depthFactor` as `depthSize`. It works exactly the same way as size, it can rely on Relative Size but also Explicit Size. As for length, if not specified the size will either be defaulted to `"="` or to `"max"` depending on the flag `defaultSizeToMaxWhenMaxSpecified` and on the fact that the user specified a maximal depth or not. The only case defaulting to `"max"` is: user specified a maximal depth onto the instance but not size and `defaultSizeToMaxWhenMaxSpecified` is set to `true`. Any other setup will fallback to `"="`.
 
-Here is how a size translates into depth factors:
+Here is how a size translates into manually defined `depthSize`:
 - `xsmall` — `1`
-- `small` (default) — `1 / 2`
-- `medium` — `1 / 4`
-- `large` — `1 / 8`
-- `xlarge` — `1 / 16`
+- `small` (default) — `2`
+- `medium` — `4`
+- `large` — `8`
+- `xlarge` — `16`
 
 In the context of fast-check@v2, the condition to leverage an automatic defaulting of the depth factor is to:
 - either define it to `=` for each arbitrary not defaulting it automatically (only `option` and `oneof` do not default it to avoid breaking existing code)
 - or to configure a `baseSize` in the global settings
 
-If none of these conditions is fulfilled the depth factor will be defaulted to `0` as it was the case befoer we introduced it.
+In the context of fast-check@v2, `depthFactor` is the same as `depthSize` except for numeric values. For those values `depthSize = 1 / depthFactor`.
+
+If none of these conditions is fulfilled the depth factor will be defaulted to `0` as it was the case before we introduced it.
 Otherwise, depth factor will be defaulted automatically for you.
 
 ### Various links

--- a/example/002-recursive/isSearchTree/arbitraries/BinaryTreeArbitrary.ts
+++ b/example/002-recursive/isSearchTree/arbitraries/BinaryTreeArbitrary.ts
@@ -22,7 +22,7 @@ export const binaryTreeWithoutMaxDepth = (): fc.Arbitrary<Tree<number>> => {
       right: fc.constant(null),
     }),
     node: fc.record({ value: fc.integer(), left: tie('tree'), right: tie('tree') }),
-    tree: fc.oneof({ depthFactor: 'small' }, tie('leaf'), tie('node')),
+    tree: fc.oneof({ depthSize: 'small' }, tie('leaf'), tie('node')),
   }));
   return tree as fc.Arbitrary<Tree<number>>;
 };

--- a/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
+++ b/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
@@ -96,7 +96,7 @@ function typedArray(constraints: { maxLength: number | undefined; size: SizeForA
 /** @internal */
 export function anyArbitraryBuilder(constraints: QualifiedObjectConstraints): Arbitrary<unknown> {
   const arbitrariesForBase = constraints.values;
-  const depthFactor = constraints.depthFactor;
+  const depthSize = constraints.depthSize;
   const depthIdentifier = createDepthIdentifier();
   const maxDepth = constraints.maxDepth;
   const maxKeys = constraints.maxKeys;
@@ -109,7 +109,7 @@ export function anyArbitraryBuilder(constraints: QualifiedObjectConstraints): Ar
 
   return letrec((tie) => ({
     anything: oneof(
-      { maxDepth, depthFactor, depthIdentifier },
+      { maxDepth, depthSize, depthIdentifier },
       baseArb, // Final recursion case
       tie('array'),
       tie('object'),

--- a/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
+++ b/src/arbitrary/_internals/helpers/JsonConstraintsBuilder.ts
@@ -2,7 +2,7 @@ import { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary';
 import { boolean } from '../../boolean';
 import { constant } from '../../constant';
 import { double } from '../../double';
-import { DepthFactorSizeForArbitrary } from './MaxLengthFromMinLength';
+import { DepthSize } from './MaxLengthFromMinLength';
 import { ObjectConstraints } from './QualifiedObjectConstraints';
 
 /**
@@ -22,7 +22,7 @@ export interface JsonSharedConstraints {
    *
    * @remarks Since 2.20.0
    */
-  depthFactor?: DepthFactorSizeForArbitrary;
+  depthSize?: DepthSize;
   /**
    * Maximal depth allowed
    * @remarks Since 2.5.0
@@ -39,7 +39,7 @@ export function jsonConstraintsBuilder(
   stringArbitrary: Arbitrary<string>,
   constraints: JsonSharedConstraints
 ): ObjectConstraints {
-  const { depthFactor, maxDepth } = constraints;
+  const { depthSize, maxDepth } = constraints;
   const key = stringArbitrary;
   const values = [
     boolean(), // any boolean
@@ -47,7 +47,7 @@ export function jsonConstraintsBuilder(
     stringArbitrary, // any string
     constant(null),
   ];
-  return { key, values, depthFactor, maxDepth };
+  return { key, values, depthSize, maxDepth };
 }
 
 /**

--- a/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
+++ b/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
@@ -6,7 +6,7 @@ import { maxSafeInteger } from '../../maxSafeInteger';
 import { oneof } from '../../oneof';
 import { string } from '../../string';
 import { boxedArbitraryBuilder } from '../builders/BoxedArbitraryBuilder';
-import { DepthFactorSizeForArbitrary, SizeForArbitrary } from './MaxLengthFromMinLength';
+import { DepthSize, SizeForArbitrary } from './MaxLengthFromMinLength';
 
 /**
  * Constraints for {@link anything} and {@link object}
@@ -19,7 +19,7 @@ export interface ObjectConstraints {
    *
    * @remarks Since 2.20.0
    */
-  depthFactor?: DepthFactorSizeForArbitrary;
+  depthSize?: DepthSize;
   /**
    * Maximal depth allowed
    * @remarks Since 0.0.7
@@ -115,7 +115,7 @@ export interface ObjectConstraints {
 }
 
 /** @internal */
-type ObjectConstraintsOptionalValues = 'depthFactor' | 'maxDepth' | 'maxKeys' | 'size';
+type ObjectConstraintsOptionalValues = 'depthSize' | 'maxDepth' | 'maxKeys' | 'size';
 
 /**
  * Internal wrapper around an `ObjectConstraints`, it adds all the missing pieces in the configuration
@@ -162,7 +162,7 @@ export function toQualifiedObjectConstraints(settings: ObjectConstraints = {}): 
       orDefault(settings.values, defaultValues(valueConstraints)),
       orDefault(settings.withBoxedValues, false)
     ),
-    depthFactor: settings.depthFactor,
+    depthSize: settings.depthSize,
     maxDepth: settings.maxDepth,
     maxKeys: settings.maxKeys,
     size: settings.size,

--- a/src/arbitrary/array.ts
+++ b/src/arbitrary/array.ts
@@ -34,7 +34,7 @@ export interface ArrayConstraints {
    */
   size?: SizeForArbitrary;
   /**
-   * When receiving a depth identifier, the arbitrary will impact the depthFactor
+   * When receiving a depth identifier, the arbitrary will impact the depth
    * attached to it to avoid going too deep if it already generated lots of items.
    *
    * In other words, if the number of generated values within the collection is large

--- a/src/arbitrary/letrec.ts
+++ b/src/arbitrary/letrec.ts
@@ -56,12 +56,12 @@ export type LetrecLooselyTypedBuilder<T> = (tie: LetrecLooselyTypedTie) => Letre
  * type Node = [Tree, Tree];
  * type Tree = Node | Leaf;
  * const { tree } = fc.letrec<{ tree: Tree, node: Node, leaf: Leaf }>(tie => ({
- *   tree: fc.oneof({depthFactor: 'small'}, tie('leaf'), tie('node')),
+ *   tree: fc.oneof({depthSize: 'small'}, tie('leaf'), tie('node')),
  *   node: fc.tuple(tie('tree'), tie('tree')),
  *   leaf: fc.nat()
  * }));
  * // tree is 50% of node, 50% of leaf
- * // the ratio goes in favor of leaves as we go deeper in the tree (thanks to depthFactor)
+ * // the ratio goes in favor of leaves as we go deeper in the tree (thanks to depthSize)
  * ```
  *
  * @param builder - Arbitraries builder based on themselves (through `tie`)
@@ -76,12 +76,12 @@ export function letrec<T>(builder: T extends Record<string, unknown> ? LetrecTyp
  * @example
  * ```typescript
  * const { tree } = fc.letrec(tie => ({
- *   tree: fc.oneof({depthFactor: 'small'}, tie('leaf'), tie('node')),
+ *   tree: fc.oneof({depthSize: 'small'}, tie('leaf'), tie('node')),
  *   node: fc.tuple(tie('tree'), tie('tree')),
  *   leaf: fc.nat()
  * }));
  * // tree is 50% of node, 50% of leaf
- * // the ratio goes in favor of leaves as we go deeper in the tree (thanks to depthFactor)
+ * // the ratio goes in favor of leaves as we go deeper in the tree (thanks to depthSize)
  * ```
  *
  * @param builder - Arbitraries builder based on themselves (through `tie`)

--- a/src/arbitrary/oneof.ts
+++ b/src/arbitrary/oneof.ts
@@ -1,7 +1,7 @@
 import { Arbitrary, isArbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { FrequencyArbitrary } from './_internals/FrequencyArbitrary';
 import { DepthIdentifier } from './_internals/helpers/DepthContext';
-import { DepthFactorSizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength';
+import { DepthSize } from './_internals/helpers/MaxLengthFromMinLength';
 
 /**
  * Conjonction of a weight and an arbitrary used by {@link oneof}
@@ -64,7 +64,7 @@ export type OneOfConstraints = {
    *
    * @remarks Since 2.14.0
    */
-  depthFactor?: DepthFactorSizeForArbitrary;
+  depthSize?: DepthSize;
   /**
    * Maximal authorized depth.
    * Once this depth has been reached only the first arbitrary will be used.

--- a/src/arbitrary/option.ts
+++ b/src/arbitrary/option.ts
@@ -2,7 +2,7 @@ import { constant } from './constant';
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { FrequencyArbitrary, _Constraints as FrequencyContraints } from './_internals/FrequencyArbitrary';
 import { DepthIdentifier } from './_internals/helpers/DepthContext';
-import { DepthFactorSizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength';
+import { DepthSize } from './_internals/helpers/MaxLengthFromMinLength';
 
 /**
  * Constraints to be applied on {@link option}
@@ -26,7 +26,7 @@ export interface OptionConstraints<TNil = null> {
    *
    * @remarks Since 2.14.0
    */
-  depthFactor?: DepthFactorSizeForArbitrary;
+  depthSize?: DepthSize;
   /**
    * Maximal authorized depth. Once this depth has been reached only nil will be used.
    *
@@ -66,7 +66,7 @@ export function option<T, TNil = null>(
   ];
   const frequencyConstraints: FrequencyContraints = {
     withCrossShrink: true,
-    depthFactor: constraints.depthFactor,
+    depthSize: constraints.depthSize,
     maxDepth: constraints.maxDepth,
     depthIdentifier: constraints.depthIdentifier,
   };

--- a/src/arbitrary/sparseArray.ts
+++ b/src/arbitrary/sparseArray.ts
@@ -41,7 +41,7 @@ export interface SparseArrayConstraints {
    */
   size?: SizeForArbitrary;
   /**
-   * When receiving a depth identifier, the arbitrary will impact the depthFactor
+   * When receiving a depth identifier, the arbitrary will impact the depth
    * attached to it to avoid going too deep if it already generated lots of items.
    *
    * In other words, if the number of generated values within the collection is large

--- a/src/arbitrary/uniqueArray.ts
+++ b/src/arbitrary/uniqueArray.ts
@@ -65,7 +65,7 @@ export type UniqueArraySharedConstraints = {
    */
   size?: SizeForArbitrary;
   /**
-   * When receiving a depth identifier, the arbitrary will impact the depthFactor
+   * When receiving a depth identifier, the arbitrary will impact the depth
    * attached to it to avoid going too deep if it already generated lots of items.
    *
    * In other words, if the number of generated values within the collection is large

--- a/src/fast-check-default.ts
+++ b/src/fast-check-default.ts
@@ -164,11 +164,7 @@ import { float64Array, Float64ArrayConstraints } from './arbitrary/float64Array'
 import { sparseArray, SparseArrayConstraints } from './arbitrary/sparseArray';
 import { Arbitrary } from './check/arbitrary/definition/Arbitrary';
 import { Value } from './check/arbitrary/definition/Value';
-import {
-  Size,
-  SizeForArbitrary,
-  DepthFactorSizeForArbitrary,
-} from './arbitrary/_internals/helpers/MaxLengthFromMinLength';
+import { Size, SizeForArbitrary, DepthSize } from './arbitrary/_internals/helpers/MaxLengthFromMinLength';
 import {
   createDepthIdentifier,
   DepthContext,
@@ -407,7 +403,7 @@ export {
   // run configuration
   Size,
   SizeForArbitrary,
-  DepthFactorSizeForArbitrary,
+  DepthSize,
   GlobalParameters,
   GlobalAsyncPropertyHookFunction,
   GlobalPropertyHookFunction,

--- a/test/e2e/NoRegression.spec.ts
+++ b/test/e2e/NoRegression.spec.ts
@@ -601,12 +601,12 @@ describe(`NoRegression`, () => {
       )
     ).toThrowErrorMatchingSnapshot();
   });
-  it('letrec (oneof:depthFactor)', () => {
+  it('letrec (oneof:depthSize)', () => {
     expect(() =>
       fc.assert(
         fc.property(
           fc.letrec((tie) => ({
-            tree: fc.oneof({ withCrossShrink: true, depthFactor: 'small' }, tie('leaf'), tie('node')),
+            tree: fc.oneof({ withCrossShrink: true, depthSize: 'small' }, tie('leaf'), tie('node')),
             node: fc.record({ a: tie('tree'), b: tie('tree'), c: tie('tree') }),
             leaf: fc.nat(21),
           })).tree,

--- a/test/e2e/RecursiveStructures.spec.ts
+++ b/test/e2e/RecursiveStructures.spec.ts
@@ -57,7 +57,7 @@ describe(`RecursiveStructures (seed: ${seed})`, () => {
     const failingLength = 2;
     const dataArb: fc.Memo<unknown[]> = fc.memo((n) => {
       if (n <= 1) return fc.constant([0]);
-      else return fc.option(fc.tuple(dataArb(), dataArb()), { nil: [0], depthFactor: 'small' });
+      else return fc.option(fc.tuple(dataArb(), dataArb()), { nil: [0], depthSize: 'small' });
     });
 
     // Act

--- a/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -2388,7 +2388,7 @@ Execution summary:
 . . [32m√[0m [[\\"[\\"]]"
 `;
 
-exports[`NoRegression letrec (oneof:depthFactor) 1`] = `
+exports[`NoRegression letrec (oneof:depthSize) 1`] = `
 "Property failed after 37 tests
 { seed: 42, path: \\"36:1:0:0:6:4:4:4:4\\", endOnFailure: true }
 Counterexample: [{\\"a\\":0,\\"b\\":0,\\"c\\":{\\"a\\":{\\"a\\":11,\\"b\\":0,\\"c\\":0},\\"b\\":0,\\"c\\":0}}]

--- a/test/e2e/arbitraries/LetRecArbitrary.spec.ts
+++ b/test/e2e/arbitraries/LetRecArbitrary.spec.ts
@@ -16,12 +16,12 @@ describe(`LetRecArbitrary (seed: ${seed})`, () => {
     it('Should be usable to build deep tree instances', () => {
       const { tree } = fc.letrec((tie) => ({
         tree: fc.oneof(
-          // Depth factor is 'max' for this test as we want to go as deep as possible.
-          // While using non-maxed depth factor does not prevent such structure from being generated,
+          // `depthSize` is set to 'max' for this test as we want to go as deep as possible.
+          // While using non-maxed `depthSize` does not prevent such structure from being generated,
           // it may highly reduce their probability to be generated. So for the sake of this test,
           // we want to manually handle the depth via setting manually our weight so that the structure
           // will not explode and go too deep.
-          { depthFactor: 'max' },
+          { depthSize: 'max' },
           { arbitrary: tie('node'), weight: 45 },
           { arbitrary: tie('leaf'), weight: 55 }
         ),

--- a/test/legacy/node-8/main.js
+++ b/test/legacy/node-8/main.js
@@ -92,7 +92,7 @@ testArbitrary(
 testArbitrary(
   fc.letrec(function (tie) {
     return {
-      tree: fc.oneof({ depthFactor: 'small' }, tie('leaf'), tie('node')),
+      tree: fc.oneof({ depthSize: 'small' }, tie('leaf'), tie('node')),
       node: fc.tuple(tie('tree'), tie('tree')),
       leaf: fc.nat(),
     };

--- a/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
@@ -161,7 +161,7 @@ describe('ArrayArbitrary', () => {
       );
     });
 
-    it('should impact depth factor the same way for any child and reset it at the end', () => {
+    it('should bias depth the same way for any child and reset it at the end', () => {
       fc.assert(
         fc.property(
           fc.array(fc.tuple(fc.anything(), fc.anything(), fc.boolean())),

--- a/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
+++ b/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
@@ -55,8 +55,8 @@ const frequencyConstraintsArbFor = (keys: {
   return fc.record(
     {
       ...(!forbidden.includes('depthIdentifier') ? { depthIdentifier: fc.string() } : {}),
-      ...(!forbidden.includes('depthFactor')
-        ? { depthFactor: fc.oneof(fc.double({ min: 0.01, noDefaultInfinity: true, noNaN: true }), sizeArb) }
+      ...(!forbidden.includes('depthSize')
+        ? { depthSize: fc.oneof(fc.double({ min: 0, max: 100, noNaN: true }), sizeArb) }
         : {}),
       ...(!forbidden.includes('maxDepth') ? { maxDepth: fc.nat() } : {}),
       ...(!forbidden.includes('withCrossShrink') ? { withCrossShrink: fc.boolean() } : {}),
@@ -310,11 +310,11 @@ describe('FrequencyArbitrary', () => {
         )
       ));
 
-    it('should ask ranges containing negative values as we go deeper in the structure if depthFactor and first arbitrary has weight >0', () =>
+    it('should ask ranges containing negative values as we go deeper in the structure if depthSize and first arbitrary has weight >0', () =>
       fc.assert(
         fc.property(
           frequencyValidInputsArb,
-          frequencyConstraintsArbFor({ forbidden: ['maxDepth'], required: ['depthFactor'] }),
+          frequencyConstraintsArbFor({ forbidden: ['maxDepth'], required: ['depthSize'] }),
           fc.option(fc.integer({ min: 2 }), { nil: undefined }),
           (validInputs, constraints, biasFactor) => {
             // Arrange
@@ -355,7 +355,7 @@ describe('FrequencyArbitrary', () => {
       fc.assert(
         fc.property(
           frequencyValidInputsArb,
-          frequencyConstraintsArbFor({ forbidden: ['maxDepth'], required: ['depthFactor'] }),
+          frequencyConstraintsArbFor({ forbidden: ['maxDepth'], required: ['depthSize'] }),
           fc.option(fc.integer({ min: 2 }), { nil: undefined }),
           (validInputs, constraints, biasFactor) => {
             // Arrange
@@ -721,7 +721,7 @@ describe('FrequencyArbitrary (integration)', () => {
       constraints: fc.record(
         {
           withCrossShrink: fc.boolean(),
-          depthFactor: fc.oneof(fc.double({ min: 0, max: Number.MAX_VALUE, noNaN: true }), sizeArb),
+          depthSize: fc.oneof(fc.double({ min: 0, max: Number.MAX_VALUE, noNaN: true }), sizeArb),
           maxDepth: fc.nat(),
         },
         { requiredKeys: [] }

--- a/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
+++ b/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
@@ -91,7 +91,7 @@ describe('anyArbitraryBuilder (integration)', () => {
   const extraParameters: fc.Arbitrary<Extra> = fc
     .record(
       {
-        depthFactor: fc.oneof(fc.double({ min: 0, max: 10 }), sizeArb),
+        depthSize: fc.oneof(fc.double({ min: 0.1, noNaN: true }), sizeArb),
         maxDepth: fc.nat({ max: 5 }),
         maxKeys: fc.nat({ max: 10 }),
         withBigInt: fc.boolean(),
@@ -107,13 +107,13 @@ describe('anyArbitraryBuilder (integration)', () => {
       { requiredKeys: [] }
     )
     .filter((params) => {
-      if (params.depthFactor === undefined || params.depthFactor >= 0.5) {
+      if (params.depthSize === undefined || params.depthSize <= 2) {
         return true; // 0.5 is equivalent to small, the default
       }
       if (params.maxDepth !== undefined) {
         return true;
       }
-      // No maxDepth and a depthFactor relatively small can potentially lead to very very large
+      // No maxDepth and a depthSize relatively small can potentially lead to very very large
       // and deep structures. We want to avoid those cases in this test.
       return false;
     });

--- a/test/unit/arbitrary/_internals/helpers/MaxLengthFromMinLength.spec.ts
+++ b/test/unit/arbitrary/_internals/helpers/MaxLengthFromMinLength.spec.ts
@@ -1,7 +1,7 @@
 import fc from '../../../../../lib/fast-check';
 import {
   DefaultSize,
-  depthFactorFromSizeForArbitrary,
+  depthBiasFromSizeForArbitrary,
   maxGeneratedLengthFromSizeForArbitrary,
   maxLengthFromMinLength,
   MaxLengthUpperBound,
@@ -264,8 +264,8 @@ describe('maxGeneratedLengthFromSizeForArbitrary', () => {
   });
 });
 
-describe('depthFactorFromSizeForArbitrary', () => {
-  it('should only consider the received depthFactor when set to a numeric value', () => {
+describe('depthSizeFromSizeForArbitrary', () => {
+  it('should only consider the received depthSize when set to a numeric value', () => {
     fc.assert(
       fc.property(
         sizeRelatedGlobalConfigArb,
@@ -273,12 +273,12 @@ describe('depthFactorFromSizeForArbitrary', () => {
         fc.boolean(),
         (config, size, specifiedMaxDepth) => {
           // Arrange / Act
-          const computedDepthFactor = withConfiguredGlobal(config, () =>
-            depthFactorFromSizeForArbitrary(size, specifiedMaxDepth)
+          const computedDepthBias = withConfiguredGlobal(config, () =>
+            depthBiasFromSizeForArbitrary(size, specifiedMaxDepth)
           );
 
           // Assert
-          expect(computedDepthFactor).toBe(size);
+          expect(computedDepthBias).toBe(1 / size);
         }
       )
     );
@@ -288,13 +288,13 @@ describe('depthFactorFromSizeForArbitrary', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, sizeArb, fc.boolean(), (config, size, specifiedMaxDepth) => {
         // Arrange / Act
-        const computedDepthFactor = withConfiguredGlobal(config, () =>
-          depthFactorFromSizeForArbitrary(size, specifiedMaxDepth)
+        const computedDepthBias = withConfiguredGlobal(config, () =>
+          depthBiasFromSizeForArbitrary(size, specifiedMaxDepth)
         );
-        const expectedDepthFactor = { xsmall: 1, small: 1 / 2, medium: 1 / 4, large: 1 / 8, xlarge: 1 / 16 }[size];
+        const expectedDepthBias = { xsmall: 1, small: 1 / 2, medium: 1 / 4, large: 1 / 8, xlarge: 1 / 16 }[size];
 
         // Assert
-        expect(computedDepthFactor).toBe(expectedDepthFactor);
+        expect(computedDepthBias).toBe(expectedDepthBias);
       })
     );
   });
@@ -307,13 +307,13 @@ describe('depthFactorFromSizeForArbitrary', () => {
         const equivalentSize = relativeSizeToSize(size, defaultSize);
 
         // Act
-        const computedDepthFactor = withConfiguredGlobal(config, () =>
-          depthFactorFromSizeForArbitrary(size, specifiedMaxDepth)
+        const computedDepthBias = withConfiguredGlobal(config, () =>
+          depthBiasFromSizeForArbitrary(size, specifiedMaxDepth)
         );
-        const expectedDepthFactor = depthFactorFromSizeForArbitrary(equivalentSize, false);
+        const expectedDepthBias = depthBiasFromSizeForArbitrary(equivalentSize, false);
 
         // Assert
-        expect(computedDepthFactor).toBe(expectedDepthFactor);
+        expect(computedDepthBias).toBe(expectedDepthBias);
       })
     );
   });
@@ -322,12 +322,12 @@ describe('depthFactorFromSizeForArbitrary', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, fc.boolean(), (config, specifiedMaxDepth) => {
         // Arrange / Act
-        const computedDepthFactor = withConfiguredGlobal(config, () =>
-          depthFactorFromSizeForArbitrary('max', specifiedMaxDepth)
+        const computedDepthBias = withConfiguredGlobal(config, () =>
+          depthBiasFromSizeForArbitrary('max', specifiedMaxDepth)
         );
 
         // Assert
-        expect(computedDepthFactor).toBe(0);
+        expect(computedDepthBias).toBe(0);
       })
     );
   });
@@ -336,12 +336,12 @@ describe('depthFactorFromSizeForArbitrary', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, (config) => {
         // Arrange / Act
-        const computedDepthFactor = withConfiguredGlobal({ ...config, defaultSizeToMaxWhenMaxSpecified: true }, () =>
-          depthFactorFromSizeForArbitrary(undefined, true)
+        const computedDepthBias = withConfiguredGlobal({ ...config, defaultSizeToMaxWhenMaxSpecified: true }, () =>
+          depthBiasFromSizeForArbitrary(undefined, true)
         );
 
         // Assert
-        expect(computedDepthFactor).toBe(0);
+        expect(computedDepthBias).toBe(0);
       })
     );
   });

--- a/test/unit/arbitrary/jsonValue.spec.ts
+++ b/test/unit/arbitrary/jsonValue.spec.ts
@@ -17,12 +17,12 @@ describe('jsonValue (integration)', () => {
     fc
       .record(
         {
-          depthFactor: fc.oneof(fc.double({ min: 0, max: 10 }), sizeArb),
+          depthSize: fc.oneof(fc.double({ min: 0.1, noNaN: true }), sizeArb),
           maxDepth: fc.nat({ max: 5 }),
         },
         { requiredKeys: [] }
       )
-      .filter((ct) => ct.depthFactor === undefined || ct.depthFactor >= 0.1 || ct.maxDepth !== undefined),
+      .filter((ct) => ct.depthSize === undefined || ct.depthSize <= 10 || ct.maxDepth !== undefined),
     { nil: undefined }
   );
 

--- a/test/unit/arbitrary/oneof.spec.ts
+++ b/test/unit/arbitrary/oneof.spec.ts
@@ -19,7 +19,7 @@ describe('oneof', () => {
           {
             withCrossShrink: fc.boolean(),
             depthIdentifier: fc.string(),
-            depthFactor: fc.oneof(fc.double({ min: 0.01, noDefaultInfinity: true, noNaN: true }), sizeArb),
+            depthSize: fc.oneof(fc.double({ min: 0, noNaN: true }), sizeArb),
             maxDepth: fc.nat(),
           },
           { requiredKeys: [] }

--- a/test/unit/arbitrary/option.spec.ts
+++ b/test/unit/arbitrary/option.spec.ts
@@ -25,7 +25,7 @@ describe('option', () => {
         fc.record(
           {
             depthIdentifier: fc.string(),
-            depthFactor: fc.oneof(fc.double({ min: 0.01, noDefaultInfinity: true, noNaN: true }), sizeArb),
+            depthSize: fc.oneof(fc.double({ min: 0, noNaN: true }), sizeArb),
             maxDepth: fc.nat(),
             freq: fc.nat(),
             nil: fc.anything(),
@@ -55,7 +55,7 @@ describe('option', () => {
             ],
             {
               withCrossShrink: true,
-              depthFactor: constraints.depthFactor,
+              depthSize: constraints.depthSize,
               maxDepth: constraints.maxDepth,
               depthIdentifier: constraints.depthIdentifier,
             },
@@ -88,7 +88,7 @@ describe('option', () => {
       ],
       {
         withCrossShrink: true,
-        depthFactor: undefined,
+        depthSize: undefined,
         maxDepth: undefined,
         depthIdentifier: undefined,
       },

--- a/test/unit/arbitrary/unicodeJsonValue.spec.ts
+++ b/test/unit/arbitrary/unicodeJsonValue.spec.ts
@@ -17,12 +17,12 @@ describe('unicodeJsonValue (integration)', () => {
     fc
       .record(
         {
-          depthFactor: fc.oneof(fc.double({ min: 0, max: 10 }), sizeArb),
+          depthSize: fc.oneof(fc.double({ min: 0.1, noNaN: true }), sizeArb),
           maxDepth: fc.nat({ max: 5 }),
         },
         { requiredKeys: [] }
       )
-      .filter((ct) => ct.depthFactor === undefined || ct.depthFactor >= 0.1 || ct.maxDepth !== undefined),
+      .filter((ct) => ct.depthSize === undefined || ct.depthSize <= 10 || ct.maxDepth !== undefined),
     { nil: undefined }
   );
 


### PR DESCRIPTION
Rename `depthFactor` into `depthSize` for one main reason: the current attribute was used for both size (small means not deep and large means deep) and numeric values (0 means deep and +infinity means not deep) but has non-aligned meanings. As a consequence we wanted to align the logic so that small or 0 always means no deep and large or +infinity always means deep.

As this change could have been misleading for an end-user reading the documentation of v2 or v3, we decided to use another name to make it clearer that `depthFactor` and `depthSize` are not exactly the same and that an adaptation might be needed to go from one to the other.

Related to #2969

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
