### PR TITLE
🐛 Protect string generators against poisoning

### DIFF
--- a/.yarn/versions/4c781230.yml
+++ b/.yarn/versions/4c781230.yml
@@ -1,0 +1,6 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"

--- a/packages/fast-check/src/arbitrary/_internals/implementations/SlicedBasedGenerator.ts
+++ b/packages/fast-check/src/arbitrary/_internals/implementations/SlicedBasedGenerator.ts
@@ -1,6 +1,7 @@
 import { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary';
 import { Value } from '../../../check/arbitrary/definition/Value';
 import { Random } from '../../../random/generator/Random';
+import { safePush } from '../../../utils/globals';
 import { SlicedGenerator } from '../interfaces/SlicedGenerator';
 
 const safeMathMin = Math.min;
@@ -24,7 +25,7 @@ export class SlicedBasedGenerator<T> implements SlicedGenerator<T> {
       for (let index = 0; index !== this.slices.length; ++index) {
         const slice = this.slices[index];
         if (slice.length === targetLength) {
-          eligibleIndices.push(index);
+          safePush(eligibleIndices, index);
         }
       }
       if (eligibleIndices.length === 0) {


### PR DESCRIPTION
The risk of being impacted by a poisoning was pretty low as it could only happen for strings when we try to generate an exact value coming from a dicitionary of known dangerous values. While rare, it can still happen and drive developpers crazy if the crash occur in fast-check while the real issue comes from their own code.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
