### PR TITLE
🐛 Fix some remaining accesses to global properties

### DIFF
--- a/.yarn/versions/6f6f0ebe.yml
+++ b/.yarn/versions/6f6f0ebe.yml
@@ -1,0 +1,6 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"

--- a/packages/fast-check/src/arbitrary/_internals/CloneArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/CloneArbitrary.ts
@@ -5,6 +5,7 @@ import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
 import { safeMap, safePush } from '../../utils/globals';
 
+const safeSymbolIterator: typeof Symbol.iterator = Symbol.iterator;
 const safeIsArray = Array.isArray;
 const safeObjectIs = Object.is;
 
@@ -55,7 +56,7 @@ export class CloneArbitrary<T> extends Arbitrary<T[]> {
   }
 
   private *shrinkImpl(value: T[], contexts: unknown[]): IterableIterator<Value<T>[]> {
-    const its = safeMap(value, (v, idx) => this.arb.shrink(v, contexts[idx])[Symbol.iterator]());
+    const its = safeMap(value, (v, idx) => this.arb.shrink(v, contexts[idx])[safeSymbolIterator]());
     let cur = safeMap(its, (it) => it.next());
     while (!cur[0].done) {
       yield safeMap(cur, (c) => c.value);

--- a/packages/fast-check/src/arbitrary/_internals/FrequencyArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/FrequencyArbitrary.ts
@@ -6,6 +6,8 @@ import { DepthContext, DepthIdentifier, getDepthContextFor } from './helpers/Dep
 import { depthBiasFromSizeForArbitrary, DepthSize } from './helpers/MaxLengthFromMinLength';
 import { safePush } from '../../utils/globals';
 
+const safePositiveInfinity = Number.POSITIVE_INFINITY;
+const safeMaxSafeInteger = Number.MAX_SAFE_INTEGER;
 const safeNumberIsInteger = Number.isInteger;
 const safeMathFloor = Math.floor;
 const safeMathPow = Math.pow;
@@ -40,7 +42,7 @@ export class FrequencyArbitrary<T> extends Arbitrary<T> {
     }
     const sanitizedConstraints: _SanitizedConstraints = {
       depthBias: depthBiasFromSizeForArbitrary(constraints.depthSize, constraints.maxDepth !== undefined),
-      maxDepth: constraints.maxDepth != undefined ? constraints.maxDepth : Number.POSITIVE_INFINITY,
+      maxDepth: constraints.maxDepth != undefined ? constraints.maxDepth : safePositiveInfinity,
       withCrossShrink: !!constraints.withCrossShrink,
     };
     return new FrequencyArbitrary(warbs, sanitizedConstraints, getDepthContextFor(constraints.depthIdentifier));
@@ -195,7 +197,7 @@ export class FrequencyArbitrary<T> extends Arbitrary<T> {
     // to encounter thousands of instances of the current arbitrary.
     const depthBenefit = safeMathFloor(safeMathPow(1 + depthBias, this.context.depth)) - 1;
     // -0 has to be converted into 0 thus we call ||0
-    return -safeMathMin(this.totalWeight * depthBenefit, Number.MAX_SAFE_INTEGER) || 0;
+    return -safeMathMin(this.totalWeight * depthBenefit, safeMaxSafeInteger) || 0;
   }
 }
 

--- a/packages/fast-check/src/arbitrary/maxSafeInteger.ts
+++ b/packages/fast-check/src/arbitrary/maxSafeInteger.ts
@@ -1,11 +1,14 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { IntegerArbitrary } from './_internals/IntegerArbitrary';
 
+const safeMinSafeInteger = Number.MIN_SAFE_INTEGER;
+const safeMaxSafeInteger = Number.MAX_SAFE_INTEGER;
+
 /**
  * For integers between Number.MIN_SAFE_INTEGER (included) and Number.MAX_SAFE_INTEGER (included)
  * @remarks Since 1.11.0
  * @public
  */
 export function maxSafeInteger(): Arbitrary<number> {
-  return new IntegerArbitrary(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+  return new IntegerArbitrary(safeMinSafeInteger, safeMaxSafeInteger);
 }

--- a/packages/fast-check/src/arbitrary/maxSafeNat.ts
+++ b/packages/fast-check/src/arbitrary/maxSafeNat.ts
@@ -1,11 +1,13 @@
 import { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
 import { IntegerArbitrary } from './_internals/IntegerArbitrary';
 
+const safeMaxSafeInteger = Number.MAX_SAFE_INTEGER;
+
 /**
  * For positive integers between 0 (included) and Number.MAX_SAFE_INTEGER (included)
  * @remarks Since 1.11.0
  * @public
  */
 export function maxSafeNat(): Arbitrary<number> {
-  return new IntegerArbitrary(0, Number.MAX_SAFE_INTEGER);
+  return new IntegerArbitrary(0, safeMaxSafeInteger);
 }

--- a/packages/fast-check/src/stream/Stream.ts
+++ b/packages/fast-check/src/stream/Stream.ts
@@ -8,6 +8,8 @@ import {
   takeWhileHelper,
 } from './StreamHelpers';
 
+const safeSymbolIterator: typeof Symbol.iterator = Symbol.iterator;
+
 /**
  * Wrapper around `IterableIterator` interface
  * offering a set of helpers to deal with iterations in a simple way
@@ -31,7 +33,7 @@ export class Stream<T> implements IterableIterator<T> {
    * @remarks Since 2.12.0
    */
   static of<T>(...elements: T[]): Stream<T> {
-    return new Stream(elements[Symbol.iterator]());
+    return new Stream(elements[safeSymbolIterator]());
   }
 
   // /*DEBUG*/ // no double iteration
@@ -53,7 +55,7 @@ export class Stream<T> implements IterableIterator<T> {
   next(): IteratorResult<T> {
     return this.g.next();
   }
-  [Symbol.iterator](): IterableIterator<T> {
+  [safeSymbolIterator](): IterableIterator<T> {
     // /*DEBUG*/ this.closeCurrentStream();
     return this.g;
   }

--- a/packages/fast-check/src/utils/stringify.ts
+++ b/packages/fast-check/src/utils/stringify.ts
@@ -17,6 +17,8 @@ const safeObjectKeys = Object.keys;
 const safeObjectGetOwnPropertySymbols = Object.getOwnPropertySymbols;
 const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const safeObjectGetPrototypeOf = Object.getPrototypeOf;
+const safeNegativeInfinity = Number.NEGATIVE_INFINITY;
+const safePositiveInfinity = Number.POSITIVE_INFINITY;
 
 /**
  * Use this symbol to define a custom serializer for your instances.
@@ -107,10 +109,10 @@ function getSymbolDescription(s: symbol): string | null {
 function stringifyNumber(numValue: number) {
   switch (numValue) {
     case 0:
-      return 1 / numValue === Number.NEGATIVE_INFINITY ? '-0' : '0';
-    case Number.NEGATIVE_INFINITY:
+      return 1 / numValue === safeNegativeInfinity ? '-0' : '0';
+    case safeNegativeInfinity:
       return 'Number.NEGATIVE_INFINITY';
-    case Number.POSITIVE_INFINITY:
+    case safePositiveInfinity:
       return 'Number.POSITIVE_INFINITY';
     default:
       return numValue === numValue ? String(numValue) : 'Number.NaN';


### PR DESCRIPTION
By global properties we mean things like `Number.MAX_VALUE` or more generally any property (like `MAX_VALUE`) accessible from a globally available type (like `Number`).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
