### PR TITLE
🐛 Resist to poisoning of `Function`/`Array`/`String`

### DIFF
--- a/.yarn/versions/d849592c.yml
+++ b/.yarn/versions/d849592c.yml
@@ -1,0 +1,24 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/monorepo"
+  - "@fast-check/examples"
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/test-ava-bundle-cjs"
+  - "@fast-check/test-ava-bundle-esm"
+  - "@fast-check/test-bundle-esbuild-with-import"
+  - "@fast-check/test-bundle-esbuild-with-require"
+  - "@fast-check/test-bundle-node-extension-cjs"
+  - "@fast-check/test-bundle-node-extension-mjs"
+  - "@fast-check/test-bundle-node-with-import"
+  - "@fast-check/test-bundle-node-with-require"
+  - "@fast-check/test-bundle-rollup-with-import"
+  - "@fast-check/test-bundle-rollup-with-require"
+  - "@fast-check/test-bundle-webpack-with-import"
+  - "@fast-check/test-bundle-webpack-with-require"
+  - "@fast-check/test-jest-bundle-cjs"
+  - "@fast-check/test-jest-bundle-esm"
+  - "@fast-check/test-minimal-support"
+  - "@fast-check/test-types"

--- a/packages/fast-check/src/arbitrary/_internals/StreamArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/StreamArbitrary.ts
@@ -3,6 +3,7 @@ import { Value } from '../../check/arbitrary/definition/Value';
 import { cloneMethod } from '../../check/symbols';
 import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
+import { safePush } from '../../utils/globals';
 import { asyncStringify, asyncToStringMethod, stringify, toStringMethod } from '../../utils/stringify';
 
 /** @internal */
