### PR TITLE
✨(poisoning) Do not track private globals

### DIFF
--- a/.yarn/versions/8d0cae16.yml
+++ b/.yarn/versions/8d0cae16.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/poisoning": patch
+
+declined:
+  - fast-check

--- a/packages/poisoning/src/internals/CaptureAllGlobals.ts
+++ b/packages/poisoning/src/internals/CaptureAllGlobals.ts
@@ -52,7 +52,7 @@ function captureOneRecursively(knownGlobals: AllGlobals, instance: unknown, name
       // For instance: do not track the content of globalThis.__coverage__
       continue;
     }
-    const subGlobalName = topLevel ? name + '.' + String(descriptorName) : String(descriptorName);
+    const subGlobalName = !topLevel ? name + '.' + String(descriptorName) : String(descriptorName);
     captureOneRecursively(knownGlobals, descriptor.value, subGlobalName, false);
   }
 }

--- a/packages/poisoning/src/internals/CaptureAllGlobals.ts
+++ b/packages/poisoning/src/internals/CaptureAllGlobals.ts
@@ -25,7 +25,7 @@ function extractAllDescriptorsDetails(instance: unknown): [string | symbol, Prop
   return allDescriptorsDetails[SortSymbol](compareKeys);
 }
 
-function captureOneRecursively(knownGlobals: AllGlobals, instance: unknown, name: string): void {
+function captureOneRecursively(knownGlobals: AllGlobals, instance: unknown, name: string, topLevel: boolean): void {
   if (typeof instance !== 'function' && typeof instance !== 'object') {
     return;
   }
@@ -47,14 +47,19 @@ function captureOneRecursively(knownGlobals: AllGlobals, instance: unknown, name
       // For instance: do not monitor the content of globalThis.Symbol(JEST_STATE_SYMBOL)
       continue;
     }
-    const subGlobalName = name !== 'globalThis' ? name + '.' + String(descriptorName) : String(descriptorName);
-    captureOneRecursively(knownGlobals, descriptor.value, subGlobalName);
+    if (topLevel && descriptorName[0] === '_') {
+      // Do not scan what's sounds like private properties dropped on globalThis
+      // For instance: do not track the content of globalThis.__coverage__
+      continue;
+    }
+    const subGlobalName = topLevel ? name + '.' + String(descriptorName) : String(descriptorName);
+    captureOneRecursively(knownGlobals, descriptor.value, subGlobalName, false);
   }
 }
 
 /** Capture all globals accessible from globalThis */
 export function captureAllGlobals(): AllGlobals {
   const knownGlobals = toPoisoningFreeMap(new Map<unknown, GlobalDetails>());
-  captureOneRecursively(knownGlobals, globalThis, 'globalThis');
+  captureOneRecursively(knownGlobals, globalThis, 'globalThis', true);
   return knownGlobals;
 }


### PR DESCRIPTION
Globals starting with a `_` are generally used for private stuffs such as: measuring coverage with nyc, gathering buffer related metas before dropping it to the console...

As we want poisoning to be easily pluggable without any extensive configuration, we prefer not tracking the content of such entity and just limit ourselves to check in their pointer changed or not but not deeply checking them.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
