### PR TITLE
🐛 Support `__proto__` as key in `record`

### DIFF
--- a/.yarn/versions/4c7660a4.yml
+++ b/.yarn/versions/4c7660a4.yml
@@ -1,0 +1,24 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject.ts
@@ -9,7 +9,12 @@ export function buildValuesAndSeparateKeysToObjectMapper<T, TNoKey>(keys: Enumer
     for (let idx = 0; idx !== keys.length; ++idx) {
       const valueWrapper = gs[idx];
       if (valueWrapper !== noKeyValue) {
-        obj[keys[idx]] = valueWrapper as T[keyof T]; // not TNoKey
+        Object.defineProperty(obj, keys[idx], {
+          value: valueWrapper,
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        });
       }
     }
     return obj as Partial<T> & Pick<T, EnumerableKeyOf<T>>;


### PR DESCRIPTION
The current implementation of `record` was not properly supporting `__proto__` as a possible key. It is now the case, `__proto__` will be handled like any other key whenever specified by the users.

Fixes #3065

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