@@ -23,7 +24,7 @@ export class StreamArbitrary<T> extends Arbitrary<Stream<T>> {
       const g = function* (arb: Arbitrary<T>, clonedMrng: Random) {
         while (true) {
           const value = arb.generate(clonedMrng, appliedBiasFactor).value;
-          seenValues.push(value);
+          safePush(seenValues, value);
           yield value;
         }
       };

--- a/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
@@ -25,9 +25,9 @@ export class TupleArbitrary<Ts extends unknown[]> extends Arbitrary<Ts> {
   private static makeItCloneable<TValue>(vs: TValue[], values: Value<TValue>[]): WithCloneMethod<TValue[]> {
     return Object.defineProperty(vs, cloneMethod, {
       value: () => {
-        const cloned = [];
+        const cloned: TValue[] = [];
         for (let idx = 0; idx !== values.length; ++idx) {
-          cloned.push(values[idx].value); // push potentially cloned values
+          safePush(cloned, values[idx].value); // push potentially cloned values
         }
         TupleArbitrary.makeItCloneable(cloned, values);
         return cloned;

--- a/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
@@ -53,7 +53,7 @@ export class TupleArbitrary<Ts extends unknown[]> extends Arbitrary<Ts> {
     return TupleArbitrary.wrapper<Ts>(safeMap(this.arbs, (a) => a.generate(mrng, biasFactor)) as ValuesArray<Ts>);
   }
   canShrinkWithoutContext(value: unknown): value is Ts {
-    if (!Array.isArray(value) || value.length !== this.arbs.length) {
+    if (!safeArrayIsArray(value) || value.length !== this.arbs.length) {
       return false;
     }
     for (let index = 0; index !== this.arbs.length; ++index) {

--- a/packages/fast-check/src/check/property/AsyncProperty.ts
+++ b/packages/fast-check/src/check/property/AsyncProperty.ts
@@ -7,6 +7,7 @@ import {
   AsyncPropertyHookFunction,
 } from './AsyncProperty.generic';
 import { AlwaysShrinkableArbitrary } from '../../arbitrary/_internals/AlwaysShrinkableArbitrary';
+import { safeForEach, safeMap, safeSlice } from '../../utils/globals';
 
 /**
  * Instantiate a new {@link fast-check#IAsyncProperty}
@@ -20,10 +21,10 @@ function asyncProperty<Ts extends [unknown, ...unknown[]]>(
   if (args.length < 2) {
     throw new Error('asyncProperty expects at least two parameters');
   }
-  const arbs = args.slice(0, args.length - 1) as { [K in keyof Ts]: Arbitrary<Ts[K]> };
+  const arbs = safeSlice(args, 0, args.length - 1) as { [K in keyof Ts]: Arbitrary<Ts[K]> };
   const p = args[args.length - 1] as (...args: Ts) => Promise<boolean | void>;
-  arbs.forEach(assertIsArbitrary);
-  const mappedArbs = arbs.map((arb): typeof arb => new AlwaysShrinkableArbitrary(arb)) as typeof arbs;
+  safeForEach(arbs, assertIsArbitrary);
+  const mappedArbs = safeMap(arbs, (arb): typeof arb => new AlwaysShrinkableArbitrary(arb)) as typeof arbs;
   return new AsyncProperty(tuple<Ts>(...mappedArbs), (t) => p(...t));
 }
 

--- a/packages/fast-check/src/check/property/Property.ts
+++ b/packages/fast-check/src/check/property/Property.ts
@@ -2,6 +2,7 @@ import { Arbitrary, assertIsArbitrary } from '../arbitrary/definition/Arbitrary'
 import { tuple } from '../../arbitrary/tuple';
 import { Property, IProperty, IPropertyWithHooks, PropertyHookFunction } from './Property.generic';
 import { AlwaysShrinkableArbitrary } from '../../arbitrary/_internals/AlwaysShrinkableArbitrary';
+import { safeForEach, safeMap, safeSlice } from '../../utils/globals';
 
 /**
  * Instantiate a new {@link fast-check#IProperty}
@@ -15,10 +16,10 @@ function property<Ts extends [unknown, ...unknown[]]>(
   if (args.length < 2) {
     throw new Error('property expects at least two parameters');
   }
-  const arbs = args.slice(0, args.length - 1) as { [K in keyof Ts]: Arbitrary<Ts[K]> };
+  const arbs = safeSlice(args, 0, args.length - 1) as { [K in keyof Ts]: Arbitrary<Ts[K]> };
   const p = args[args.length - 1] as (...args: Ts) => boolean | void;
-  arbs.forEach(assertIsArbitrary);
-  const mappedArbs = arbs.map((arb): typeof arb => new AlwaysShrinkableArbitrary(arb)) as typeof arbs;
+  safeForEach(arbs, assertIsArbitrary);
+  const mappedArbs = safeMap(arbs, (arb): typeof arb => new AlwaysShrinkableArbitrary(arb)) as typeof arbs;
   return new Property(tuple<Ts>(...mappedArbs), (t) => p(...t));
 }
 

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -135,7 +135,7 @@ function check<Ts>(rawProperty: IRawProperty<Ts>, params?: Parameters<Ts>): unkn
 
   const maxInitialIterations = qParams.path.length === 0 || qParams.path.indexOf(':') === -1 ? qParams.numRuns : -1;
   const maxSkips = qParams.numRuns * qParams.maxSkipsPerRun;
-  const shrink = property.shrink.bind(property);
+  const shrink: typeof property.shrink = (...args) => property.shrink(...args);
   const initialValues = buildInitialValues(generator, shrink, qParams);
   const sourceValues = new SourceValuesIterator(initialValues, maxInitialIterations, maxSkips);
   const finalShrink = !qParams.endOnFailure ? shrink : Stream.nil;

--- a/packages/fast-check/src/check/runner/Tosser.ts
+++ b/packages/fast-check/src/check/runner/Tosser.ts
@@ -3,6 +3,7 @@ import { RandomGenerator, skipN } from 'pure-rand';
 import { Random } from '../../random/generator/Random';
 import { IRawProperty } from '../property/IRawProperty';
 import { Value } from '../arbitrary/definition/Value';
+import { safeMap } from '../../utils/globals';
 
 /** @internal */
 function lazyGenerate<Ts>(generator: IRawProperty<Ts>, rng: RandomGenerator, idx: number): () => Value<Ts> {
@@ -16,7 +17,7 @@ export function* toss<Ts>(
   random: (seed: number) => RandomGenerator,
   examples: Ts[]
 ): IterableIterator<() => Value<Ts>> {
-  yield* examples.map((e) => () => new Value(e, undefined));
+  yield* safeMap(examples, (e) => () => new Value(e, undefined));
   let idx = 0;
   let rng = random(seed);
   for (;;) {

--- a/packages/fast-check/src/check/runner/reporter/RunExecution.ts
+++ b/packages/fast-check/src/check/runner/reporter/RunExecution.ts
@@ -4,6 +4,7 @@ import { ExecutionTree } from './ExecutionTree';
 import { RunDetails } from './RunDetails';
 import { QualifiedParameters } from '../configuration/QualifiedParameters';
 import { PropertyFailure } from '../../property/IRawProperty';
+import { safeSplit } from '../../../utils/globals';
 
 /**
  * Report the status of a run
@@ -68,8 +69,8 @@ export class RunExecution<Ts> {
   }
 
   private isSuccess = (): boolean => this.pathToFailure == null;
-  private firstFailure = (): number => (this.pathToFailure ? +this.pathToFailure.split(':')[0] : -1);
-  private numShrinks = (): number => (this.pathToFailure ? this.pathToFailure.split(':').length - 1 : 0);
+  private firstFailure = (): number => (this.pathToFailure ? +safeSplit(this.pathToFailure, ':')[0] : -1);
+  private numShrinks = (): number => (this.pathToFailure ? safeSplit(this.pathToFailure, ':').length - 1 : 0);
 
   private extractFailures() {
     if (this.isSuccess()) {

--- a/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
+++ b/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
@@ -1,3 +1,4 @@
+import { safePush } from '../../../utils/globals';
 import { stringify, possiblyAsyncStringify } from '../../../utils/stringify';
 import { VerbosityLevel } from '../configuration/VerbosityLevel';
 import { ExecutionStatus } from '../reporter/ExecutionStatus';
@@ -67,7 +68,8 @@ function preFormatTooManySkipped<Ts>(out: RunDetailsFailureTooManySkips<Ts>, str
   if (out.verbose >= VerbosityLevel.VeryVerbose) {
     details = formatExecutionSummary(out.executionSummary, stringifyOne);
   } else {
-    hints.push(
+    safePush(
+      hints,
       'Enable verbose mode at level VeryVerbose in order to check all generated values and their associated status'
     );
   }
@@ -83,14 +85,14 @@ function preFormatFailure<Ts>(out: RunDetailsFailureProperty<Ts>, stringifyOne: 
     out.numShrinks
   } time(s)\nGot error: ${out.error}`;
   let details: string | null = null;
-  const hints = [];
+  const hints: string[] = [];
 
   if (out.verbose >= VerbosityLevel.VeryVerbose) {
     details = formatExecutionSummary(out.executionSummary, stringifyOne);
   } else if (out.verbose === VerbosityLevel.Verbose) {
     details = formatFailures(out.failures, stringifyOne);
   } else {
-    hints.push('Enable verbose mode in order to have the list of all failing values encountered during the run');
+    safePush(hints, 'Enable verbose mode in order to have the list of all failing values encountered during the run');
   }
 
   return { message, details, hints };
@@ -100,12 +102,13 @@ function preFormatFailure<Ts>(out: RunDetailsFailureProperty<Ts>, stringifyOne: 
 function preFormatEarlyInterrupted<Ts>(out: RunDetailsFailureInterrupted<Ts>, stringifyOne: (value: Ts) => string) {
   const message = `Property interrupted after ${out.numRuns} tests\n{ seed: ${out.seed} }`;
   let details: string | null = null;
-  const hints = [];
+  const hints: string[] = [];
 
   if (out.verbose >= VerbosityLevel.VeryVerbose) {
     details = formatExecutionSummary(out.executionSummary, stringifyOne);
   } else {
-    hints.push(
+    safePush(
+      hints,
       'Enable verbose mode at level VeryVerbose in order to check all generated values and their associated status'
     );
   }

--- a/packages/fast-check/src/utils/globals.ts
+++ b/packages/fast-check/src/utils/globals.ts
@@ -1,11 +1,55 @@
 import { safeApply } from './apply';
 
+// Array
+const untouchedForEach = Array.prototype.forEach;
+const untouchedIndexOf = Array.prototype.indexOf;
+const untouchedJoin = Array.prototype.join;
+const untouchedMap = Array.prototype.map;
+const untouchedPush = Array.prototype.push;
+const untouchedSlice = Array.prototype.slice;
+
+/** @internal */
+export function safeForEach<T>(instance: T[], ...args: [fn: (value: T, index: number, array: T[]) => void]): void {
+  return safeApply(untouchedForEach, instance, args);
+}
+
+/** @internal */
+export function safeIndexOf<T>(instance: T[], ...args: [searchElement: any, fromIndex?: number | undefined]): number {
+  return safeApply(untouchedIndexOf, instance, args);
+}
+
+/** @internal */
+export function safeJoin<T>(instance: T[], ...args: [separator?: string | undefined]): string {
+  return safeApply(untouchedJoin, instance, args);
+}
+
+/** @internal */
+export function safeMap<T, U>(instance: T[], ...args: [fn: (value: T, index: number, array: T[]) => U]): U[] {
+  return safeApply(untouchedMap, instance, args);
+}
+
+/** @internal */
+export function safePush<T>(instance: T[], ...args: T[]): number {
+  return safeApply(untouchedPush, instance, args);
+}
+
+/** @internal */
+export function safeSlice<T>(instance: T[], ...args: [start?: number | undefined, end?: number | undefined]): T[] {
+  return safeApply(untouchedSlice, instance, args);
+}
+
+// Object
 const untouchedToString = Object.prototype.toString;
 
-/**
- * Safe Object.prototype.toString
- * @internal
- */
+/** @internal */
 export function safeToString(instance: unknown): string {
   return safeApply(untouchedToString, instance, []);
+}
+
+// String
+const untouchedSplit: (separator: string | RegExp, limit?: number | undefined) => string[] = String.prototype.split;
+
+/** @internal */
+export function safeSplit(instance: string, ...args: Parameters<typeof untouchedSplit>): string[] {
+  return safeApply(untouchedSplit, instance, args);
 }

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -59,11 +59,11 @@ function dropAllFromObj(obj: unknown): void {
 function dropMainGlobals(): void {
   const mainGlobals = [
     Object,
-    //Function,
-    //Array,
+    Function,
+    Array,
     Number,
     Boolean,
-    //String,
+    String,
     Symbol,
     Date,
     Promise,


### PR DESCRIPTION
Follow-up of #3086

This time we make sure that `fc.assert` will be as bulletproof as possible in case of poisoning.

Follwoing that change, we more or less made sure that a normal property running against the Noop arbitrary will be able to run and shrink up to the end whatever the poisoning occuring on the shared environment. Now many things needs to be done in order to extend that to all our built-in arbitraries.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
