### PR TITLE
👷 Switch to `yarn workspace *` instead of `cd packages/*`

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Check format
-        run: cd packages/fast-check && yarn format:check
+        run: yarn workspace fast-check format:check
       - name: Check lint
-        run: cd packages/fast-check && yarn lint:check
+        run: yarn workspace fast-check lint:check
   typecheck:
     name: "Typecheck"
     runs-on: ubuntu-latest
@@ -44,9 +44,9 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build the library (dev version)
-        run: cd packages/fast-check && yarn build
+        run: yarn workspace fast-check build
       - name: Typecheck
-        run: cd packages/fast-check && yarn typecheck
+        run: yarn workspace fast-check typecheck
   test:
     name: "Test"
     runs-on: ubuntu-latest
@@ -68,14 +68,14 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build the library (dev version)
-        run: cd packages/fast-check && yarn build
+        run: yarn workspace fast-check build
       - name: Unit tests
         shell: bash -l {0}
         run: |
           export EXPECT_DEFAULT_SEED="true"
           export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
           echo "DEFAULT_SEED is: ${DEFAULT_SEED}"
-          cd packages/fast-check && yarn test
+          yarn workspace fast-check test
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -105,14 +105,14 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build the library (dev version)
-        run: cd packages/fast-check && yarn build
+        run: yarn workspace fast-check build
       - name: End-to-end tests
         shell: bash -l {0}
         run: |
           export EXPECT_DEFAULT_SEED="true"
           export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
           echo "DEFAULT_SEED is: ${DEFAULT_SEED}"
-          cd packages/fast-check && yarn e2e
+          yarn workspace fast-check e2e
   test_package_quality:
     name: "Test package quality"
     runs-on: ubuntu-latest
@@ -137,9 +137,9 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build minimal package
-        run: cd packages/fast-check && yarn build:publish-types
+        run: yarn workspace fast-check build:publish-types
       - name: Generate documentation
-        run: cd packages/fast-check && yarn docs-ci
+        run: yarn workspace fast-check docs-ci
       - name: Upload documentation
         uses: actions/upload-artifact@v3
         with:
@@ -160,11 +160,9 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build production package
-        run: cd packages/fast-check && yarn build:prod-ci
+        run: yarn workspace fast-check build:prod-ci
       - name: Create bundle
-        run: |
-          cd packages/fast-check && yarn pack
-          mv package.tgz fast-check.tgz
+        run: yarn workspace fast-check pack --out %s.tgz
       - name: Upload production package
         uses: actions/upload-artifact@v3
         with:
@@ -194,7 +192,7 @@ jobs:
       - name: Install dependencies
         run: yarn workspace fast-check install --immutable
       - name: Check ES Version
-        run: cd packages/fast-check && yarn test:es
+        run: yarn workspace fast-check test:es
   test_examples:
     name: "Test examples/"
     needs: production_package
@@ -215,13 +213,9 @@ jobs:
           package: "@fast-check/examples"
           path: "examples"
       - name: Typecheck examples/
-        run: |
-          cd examples
-          yarn typecheck
+        run: yarn workspace @fast-check/examples typecheck
       - name: Test examples/
-        run: |
-          cd examples
-          yarn test
+        run: yarn workspace @fast-check/examples test
   test_types:
     name: "Test types"
     needs: production_package

--- a/.github/workflows/please-actions.yml
+++ b/.github/workflows/please-actions.yml
@@ -34,14 +34,11 @@ jobs:
       - name: Install fast-check dependencies
         run: yarn workspace fast-check install --immutable
       - name: Build package
-        run: cd packages/fast-check && yarn build:prod-ci
+        run: yarn workspace fast-check build:prod-ci
       - name: Generate documentation
-        run: cd packages/fast-check && yarn docs-ci
+        run: yarn workspace fast-check yarn docs-ci
       - name: Generate bundle
-        run: |
-          cd packages/fast-check
-          yarn pack
-          mv fast-check-*.tgz packages/fast-check/docs/fast-check.tgz
+        run: yarn workspace fast-check pack --out docs/%s.tgz
       - name: Install deploy-netlify dependencies
         run: |
           cd ./.github/actions/deploy-netlify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ In order to start playing with the code locally you must run the following set o
 ```bash
 git clone https://github.com/dubzzz/fast-check.git && cd fast-check
 yarn
-yarn build    #compile the code in ./src, build the ./lib content
+yarn workspace fast-check build    #compile the code in packages/fast-check/src, build the packages/fast-check/lib content
 ```
 
 Once done, everything is ready for you to start working on the code.
@@ -162,7 +162,7 @@ describe('myArbitrary (integration)', () => {
 
 - No regression test - in `test/e2e/NoRegression.spec.ts`
 
-Then run `yarn e2e -- -u` locally to update the snapshot file. The `NoRegression` spec is supposed to prevent unwanted breaking changes to be included in a future release of fast-check by taking a snapshot of the current output and enforcing it does not change over time (except if needed).
+Then run `yarn workspace fast-check e2e -- -u` locally to update the snapshot file. The `NoRegression` spec is supposed to prevent unwanted breaking changes to be included in a future release of fast-check by taking a snapshot of the current output and enforcing it does not change over time (except if needed).
 
 - Legacy support test - in `packages/test-minimal-support/main.js`
 


### PR DESCRIPTION
Simplify the build workflow by using `yarn workspace *` instead of `cd packages/*` whenever possible.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
