### PR TITLE
✅ Add some more type related tests for oneof

### DIFF
--- a/packages/test-types/main.ts
+++ b/packages/test-types/main.ts
@@ -316,6 +316,9 @@ expectType<fc.Arbitrary<string | number>>()(
   fc.oneof({ withCrossShrink: true }, { arbitrary: fc.string(), weight: 1 }, fc.nat()),
   '"oneof" with weighted arbitraries and non-weighted arbitraries'
 );
+expectType<fc.Arbitrary<number>>()(fc.oneof(...([] as fc.Arbitrary<number>[])), '"oneof" from array of arbitraries');
+expectType<fc.Arbitrary<never>>()(fc.oneof(), '"oneof" must receive at least one arbitrary');
+
 // @ts-expect-error - oneof expects arbitraries not raw values
 fc.oneof(fc.string(), '1');
 // @ts-expect-error - oneof expects weighted arbitraries with real arbitrraies and not raw values


### PR DESCRIPTION
While ideally writing `oneof()` should be prevented having a version accepting `oneof(...arrayOfArbs)` but rejecting `oneof()` was not straightforward to come up with.

The current output for `oneof()` seems already to be already a good trade-off. So I believe we can close #546 for now.

Fixes #546

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
