### PR TITLE
👷 Do not suggest private packages during version bumps

### DIFF
--- a/.github/actions/deploy-netlify/package.json
+++ b/.github/actions/deploy-netlify/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/deploy-netlify",
   "description": "Test making sure fast-check expose the right typings",
-  "version": "0.0.0",
   "main": "index.cjs",
   "dependencies": {
     "@actions/core": "^1.7.0",

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,8 +9,6 @@ plugins:
     spec: '@yarnpkg/plugin-version'
 
 changesetIgnorePatterns:
-  - '.github/**'
-  - '.yarnrc.yml'
   - '**/*.spec.{js,ts}'
 
 yarnPath: .yarn/releases/yarn-3.2.3.cjs

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/examples",
   "description": "Examples of usage of fast-check",
-  "version": "0.0.0",
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/monorepo",
   "description": "Test making sure fast-check expose the right typings",
-  "version": "0.0.0",
   "packageManager": "yarn@3.2.3",
   "workspaces": [
     ".github/actions/*",
@@ -19,7 +18,7 @@
     "format:check": "prettier --list-different .",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "version:bump": "yarn version check --interactive && yarn workspace @fast-check/monorepo version decline",
+    "version:bump": "yarn version check --interactive",
     "pack:all": "yarn workspaces foreach -pvi --no-private pack --out package.tgz",
     "unpack:all": "yarn workspaces foreach -pvi --no-private exec tar -xvf package.tgz --strip-components=1 --exclude='package/package.json'"
   },

--- a/packages/test-ava-bundle-cjs/package.json
+++ b/packages/test-ava-bundle-cjs/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-ava-bundle-cjs",
   "descrition": "Test bundling of @fast-check/ava against CJS runners",
-  "version": "0.0.0",
   "type": "commonjs",
   "scripts": {
     "test": "ava"

--- a/packages/test-ava-bundle-esm/package.json
+++ b/packages/test-ava-bundle-esm/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-ava-bundle-esm",
   "descrition": "Test bundling of @fast-check/ava against ESM runners",
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "test": "ava"

--- a/packages/test-bundle-esbuild-with-import/package.json
+++ b/packages/test-bundle-esbuild-with-import/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-esbuild-with-import",
   "description": "Test making sure fast-check can be used with ESM in ESBuild",
-  "version": "0.0.0",
   "scripts": {
     "generate:browser": "esbuild main.js --bundle --platform=browser --outfile=dist/main.browser.js",
     "generate:node": "esbuild main.js --bundle --platform=node --outfile=dist/main.node.js",

--- a/packages/test-bundle-esbuild-with-require/package.json
+++ b/packages/test-bundle-esbuild-with-require/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-esbuild-with-require",
   "description": "Test making sure fast-check can be used with CommonJS in ESBuild",
-  "version": "0.0.0",
   "scripts": {
     "generate:browser": "esbuild main.js --bundle --platform=browser --outfile=dist/main.browser.js",
     "generate:node": "esbuild main.js --bundle --platform=node --outfile=dist/main.node.js",

--- a/packages/test-bundle-node-extension-cjs/package.json
+++ b/packages/test-bundle-node-extension-cjs/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-node-extension-cjs",
   "description": "Test making sure fast-check can be referenced from cjs files",
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dry": "node dry.cjs",

--- a/packages/test-bundle-node-extension-mjs/package.json
+++ b/packages/test-bundle-node-extension-mjs/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-node-extension-mjs",
   "description": "Test making sure fast-check can be referenced from mjs files",
-  "version": "0.0.0",
   "type": "commonjs",
   "scripts": {
     "dry": "node dry.mjs",

--- a/packages/test-bundle-node-with-import/package.json
+++ b/packages/test-bundle-node-with-import/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-node-with-import",
   "description": "Test making sure fast-check can be referenced from ESM projects",
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dry": "node dry.js",

--- a/packages/test-bundle-node-with-require/package.json
+++ b/packages/test-bundle-node-with-require/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-node-with-require",
   "description": "Test making sure fast-check can be referenced from CJS projects",
-  "version": "0.0.0",
   "type": "commonjs",
   "scripts": {
     "dry": "node dry.js",

--- a/packages/test-bundle-rollup-with-import/package.json
+++ b/packages/test-bundle-rollup-with-import/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-rollup-with-import",
   "description": "Test making sure fast-check can be used with ESM in Rollup",
-  "version": "0.0.0",
   "scripts": {
     "generate": "rollup --config rollup.config.js && rollup --config rollup.config.dry.js",
     "out:dry": "node dist/dry.js",

--- a/packages/test-bundle-rollup-with-require/package.json
+++ b/packages/test-bundle-rollup-with-require/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-rollup-with-require",
   "description": "Test making sure fast-check can be used with CJS in Rollup",
-  "version": "0.0.0",
   "scripts": {
     "generate": "rollup --config rollup.config.js && rollup --config rollup.config.dry.js",
     "out:dry": "node dist/dry.js",

--- a/packages/test-bundle-webpack-with-import/package.json
+++ b/packages/test-bundle-webpack-with-import/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-webpack-with-import",
   "description": "Test making sure fast-check can be used with ESM in Webpack",
-  "version": "0.0.0",
   "scripts": {
     "generate": "webpack && webpack --config webpack.config.dry.js",
     "out:dry": "node dist/dry.js",

--- a/packages/test-bundle-webpack-with-require/package.json
+++ b/packages/test-bundle-webpack-with-require/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-bundle-webpack-with-require",
   "description": "Test making sure fast-check can be used with CJS in Webpack",
-  "version": "0.0.0",
   "scripts": {
     "generate": "webpack && webpack --config webpack.config.dry.js",
     "out:dry": "node dist/dry.js",

--- a/packages/test-jest-bundle-cjs/package.json
+++ b/packages/test-jest-bundle-cjs/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-jest-bundle-cjs",
   "descrition": "Test bundling of @fast-check/jest against CJS runners",
-  "version": "0.0.0",
   "type": "commonjs",
   "scripts": {
     "test": "jest --config jest.config.cjs"

--- a/packages/test-jest-bundle-esm/package.json
+++ b/packages/test-jest-bundle-esm/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-jest-bundle-esm",
   "descrition": "Test bundling of @fast-check/jest against ESM runners",
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.mjs"

--- a/packages/test-minimal-support/package.json
+++ b/packages/test-minimal-support/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-minimal-support",
   "description": "Test making sure fast-check can be used with it's official minimal requirement of node",
-  "version": "0.0.0",
   "scripts": {
     "test": "node main.js"
   },

--- a/packages/test-types/package.json
+++ b/packages/test-types/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@fast-check/test-types",
   "description": "Test making sure fast-check expose the right typings",
-  "version": "0.0.0",
   "scripts": {
     "test": "tsc"
   },


### PR DESCRIPTION
As seen within the code of berry, it seems that not providing any version to a package make it ignored by the version bump plugin. As a consequence let's try that.

Reference: https://github.com/yarnpkg/berry/blob/a66e528506168f7bfaa4fa9fc02b8edb226e47d4/packages/plugin-version/sources/versionUtils.ts#L247-L248

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
