### PR TITLE
👷 Make fast-check's tests rely on its own build

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -84,7 +84,9 @@ jobs:
         run: yarn version check
   typecheck:
     name: 'Typecheck'
-    needs: warmup_yarn_cache
+    needs:
+      - warmup_yarn_cache
+      - production_packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -94,11 +96,16 @@ jobs:
           node-version: '16.x'
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn workspace fast-check install --immutable
-      - name: Build the library (dev version)
-        run: yarn workspace fast-check build
+        run: yarn install --immutable
+      - name: Download production packages
+        uses: actions/download-artifact@v3
+        with:
+          name: bundles
+          path: packages/
+      - name: Unpack production packages
+        run: yarn unpack:all
       - name: Typecheck
-        run: yarn workspace fast-check typecheck
+        run: yarn workspaces foreach -pvi run typecheck
   test:
     name: 'Test'
     needs:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -122,6 +122,11 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Download production packages
+        uses: actions/download-artifact@v3
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: yarn unpack:all
       - name: Alter internals to behave as if published

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -101,7 +101,9 @@ jobs:
         run: yarn workspace fast-check typecheck
   test:
     name: 'Test'
-    needs: warmup_yarn_cache
+    needs:
+      - warmup_yarn_cache
+      - production_packages
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -119,9 +121,11 @@ jobs:
           node-version: ${{matrix.node-version}}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn workspace fast-check install --immutable
-      - name: Build the library (dev version)
-        run: yarn workspace fast-check build
+        run: yarn install --immutable
+      - name: Unpack production packages
+        run: yarn unpack:all
+      - name: Alter internals to behave as if published
+        run: yarn workspaces foreach -pRvi --from 'fast-check' --no-private --exclude 'fast-check' exec yarn node $(yarn bin packaged) --keep-node-modules
       - name: Unit tests
         shell: bash -l {0}
         run: |
@@ -138,7 +142,9 @@ jobs:
           verbose: false # default: false
   test_e2e:
     name: 'Test E2E'
-    needs: warmup_yarn_cache
+    needs:
+      - warmup_yarn_cache
+      - production_packages
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -157,9 +163,16 @@ jobs:
           node-version: ${{matrix.node-version}}
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn workspace fast-check install --immutable
-      - name: Build the library (dev version)
-        run: yarn workspace fast-check build
+        run: yarn install --immutable
+      - name: Download production packages
+        uses: actions/download-artifact@v3
+        with:
+          name: bundles
+          path: packages/
+      - name: Unpack production packages
+        run: yarn unpack:all
+      - name: Alter internals to behave as if published
+        run: yarn workspaces foreach -pRvi --from 'fast-check' --no-private --exclude 'fast-check' exec yarn node $(yarn bin packaged) --keep-node-modules
       - name: End-to-end tests
         shell: bash -l {0}
         run: |
@@ -180,7 +193,9 @@ jobs:
         run: cd packages/fast-check && yarn dlx @skypack/package-check
   documentation:
     name: 'Build documentation'
-    needs: warmup_yarn_cache
+    needs:
+      - warmup_yarn_cache
+      - production_packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -190,9 +205,14 @@ jobs:
           node-version: '16.x'
           cache: 'yarn'
       - name: Install dependencies
-        run: yarn workspace fast-check install --immutable
-      - name: Build minimal package
-        run: yarn workspace fast-check build:publish-types
+        run: yarn install --immutable
+      - name: Download production packages
+        uses: actions/download-artifact@v3
+        with:
+          name: bundles
+          path: packages/
+      - name: Unpack production packages
+        run: yarn unpack:all
       - name: Generate documentation
         run: yarn workspace fast-check docs-ci
       - name: Upload documentation

--- a/.yarn/versions/ebf9fefd.yml
+++ b/.yarn/versions/ebf9fefd.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@fast-check/monorepo"


### PR DESCRIPTION
Up-to-now the jobs dealing with the specs of fast-check has to first build the package and then run the tests. As we already build the package via a dedicated job, let's leverage this job in all the jobs requesting to build the package.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
