### PR TITLE
✅ Check SHA1 of produced bundle in E2E tests

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -163,6 +163,7 @@ jobs:
       - name: End-to-end tests
         shell: bash -l {0}
         run: |
+          export EXPECT_COMMIT_HASH="true"
           export EXPECT_DEFAULT_SEED="true"
           export DEFAULT_SEED=$(node -p "Date.now() ^ (Math.random() * 0x100000000)")
           echo "DEFAULT_SEED is: ${DEFAULT_SEED}"

--- a/packages/fast-check/test/e2e/Bundle.spec.ts
+++ b/packages/fast-check/test/e2e/Bundle.spec.ts
@@ -1,0 +1,14 @@
+import { __commitHash } from 'fast-check';
+
+describe(`Bundle`, () => {
+  it('should be packaged with the right commit SHA1', () => {
+    // Arrange
+    const expectedCommitHash = process.env.GITHUB_SHA;
+
+    // Act / Assert
+    if (process.env.EXPECT_COMMIT_HASH || process.env.GITHUB_ACTION) {
+      expect(expectedCommitHash).toBeDefined();
+      expect(__commitHash).toBe(expectedCommitHash);
+    }
+  });
+});


### PR DESCRIPTION
Up to now it used to be done in test-bundle-* and others. But this check has been dropped in https://github.com/dubzzz/fast-check/pull/3014, so we reintroduce it as a dedicated E2E.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
