### PR TITLE
🐛 Protect `assert` from poisoned `Math` or `Date`

### DIFF
--- a/.yarn/versions/29271184.yml
+++ b/.yarn/versions/29271184.yml
@@ -1,0 +1,24 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/arbitrary/_internals/IntegerArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/IntegerArbitrary.ts
@@ -5,6 +5,8 @@ import { Stream } from '../../stream/Stream';
 import { integerLogLike, biasNumericRange } from './helpers/BiasNumericRange';
 import { shrinkInteger } from './helpers/ShrinkInteger';
 
+const safeMathSign = Math.sign;
+
 /** @internal */
 export class IntegerArbitrary extends Arbitrary<number> {
   constructor(readonly min: number, readonly max: number) {
@@ -87,7 +89,7 @@ export class IntegerArbitrary extends Arbitrary<number> {
     if (typeof context !== 'number') {
       throw new Error(`Invalid context type passed to IntegerArbitrary (#1)`);
     }
-    if (context !== 0 && Math.sign(current) !== Math.sign(context)) {
+    if (context !== 0 && safeMathSign(current) !== safeMathSign(context)) {
       throw new Error(`Invalid context value passed to IntegerArbitrary (#2)`);
     }
     return true;

--- a/packages/fast-check/src/arbitrary/_internals/helpers/BiasNumericRange.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/BiasNumericRange.ts
@@ -1,6 +1,9 @@
+const safeMathFloor = Math.floor;
+const safeMathLog = Math.log;
+
 /** @internal */
 export function integerLogLike(v: number): number {
-  return Math.floor(Math.log(v) / Math.log(2));
+  return safeMathFloor(safeMathLog(v) / safeMathLog(2));
 }
 
 /** @internal */

--- a/packages/fast-check/src/arbitrary/_internals/helpers/ShrinkInteger.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/ShrinkInteger.ts
@@ -1,13 +1,16 @@
 import { Value } from '../../../check/arbitrary/definition/Value';
 import { Stream, stream } from '../../../stream/Stream';
 
+const safeMathCeil = Math.ceil;
+const safeMathFloor = Math.floor;
+
 /** @internal */
 function halvePosInteger(n: number): number {
-  return Math.floor(n / 2);
+  return safeMathFloor(n / 2);
 }
 /** @internal */
 function halveNegInteger(n: number): number {
-  return Math.ceil(n / 2);
+  return safeMathCeil(n / 2);
 }
 
 /**

--- a/packages/fast-check/src/check/property/IRawProperty.ts
+++ b/packages/fast-check/src/check/property/IRawProperty.ts
@@ -3,6 +3,9 @@ import { Stream } from '../../stream/Stream';
 import { Value } from '../arbitrary/definition/Value';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
 
+const safeMathFloor = Math.floor;
+const safeMathLog = Math.log;
+
 /**
  * Represent failures of the property
  * @remarks Since 3.0.0
@@ -80,4 +83,4 @@ export interface IRawProperty<Ts, IsAsync extends boolean = boolean> {
  *
  * @internal
  */
-export const runIdToFrequency = (runId: number): number => 2 + Math.floor(Math.log(runId + 1) / Math.log(10));
+export const runIdToFrequency = (runId: number): number => 2 + safeMathFloor(safeMathLog(runId + 1) / safeMathLog(10));

--- a/packages/fast-check/src/check/runner/DecorateProperty.ts
+++ b/packages/fast-check/src/check/runner/DecorateProperty.ts
@@ -5,6 +5,8 @@ import { UnbiasedProperty } from '../property/UnbiasedProperty';
 import { QualifiedParameters } from './configuration/QualifiedParameters';
 import { IgnoreEqualValuesProperty } from '../property/IgnoreEqualValuesProperty';
 
+const safeDateNow = Date.now;
+
 /** @internal */
 type MinimalQualifiedParameters<Ts> = Pick<
   QualifiedParameters<Ts>,
@@ -24,10 +26,10 @@ export function decorateProperty<Ts>(
     prop = new UnbiasedProperty(prop);
   }
   if (qParams.skipAllAfterTimeLimit != null) {
-    prop = new SkipAfterProperty(prop, Date.now, qParams.skipAllAfterTimeLimit, false);
+    prop = new SkipAfterProperty(prop, safeDateNow, qParams.skipAllAfterTimeLimit, false);
   }
   if (qParams.interruptAfterTimeLimit != null) {
-    prop = new SkipAfterProperty(prop, Date.now, qParams.interruptAfterTimeLimit, true);
+    prop = new SkipAfterProperty(prop, safeDateNow, qParams.interruptAfterTimeLimit, true);
   }
   if (qParams.skipEqualValues) {
     prop = new IgnoreEqualValuesProperty(prop, true);

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -4,6 +4,9 @@ import { VerbosityLevel } from './VerbosityLevel';
 import { RunDetails } from '../reporter/RunDetails';
 import { RandomGenerator } from 'pure-rand';
 
+const safeDateNow = Date.now;
+const safeMathRandom = Math.random;
+
 /**
  * Configuration extracted from incoming Parameters
  *
@@ -82,7 +85,7 @@ export class QualifiedParameters<T> {
 
   private static readSeed = <T>(p: Parameters<T>): number => {
     // No seed specified
-    if (p.seed == null) return Date.now() ^ (Math.random() * 0x100000000);
+    if (p.seed == null) return safeDateNow() ^ (safeMathRandom() * 0x100000000);
 
     // Seed is a 32 bits signed integer
     const seed32 = p.seed | 0;

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -38,7 +38,7 @@ describe(`Poisoning (seed: ${seed})`, () => {
     restoreGlobals(); // Restore globals before running real checks
     expect(interceptedException).toBeDefined();
     expect(interceptedException).toBeInstanceOf(Error);
-    expect((interceptedException as Error).message).toMatch(/Property failed after/);
+    expect(interceptedException).toMatch(/Property failed after/);
   });
 });
 

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -38,7 +38,7 @@ describe(`Poisoning (seed: ${seed})`, () => {
     restoreGlobals(); // Restore globals before running real checks
     expect(interceptedException).toBeDefined();
     expect(interceptedException).toBeInstanceOf(Error);
-    expect(interceptedException).toMatch(/Property failed after/);
+    expect((interceptedException as Error).message).toMatch(/Property failed after/);
   });
 });
 

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -10,7 +10,7 @@ describe(`Poisoning (seed: ${seed})`, () => {
     // Arrange
     let runId = 0;
     let failedOnce = false;
-    const resultStream = fc.sample(fc.infiniteStream(fc.boolean()), { numRuns: 1 })[0];
+    const resultStream = fc.sample(fc.infiniteStream(fc.boolean()), { seed, numRuns: 1 })[0];
     const testResult = (): boolean => {
       if (++runId === 100 && !failedOnce) {
         // Force a failure for the 100th execution if we never encountered any before
@@ -26,7 +26,10 @@ describe(`Poisoning (seed: ${seed})`, () => {
     // Act
     let interceptedException: unknown = undefined;
     try {
-      fc.assert(fc.property(arbitraryBuilder(), (_v) => testResult()));
+      fc.assert(
+        fc.property(arbitraryBuilder(), (_v) => testResult()),
+        { seed }
+      );
     } catch (err) {
       interceptedException = err;
     }

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -62,7 +62,7 @@ function dropMainGlobals(): void {
     Boolean,
     //String,
     Symbol,
-    //Date,
+    Date,
     Promise,
     RegExp,
     Error,
@@ -102,7 +102,7 @@ function dropMainGlobals(): void {
     //URL,
     URLSearchParams,
     JSON,
-    //Math,
+    Math,
     Intl,
   ];
   for (const mainGlobal of mainGlobals) {


### PR DESCRIPTION
Up-to-now calling `fc.assert` from a broken environment was exploding at execution time because of missing `Math.*` or `Date.*`. Those built-ins were required by fast-check to make some internal computations, but could have been broken by a nasty test fully breaking the environment. As fast-check has to be as good as possible to run without them when they appear broken, we try to make it more reliable in such contexts.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
