### PR TITLE
🐛 Allow strange keys as keys of dictionary

### DIFF
--- a/.yarn/versions/27dffeb9.yml
+++ b/.yarn/versions/27dffeb9.yml
@@ -1,0 +1,25 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/packaged"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/arbitrary/_internals/mappers/KeyValuePairsToObject.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/KeyValuePairsToObject.ts
@@ -1,9 +1,13 @@
 /** @internal */
 export function keyValuePairsToObjectMapper<T>(items: [string, T][]): { [key: string]: T } {
-  // Equivalent to Object.fromEntries
   const obj: { [key: string]: T } = {};
   for (const keyValue of items) {
-    obj[keyValue[0]] = keyValue[1];
+    Object.defineProperty(obj, keyValue[0], {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      value: keyValue[1],
+    });
   }
   return obj;
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
@@ -2,18 +2,85 @@ import {
   keyValuePairsToObjectMapper,
   keyValuePairsToObjectUnmapper,
 } from '../../../../../src/arbitrary/_internals/mappers/KeyValuePairsToObject';
+import fc from '../../../../../src/fast-check';
 
 describe('keyValuePairsToObjectMapper', () => {
   it('should create instances with Object prototype', () => {
-    // Arrange
-    const keyValues: [string, unknown][] = [];
+    fc.assert(
+      fc.property(fc.uniqueArray(fc.tuple(fc.string(), fc.anything()), { selector: (kv) => kv[0] }), (keyValues) => {
+        // Arrange / Act
+        const obj = keyValuePairsToObjectMapper(keyValues);
 
-    // Act
-    const obj = keyValuePairsToObjectMapper(keyValues);
+        // Assert
+        expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+        if (!keyValues.some(([k]) => k === 'constructor')) {
+          expect(obj.constructor).toBe(Object);
+        }
+        if (!keyValues.some(([k]) => k === '__proto__')) {
+          expect(obj.__proto__).toBe(Object.prototype);
+        }
+      })
+    );
+  });
+
+  it('should create instances with all requested keys', () => {
+    fc.assert(
+      fc.property(fc.uniqueArray(fc.tuple(fc.string(), fc.anything()), { selector: (kv) => kv[0] }), (keyValues) => {
+        // Arrange / Act
+        const obj = keyValuePairsToObjectMapper(keyValues);
+
+        // Assert
+        expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+        for (const [key, value] of keyValues) {
+          expect(key in obj).toBe(true);
+          expect(obj[key]).toBe(value);
+        }
+      })
+    );
+  });
+
+  it('should create the same instances as-if we used bracket-based assignment', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(
+          fc.tuple(
+            fc.string().filter((k) => k !== '__proto__'),
+            fc.anything()
+          ),
+          { selector: (kv) => kv[0] }
+        ),
+        (keyValues) => {
+          // Arrange / Act
+          const obj = keyValuePairsToObjectMapper(keyValues);
+          const refObj = Object.fromEntries(keyValues); // will miss __proto__ if passed as keys
+
+          // Assert
+          expect(obj).toEqual(refObj);
+          expect(Object.keys(obj).sort()).toEqual(Object.keys(refObj).sort());
+          expect(Object.getOwnPropertyNames(obj).sort()).toEqual(Object.getOwnPropertyNames(refObj).sort());
+          expect(Object.getOwnPropertyDescriptors(obj)).toEqual(Object.getOwnPropertyDescriptors(refObj));
+        }
+      )
+    );
+  });
+
+  it('should be able to build instances with dangerous keys', () => {
+    // Arrange / Act
+    const obj = keyValuePairsToObjectMapper([
+      ['__proto__', '1'],
+      ['constructor', '2'],
+      ['toString', '3'],
+    ]);
 
     // Assert
-    expect(obj.constructor).toBe(Object);
-    expect(obj.__proto__).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+    // Valid values
+    expect(obj.__proto__).toBe('1');
+    expect(obj.constructor).toBe('2');
+    expect(obj.toString).toBe('3');
+    // Enumerable properties
+    expect(Object.keys(obj).sort()).toEqual(['__proto__', 'constructor', 'toString'].sort());
+    expect(Object.values(obj).sort()).toEqual(['1', '2', '3'].sort());
   });
 });
 


### PR DESCRIPTION
Up-to-now the instances of `dictionary` were unable to generate key "__proto__" even if they were asked to. This is now not anymore the case and they can easily create them too.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
