### PR TITLE
🐛 Fix `safeApply` never calling original `apply`

### DIFF
--- a/.yarn/versions/33387874.yml
+++ b/.yarn/versions/33387874.yml
@@ -1,0 +1,6 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"

--- a/packages/fast-check/src/utils/apply.ts
+++ b/packages/fast-check/src/utils/apply.ts
@@ -1,4 +1,6 @@
+const safeObjectGetPrototypeOf = Object.getPrototypeOf;
 const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const untouchedPrototype = Function.prototype;
 const untouchedApply = Function.prototype.apply;
 
 const ApplySymbol = Symbol('apply');
@@ -28,9 +30,12 @@ export function safeApply<T, TArgs extends unknown[], TReturn>(
   instance: T,
   args: TArgs
 ): TReturn {
-  const descApply = safeObjectGetOwnPropertyDescriptor(f, 'apply');
-  if (descApply !== undefined && descApply.value === untouchedApply) {
-    return f.apply(instance, args);
+  const fPrototype = safeObjectGetPrototypeOf(f);
+  if (fPrototype === untouchedPrototype && safeObjectGetOwnPropertyDescriptor(f, 'apply') === undefined) {
+    const functionApplyDesc = safeObjectGetOwnPropertyDescriptor(untouchedPrototype, 'apply');
+    if (functionApplyDesc !== undefined && functionApplyDesc.value === untouchedApply) {
+      return f.apply(instance, args);
+    }
   }
   return safeApplyHacky(f, instance, args);
 }

--- a/packages/fast-check/test/unit/utils/apply.spec.ts
+++ b/packages/fast-check/test/unit/utils/apply.spec.ts
@@ -84,4 +84,34 @@ describe('safeApply', () => {
     // Assert
     expect(out).toBe(5 + 3 + 10);
   });
+
+  it('should apply if throwing poisoning of Function.prototype.apply', () => {
+    // Arrange
+    class Nominal {
+      constructor(private initialValue: number) {}
+      doStuff(v1: number, v2: number): number {
+        return this.initialValue + v1 + v2;
+      }
+    }
+    const n = new Nominal(5);
+    const originalApplyDescriptor = Object.getOwnPropertyDescriptor(Function.prototype, 'apply');
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    delete (Function.prototype as Partial<Function['prototype']>).apply;
+    Object.defineProperty(Function.prototype, 'apply', {
+      configurable: true, // so that we can revert the change
+      get: () => {
+        throw new Error('evil code');
+      },
+    });
+
+    try {
+      // Act
+      const out = safeApply(Nominal.prototype.doStuff, n, [3, 10]);
+
+      // Assert
+      expect(out).toBe(5 + 3 + 10);
+    } finally {
+      Object.defineProperty(Function.prototype, 'apply', originalApplyDescriptor!);
+    }
+  });
 });


### PR DESCRIPTION
Existing version of the code was wrong as it was expecting `apply` to be directly defined on the called function while in theory it comes from the `Function.prototype`.

Given benchmarks we did on https://github.com/dubzzz/fast-check-benchmarks/blob/main/benchmark-poisoning-results.txt, we expect some performance uplift from this change:
- before: from 8,572.147 to 8,823.322 ops/sec
- after: from 15,083.692 to 15,573.392 ops/sec

Measurements on fast-check itself will be carried out before merging the fix to make sure of the performance boost.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
