### PR TITLE
🐛 Better rounding in `statistics`

### DIFF
--- a/packages/fast-check/src/check/runner/Sampler.ts
+++ b/packages/fast-check/src/check/runner/Sampler.ts
@@ -69,6 +69,11 @@ function sample<Ts>(generator: IRawProperty<Ts> | Arbitrary<Ts>, params?: Parame
   return [...streamSample(generator, params)];
 }
 
+/** @internal */
+function round2(n: number): number {
+  return (Math.round(n * 100) / 100).toFixed(2);
+}
+
 /**
  * Gather useful statistics concerning generated values
  *
@@ -113,7 +118,7 @@ function statistics<Ts>(
   }
   const data = Object.entries(recorded)
     .sort((a, b) => b[1] - a[1])
-    .map((i) => [i[0], `${((i[1] * 100.0) / qParams.numRuns).toFixed(2)}%`]);
+    .map((i) => [i[0], `${round2((i[1] * 100.0) / qParams.numRuns)}%`]);
   const longestName = data.map((i) => i[0].length).reduce((p, c) => Math.max(p, c), 0);
   const longestPercent = data.map((i) => i[1].length).reduce((p, c) => Math.max(p, c), 0);
   for (const item of data) {

--- a/packages/fast-check/src/check/runner/Sampler.ts
+++ b/packages/fast-check/src/check/runner/Sampler.ts
@@ -70,7 +70,7 @@ function sample<Ts>(generator: IRawProperty<Ts> | Arbitrary<Ts>, params?: Parame
 }
 
 /** @internal */
-function round2(n: number): number {
+function round2(n: number): string {
   return (Math.round(n * 100) / 100).toFixed(2);
 }
 


### PR DESCRIPTION
Existing rounding strategy was implementation dependant as toFixed does not really comes with an explicit rounding rule.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
