### PR TITLE
🐛 Fix out-of-range in `SlicedBasedGenerator`

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/implementations/SlicedBasedGenerator.ts
+++ b/packages/fast-check/src/arbitrary/_internals/implementations/SlicedBasedGenerator.ts
@@ -43,18 +43,17 @@ export class SlicedBasedGenerator<T> implements SlicedGenerator<T> {
     }
     // We update the active slice
     this.activeSliceIndex = this.mrng.nextInt(0, this.slices.length - 1);
+    const slice = this.slices[this.activeSliceIndex];
     if (this.mrng.nextInt(1, this.biasFactor) !== 1) {
       // We will consider the whole slice and not a sub-set of it
       this.nextIndexInSlice = 1;
-      this.lastIndexInSlice = this.slices.length - 1;
-      return new Value(this.slices[this.activeSliceIndex][0], undefined);
+      this.lastIndexInSlice = slice.length - 1;
+      return new Value(slice[0], undefined);
     }
-    const slice = this.slices[this.activeSliceIndex];
     const rangeBoundaryA = this.mrng.nextInt(0, slice.length - 1);
     const rangeBoundaryB = this.mrng.nextInt(0, slice.length - 1);
     this.nextIndexInSlice = Math.min(rangeBoundaryA, rangeBoundaryB);
     this.lastIndexInSlice = Math.max(rangeBoundaryA, rangeBoundaryB);
-    this.lastIndexInSlice = this.slices.length - 1;
-    return new Value(this.slices[this.activeSliceIndex][this.nextIndexInSlice++], undefined);
+    return new Value(slice[this.nextIndexInSlice++], undefined);
   }
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/implementations/SlicedBasedGenerator.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/implementations/SlicedBasedGenerator.spec.ts
@@ -89,6 +89,7 @@ describe('SlicedBasedGenerator', () => {
             // Arrange
             const { instance: arb, generate } = fakeArbitrary();
             const { instance: mrng, nextInt } = fakeRandom();
+            const allValuesFromSlices = slices.flat();
 
             // Act
             const generator = new SlicedBasedGenerator(arb, mrng, slices, biasFactor);
@@ -106,7 +107,9 @@ describe('SlicedBasedGenerator', () => {
                 }
                 return (streamModValues.next().value % (max - min + 1)) + min; // pure random for next calls
               });
-              readFromGenerator.push(generator.next().value);
+              const value = generator.next().value;
+              expect(allValuesFromSlices).toContain(value); // should only produce values coming from slices
+              readFromGenerator.push(value);
             }
 
             // Assert


### PR DESCRIPTION
The newly added `SlicedBasedGenerator` was reaching out-of-range values when trying to generate from slices.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
