### PR TITLE
✨ Add experimental "custom slices" constraint on array

### DIFF
--- a/.yarn/versions/c3a09b7f.yml
+++ b/.yarn/versions/c3a09b7f.yml
@@ -1,0 +1,24 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/arbitrary/_internals/ArrayArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/ArrayArbitrary.ts
@@ -38,7 +38,8 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
     depthIdentifier: DepthIdentifier | string | undefined,
     // Whenever passing a isEqual to ArrayArbitrary, you also have to filter
     // it's output just in case produced values are too small (below minLength)
-    readonly setBuilder?: CustomSetBuilder<Value<T>>
+    readonly setBuilder: CustomSetBuilder<Value<T>> | undefined,
+    readonly customSlices: T[][]
   ) {
     super();
     this.lengthArb = integer({ min: minLength, max: maxGeneratedLength });
@@ -76,7 +77,7 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
   ): Value<T>[] {
     let numSkippedInRow = 0;
     const s = setBuilder();
-    const slicedGenerator = buildSlicedGenerator(this.arb, mrng, [], biasFactorItems);
+    const slicedGenerator = buildSlicedGenerator(this.arb, mrng, this.customSlices, biasFactorItems);
     // Try to append into items up to the target size
     // We may reject some items as they are already part of the set
     // so we need to retry and generate other ones. In order to prevent infinite loop,
@@ -110,7 +111,7 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
 
   private generateNItems(N: number, mrng: Random, biasFactorItems: number | undefined): Value<T>[] {
     const items: Value<T>[] = [];
-    const slicedGenerator = buildSlicedGenerator(this.arb, mrng, [], biasFactorItems);
+    const slicedGenerator = buildSlicedGenerator(this.arb, mrng, this.customSlices, biasFactorItems);
     slicedGenerator.attemptExact(N);
     for (let index = 0; index !== N; ++index) {
       const current = slicedGenerator.next();

--- a/packages/fast-check/src/arbitrary/array.ts
+++ b/packages/fast-check/src/arbitrary/array.ts
@@ -50,6 +50,21 @@ export interface ArrayConstraints {
 }
 
 /**
+ * Extra but internal constraints that can be passed to array.
+ * This extra set is made of constraints mostly targets experimental and internal features not yet mature to be exposed.
+ * @internal
+ */
+export interface ArrayConstraintsInternal<T> extends ArrayConstraints {
+  /**
+   * Extra user-definable and hardcoded values.
+   * Each entry in the array could be used to build the final generated value outputed by the arbitrary of array on generate.
+   * Each entry must have at least one element of type T into it.
+   * Each T must be a value acceptable for the arbitrary passed to the array.
+   */
+  experimentalCustomSlices?: T[][];
+}
+
+/**
  * For arrays of values coming from `arb`
  *
  * @param arb - Arbitrary used to generate the values inside the array
@@ -66,6 +81,7 @@ function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints = {}): Arbitr
   const maxLength = maxLengthOrUnset !== undefined ? maxLengthOrUnset : MaxLengthUpperBound;
   const specifiedMaxLength = maxLengthOrUnset !== undefined;
   const maxGeneratedLength = maxGeneratedLengthFromSizeForArbitrary(size, minLength, maxLength, specifiedMaxLength);
-  return new ArrayArbitrary<T>(arb, minLength, maxGeneratedLength, maxLength, depthIdentifier);
+  const customSlices = (constraints as ArrayConstraintsInternal<T>).experimentalCustomSlices || [];
+  return new ArrayArbitrary<T>(arb, minLength, maxGeneratedLength, maxLength, depthIdentifier, undefined, customSlices);
 }
 export { array };

--- a/packages/fast-check/src/arbitrary/uniqueArray.ts
+++ b/packages/fast-check/src/arbitrary/uniqueArray.ts
@@ -223,7 +223,15 @@ export function uniqueArray<T, U>(arb: Arbitrary<T>, constraints: UniqueArrayCon
   const depthIdentifier = constraints.depthIdentifier;
   const setBuilder = buildUniqueArraySetBuilder(constraints);
 
-  const arrayArb = new ArrayArbitrary<T>(arb, minLength, maxGeneratedLength, maxLength, depthIdentifier, setBuilder);
+  const arrayArb = new ArrayArbitrary<T>(
+    arb,
+    minLength,
+    maxGeneratedLength,
+    maxLength,
+    depthIdentifier,
+    setBuilder,
+    []
+  );
   if (minLength === 0) return arrayArb;
   return arrayArb.filter((tab) => tab.length >= minLength);
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
@@ -44,7 +44,15 @@ describe('ArrayArbitrary', () => {
             const { instance: mrng } = fakeRandom();
 
             // Act
-            const arb = new ArrayArbitrary(instance, minLength, maxGeneratedLength, maxLength, undefined);
+            const arb = new ArrayArbitrary(
+              instance,
+              minLength,
+              maxGeneratedLength,
+              maxLength,
+              undefined,
+              undefined,
+              []
+            );
             const g = arb.generate(mrng, undefined);
 
             // Assert
@@ -82,7 +90,15 @@ describe('ArrayArbitrary', () => {
             const { instance: mrng } = fakeRandom();
 
             // Act
-            const arb = new ArrayArbitrary(instance, minLength, maxGeneratedLength, maxLength, undefined, setBuilder);
+            const arb = new ArrayArbitrary(
+              instance,
+              minLength,
+              maxGeneratedLength,
+              maxLength,
+              undefined,
+              setBuilder,
+              []
+            );
             const g = arb.generate(mrng, undefined);
 
             // Assert
@@ -132,7 +148,8 @@ describe('ArrayArbitrary', () => {
               minLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             const g = arb.generate(mrng, biasFactor);
 
@@ -198,7 +215,8 @@ describe('ArrayArbitrary', () => {
               maxGeneratedLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             arb.generate(mrng, biasFactor);
 
@@ -230,7 +248,7 @@ describe('ArrayArbitrary', () => {
       const { instance: mrng } = fakeRandom();
 
       // Act
-      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined);
+      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined, undefined, []);
       const g = arb.generate(mrng, undefined);
 
       // Assert
@@ -258,7 +276,7 @@ describe('ArrayArbitrary', () => {
       const { instance: mrng } = fakeRandom();
 
       // Act
-      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined);
+      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined, undefined, []);
       const g = arb.generate(mrng, undefined);
 
       // Assert
@@ -307,7 +325,8 @@ describe('ArrayArbitrary', () => {
               maxGeneratedLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             const out = arb.canShrinkWithoutContext(value);
 
@@ -358,7 +377,8 @@ describe('ArrayArbitrary', () => {
               maxGeneratedLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             const out = arb.canShrinkWithoutContext(value.map((v) => v[0]));
 
@@ -404,7 +424,15 @@ describe('ArrayArbitrary', () => {
             setBuilder.mockReturnValue(customSet);
 
             // Act
-            const arb = new ArrayArbitrary(instance, minLength, maxGeneratedLength, maxLength, undefined, setBuilder);
+            const arb = new ArrayArbitrary(
+              instance,
+              minLength,
+              maxGeneratedLength,
+              maxLength,
+              undefined,
+              setBuilder,
+              []
+            );
             const out = arb.canShrinkWithoutContext(value.map((v) => v[0]));
 
             // Assert
@@ -450,7 +478,8 @@ describe('ArrayArbitrary', () => {
               maxGeneratedLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             const out = arb.canShrinkWithoutContext(value);
 
@@ -494,7 +523,8 @@ describe('ArrayArbitrary', () => {
               maxGeneratedLength,
               maxLength,
               undefined,
-              withSetBuilder ? setBuilder : undefined
+              withSetBuilder ? setBuilder : undefined,
+              []
             );
             const out = arb.canShrinkWithoutContext(value);
 
@@ -512,7 +542,7 @@ describe('ArrayArbitrary (integration)', () => {
     // Arrange
     const alreadySeenCloneable = new Set<unknown>();
     const mrng = new Random(prand.mersenne(0));
-    const arb = new ArrayArbitrary(new CloneableArbitrary(), 0, 5, 100, undefined); // 0 to 5 generated items
+    const arb = new ArrayArbitrary(new CloneableArbitrary(), 0, 5, 100, undefined, undefined, []); // 0 to 5 generated items
 
     // Act
     let g = arb.generate(mrng, undefined);

--- a/packages/fast-check/test/unit/arbitrary/array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/array.spec.ts
@@ -38,7 +38,15 @@ describe('array', () => {
         const arb = withConfiguredGlobal(config, () => array(childInstance));
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, expect.any(Number), 0x7fffffff, undefined);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(
+          childInstance,
+          0,
+          expect.any(Number),
+          0x7fffffff,
+          undefined,
+          undefined,
+          []
+        );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThan(0);
         expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(2 ** 31 - 1);
@@ -61,13 +69,21 @@ describe('array', () => {
         const arb = withConfiguredGlobal(config, () => array(childInstance, { maxLength }));
 
         // Assert
-        expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, expect.any(Number), maxLength, undefined);
+        expect(ArrayArbitrary).toHaveBeenCalledWith(
+          childInstance,
+          0,
+          expect.any(Number),
+          maxLength,
+          undefined,
+          undefined,
+          []
+        );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(0);
         expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(maxLength);
         expect(Number.isInteger(receivedGeneratedMaxLength)).toBe(true);
         if (config.defaultSizeToMaxWhenMaxSpecified) {
-          expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength, undefined);
+          expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength, undefined, undefined, []);
         }
         expect(arb).toBe(instance);
       })
@@ -137,7 +153,15 @@ describe('array', () => {
           expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(maxLength);
           expect(Number.isInteger(receivedGeneratedMaxLength)).toBe(true);
           if (config.defaultSizeToMaxWhenMaxSpecified) {
-            expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, minLength, maxLength, maxLength, undefined);
+            expect(ArrayArbitrary).toHaveBeenCalledWith(
+              childInstance,
+              minLength,
+              maxLength,
+              maxLength,
+              undefined,
+              undefined,
+              []
+            );
           }
           expect(arb).toBe(instance);
         }
@@ -183,7 +207,9 @@ describe('array', () => {
               minLength,
               maxLength,
               maxLength,
-              depthIdentifier
+              depthIdentifier,
+              undefined,
+              []
             );
           }
           expect(arb).toBe(instance);

--- a/packages/fast-check/test/unit/arbitrary/array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/array.spec.ts
@@ -108,7 +108,9 @@ describe('array', () => {
           minLength,
           expect.any(Number),
           0x7fffffff,
-          undefined
+          undefined,
+          undefined,
+          []
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         if (minLength !== 2 ** 31 - 1) {
@@ -146,7 +148,9 @@ describe('array', () => {
             minLength,
             expect.any(Number),
             maxLength,
-            undefined
+            undefined,
+            undefined,
+            []
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);
@@ -195,7 +199,9 @@ describe('array', () => {
             minLength,
             expect.any(Number),
             maxLength,
-            depthIdentifier
+            depthIdentifier,
+            undefined,
+            []
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);

--- a/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
@@ -87,7 +87,8 @@ describe('uniqueArray', () => {
             maxLength,
             maxLength,
             undefined,
-            expect.any(Function)
+            expect.any(Function),
+            []
           );
         }
         expect(arb).toBe(instance);
@@ -170,7 +171,8 @@ describe('uniqueArray', () => {
               maxLength,
               maxLength,
               undefined,
-              expect.any(Function)
+              expect.any(Function),
+              []
             );
           }
           expect(arb).toBe(instance);

--- a/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
@@ -42,7 +42,8 @@ describe('uniqueArray', () => {
           expect.any(Number),
           0x7fffffff,
           undefined,
-          expect.any(Function)
+          expect.any(Function),
+          []
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThan(0);
@@ -72,7 +73,8 @@ describe('uniqueArray', () => {
           expect.any(Number),
           maxLength,
           undefined,
-          expect.any(Function)
+          expect.any(Function),
+          []
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(0);
@@ -113,7 +115,8 @@ describe('uniqueArray', () => {
           expect.any(Number),
           0x7fffffff,
           undefined,
-          expect.any(Function)
+          expect.any(Function),
+          []
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         if (minLength !== 2 ** 31 - 1) {
@@ -153,7 +156,8 @@ describe('uniqueArray', () => {
             expect.any(Number),
             maxLength,
             undefined,
-            expect.any(Function)
+            expect.any(Function),
+            []
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);
@@ -219,7 +223,8 @@ describe('uniqueArray', () => {
             expect.any(Number),
             constraints.maxLength !== undefined ? constraints.maxLength : expect.any(Number),
             constraints.depthIdentifier,
-            expect.any(Function)
+            expect.any(Function),
+            []
           );
           expect(arb).toBe(instance);
         }


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

This new constraint not officially exposed to fast-check's users (in other words, name might change in patch, minor... without any precise warning), should unlock the feature "Helper to deal with dangerous strings" https://github.com/dubzzz/fast-check/issues/484 by making it feasible.

So far, it only provides an extra constraint on the API of `array` but it will soon be leveraged for arbitraries on strings.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
