### PR TITLE
🐛 Resist to poisoning of `Object`

### DIFF
--- a/.yarn/versions/87062abc.yml
+++ b/.yarn/versions/87062abc.yml
@@ -1,0 +1,24 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -17,6 +17,8 @@ import { IAsyncProperty } from '../property/AsyncProperty';
 import { IProperty } from '../property/Property';
 import { Value } from '../arbitrary/definition/Value';
 
+const safeObjectAssign = Object.assign;
+
 /** @internal */
 function runIt<Ts>(
   property: IRawProperty<Ts>,
@@ -120,10 +122,10 @@ function check<Ts>(rawProperty: IRawProperty<Ts>, params?: Parameters<Ts>): unkn
     throw new Error('Invalid property encountered, please use a valid property');
   if (rawProperty.run == null)
     throw new Error('Invalid property encountered, please use a valid property not an arbitrary');
-  const qParams: QualifiedParameters<Ts> = QualifiedParameters.read<Ts>({
-    ...(readConfigureGlobal() as Parameters<Ts>),
-    ...params,
-  });
+  const qParams: QualifiedParameters<Ts> = QualifiedParameters.read<Ts>(
+    // TODO - Move back to object spreading as soon as we bump support from es2017 to es2018+
+    safeObjectAssign(safeObjectAssign({}, readConfigureGlobal() as Parameters<Ts>), params)
+  );
   if (qParams.reporter !== null && qParams.asyncReporter !== null)
     throw new Error('Invalid parameters encountered, reporter and asyncReporter cannot be specified together');
   if (qParams.asyncReporter !== null && !rawProperty.isAsync())
@@ -131,7 +133,7 @@ function check<Ts>(rawProperty: IRawProperty<Ts>, params?: Parameters<Ts>): unkn
   const property = decorateProperty(rawProperty, qParams);
   const generator = toss(property, qParams.seed, qParams.randomType, qParams.examples);
 
-  const maxInitialIterations = qParams.path.indexOf(':') === -1 ? qParams.numRuns : -1;
+  const maxInitialIterations = qParams.path.length === 0 || qParams.path.indexOf(':') === -1 ? qParams.numRuns : -1;
   const maxSkips = qParams.numRuns * qParams.maxSkipsPerRun;
   const shrink = property.shrink.bind(property);
   const initialValues = buildInitialValues(generator, shrink, qParams);

--- a/packages/fast-check/src/utils/apply.ts
+++ b/packages/fast-check/src/utils/apply.ts
@@ -1,0 +1,36 @@
+const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const untouchedApply = Function.prototype.apply;
+
+const ApplySymbol = Symbol('apply');
+
+/**
+ * Equivalent to `f.apply(instance, args)` but temporary altering the instance
+ * @internal
+ */
+function safeApplyHacky<T, TArgs extends unknown[], TReturn>(
+  f: (this: T, ...args: TArgs) => TReturn,
+  instance: T,
+  args: TArgs
+): TReturn {
+  const ff: typeof f & { [ApplySymbol]?: typeof untouchedApply } = f;
+  ff[ApplySymbol] = untouchedApply;
+  const out = ff[ApplySymbol](instance, args);
+  delete ff[ApplySymbol];
+  return out;
+}
+
+/**
+ * Equivalent to `f.apply(instance, args)`
+ * @internal
+ */
+export function safeApply<T, TArgs extends unknown[], TReturn>(
+  f: (this: T, ...args: TArgs) => TReturn,
+  instance: T,
+  args: TArgs
+): TReturn {
+  const descApply = safeObjectGetOwnPropertyDescriptor(f, 'apply');
+  if (descApply !== undefined && descApply.value === untouchedApply) {
+    return f.apply(instance, args);
+  }
+  return safeApplyHacky(f, instance, args);
+}

--- a/packages/fast-check/src/utils/globals.ts
+++ b/packages/fast-check/src/utils/globals.ts
@@ -1,0 +1,11 @@
+import { safeApply } from './apply';
+
+const untouchedToString = Object.prototype.toString;
+
+/**
+ * Safe Object.prototype.toString
+ * @internal
+ */
+export function safeToString(instance: unknown): string {
+  return safeApply(untouchedToString, instance, []);
+}

--- a/packages/fast-check/src/utils/stringify.ts
+++ b/packages/fast-check/src/utils/stringify.ts
@@ -1,3 +1,5 @@
+import { safeToString } from './globals';
+
 /**
  * Use this symbol to define a custom serializer for your instances.
  * Serializer must be a function returning a string (see {@link WithToStringMethod}).
@@ -138,7 +140,7 @@ export function stringifyInternal<Ts>(
     }
   }
 
-  switch (Object.prototype.toString.call(value)) {
+  switch (safeToString(value)) {
     case '[object Array]': {
       const arr = value as unknown as unknown[];
       if (arr.length >= 50 && isSparseArray(arr)) {

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -58,7 +58,7 @@ function dropAllFromObj(obj: unknown): void {
 }
 function dropMainGlobals(): void {
   const mainGlobals = [
-    //Object,
+    Object,
     //Function,
     //Array,
     Number,

--- a/packages/fast-check/test/unit/utils/apply.spec.ts
+++ b/packages/fast-check/test/unit/utils/apply.spec.ts
@@ -1,0 +1,87 @@
+import { safeApply } from '../../../src/utils/apply';
+
+describe('safeApply', () => {
+  it('should apply if no poisoning', () => {
+    // Arrange
+    class Nominal {
+      constructor(private initialValue: number) {}
+      doStuff(v1: number, v2: number): number {
+        return this.initialValue + v1 + v2;
+      }
+    }
+    const n = new Nominal(5);
+
+    // Act
+    const out = safeApply(Nominal.prototype.doStuff, n, [3, 10]);
+
+    // Assert
+    expect(out).toBe(5 + 3 + 10);
+  });
+
+  it('should apply if poisoning of f.apply', () => {
+    // Arrange
+    class Nominal {
+      constructor(private initialValue: number) {}
+      doStuff(v1: number, v2: number): number {
+        return this.initialValue + v1 + v2;
+      }
+    }
+    const n = new Nominal(5);
+    const poisoned = jest.fn();
+    Nominal.prototype.doStuff.apply = poisoned;
+
+    // Act
+    const out = safeApply(Nominal.prototype.doStuff, n, [3, 10]);
+
+    // Assert
+    expect(poisoned).not.toHaveBeenCalled();
+    expect(out).toBe(5 + 3 + 10);
+  });
+
+  it('should apply if poisoning of Function.prototype.apply', () => {
+    // Arrange
+    class Nominal {
+      constructor(private initialValue: number) {}
+      doStuff(v1: number, v2: number): number {
+        return this.initialValue + v1 + v2;
+      }
+    }
+    const n = new Nominal(5);
+    const poisoned = jest.fn();
+    const sourceFunctionApply = Function.prototype.apply;
+    Function.prototype.apply = poisoned;
+
+    try {
+      // Act
+      const out = safeApply(Nominal.prototype.doStuff, n, [3, 10]);
+
+      // Assert
+      expect(poisoned).not.toHaveBeenCalled();
+      expect(out).toBe(5 + 3 + 10);
+    } finally {
+      Function.prototype.apply = sourceFunctionApply;
+    }
+  });
+
+  it('should apply if throwing poisoning of f.apply', () => {
+    // Arrange
+    class Nominal {
+      constructor(private initialValue: number) {}
+      doStuff(v1: number, v2: number): number {
+        return this.initialValue + v1 + v2;
+      }
+    }
+    const n = new Nominal(5);
+    Object.defineProperty(Nominal.prototype.doStuff, 'apply', {
+      get: () => {
+        throw new Error('evil code');
+      },
+    });
+
+    // Act
+    const out = safeApply(Nominal.prototype.doStuff, n, [3, 10]);
+
+    // Assert
+    expect(out).toBe(5 + 3 + 10);
+  });
+});


### PR DESCRIPTION
This PR makes sure the basic code of `fc.assert` can resist to poisoning occuring on `Object` and `Object.prototype`.

While not covering everything (not all arbitraries), it make sure the bare minimal stuff is working. Arbitraries will be tackled in later changes as soon as basic path fully works without issues for any kind of poisoning.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
