### PR TITLE
⚡️ Faster implementation for `safeApply`

### DIFF
--- a/.yarn/versions/2eb7f70f.yml
+++ b/.yarn/versions/2eb7f70f.yml
@@ -1,0 +1,6 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"

--- a/packages/fast-check/src/utils/apply.ts
+++ b/packages/fast-check/src/utils/apply.ts
@@ -1,9 +1,20 @@
-const safeObjectGetPrototypeOf = Object.getPrototypeOf;
-const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-const untouchedPrototype = Function.prototype;
 const untouchedApply = Function.prototype.apply;
-
 const ApplySymbol = Symbol('apply');
+
+/**
+ * Extract apply or return undefined
+ * @param f - Function to extract apply from
+ * @internal
+ */
+function safeExtractApply<T, TArgs extends unknown[], TReturn>(
+  f: (this: T, ...args: TArgs) => TReturn
+): ((thisArg: T) => TReturn) | undefined {
+  try {
+    return f.apply;
+  } catch (err) {
+    return undefined;
+  }
+}
 
 /**
  * Equivalent to `f.apply(instance, args)` but temporary altering the instance
@@ -30,12 +41,10 @@ export function safeApply<T, TArgs extends unknown[], TReturn>(
   instance: T,
   args: TArgs
 ): TReturn {
-  const fPrototype = safeObjectGetPrototypeOf(f);
-  if (fPrototype === untouchedPrototype && safeObjectGetOwnPropertyDescriptor(f, 'apply') === undefined) {
-    const functionApplyDesc = safeObjectGetOwnPropertyDescriptor(untouchedPrototype, 'apply');
-    if (functionApplyDesc !== undefined && functionApplyDesc.value === untouchedApply) {
-      return f.apply(instance, args);
-    }
+  // Not as safe as checking the descriptor of the property but much faster
+  // Can be by-passed by an appropriate getter property on 'apply'
+  if (safeExtractApply(f) === untouchedApply) {
+    return f.apply(instance, args);
   }
   return safeApplyHacky(f, instance, args);
 }


### PR DESCRIPTION
Benchmark measurements made at https://github.com/dubzzz/fast-check-benchmarks/blob/main/benchmark-poisoning.js proved that the code for `safeApply` can be speed-up by huge factors if rewritten in a try/catch maner.

We measured:
- before: from 15,083.692 to 15,573.392 ops/sec
- after: from 59,929.287 to 61,058.436 ops/sec

On this benchmark. Figures need to be confirmed on fast-check's code but figures looks promising.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
