### PR TITLE
✨(poisoning) Adopt shorter names for labels of globals

### DIFF
--- a/packages/poisoning/src/internals/CaptureAllGlobals.ts
+++ b/packages/poisoning/src/internals/CaptureAllGlobals.ts
@@ -47,7 +47,8 @@ function captureOneRecursively(knownGlobals: AllGlobals, instance: unknown, name
       // For instance: do not monitor the content of globalThis.Symbol(JEST_STATE_SYMBOL)
       continue;
     }
-    captureOneRecursively(knownGlobals, descriptor.value, name + '.' + String(descriptorName));
+    const subGlobalName = name !== 'globalThis' ? name + '.' + String(descriptorName) : String(descriptorName);
+    captureOneRecursively(knownGlobals, descriptor.value, subGlobalName);
   }
 }
 

--- a/packages/poisoning/test/internals/CaptureAllGlobals.spec.ts
+++ b/packages/poisoning/test/internals/CaptureAllGlobals.spec.ts
@@ -31,20 +31,19 @@ describe('captureAllGlobals', () => {
   // For the moment, internal data for globals linked to symbols is not tracked
   it.each(expectedGlobalsExcludingSymbols)('should track the content of $globalName', ({ globalName, globalValue }) => {
     // Arrange / Act
-    const fullGlobalName = `globalThis.${globalName}`;
     const globals = captureAllGlobals();
 
     // Assert
     const flattenGlobalsNames = [...globals.values()].map((globalDetails) => globalDetails.name);
     try {
-      expect(flattenGlobalsNames).toContainEqual(fullGlobalName);
+      expect(flattenGlobalsNames).toContainEqual(globalName);
     } catch (err) {
       const flattenGlobalsValuesToName = new Map(
         [...globals.entries()].map(([globalDetailsValue, globalDetails]) => [globalDetailsValue, globalDetails.name])
       );
       if (flattenGlobalsValuesToName.has(globalValue)) {
         const associatedName = flattenGlobalsValuesToName.get(globalValue);
-        const errorMessage = `Found value for ${globalName} (looked for ${fullGlobalName}) attached to ${associatedName}`;
+        const errorMessage = `Found value for ${globalName} attached to ${associatedName}`;
         throw new Error(errorMessage, { cause: err });
       }
       throw err;


### PR DESCRIPTION
No need to prefix all of them with `globalThis.*`.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
