### PR TITLE
♻️ Attach a `depth` onto globals internally

### DIFF
--- a/.yarn/versions/e4c620f3.yml
+++ b/.yarn/versions/e4c620f3.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/poisoning": patch
+
+declined:
+  - fast-check

--- a/packages/poisoning/src/internals/types/AllGlobals.ts
+++ b/packages/poisoning/src/internals/types/AllGlobals.ts
@@ -1,7 +1,20 @@
 import { PoisoningFreeMap } from '../PoisoningFreeMap.js';
 
 export type GlobalDetails = {
+  /**
+   * Name associated to the current global,
+   * in other words the path leading to it such as `Array.prototype.map` or `Object.entries`
+   */
   name: string;
+  /**
+   * Depth of the global relative to the scanning root
+   * Remark: in the current implementation it might not be the shortest one but it will be updated soon
+   */
+  depth: number;
+  /**
+   * Map containing all the known properties attached to the current global
+   * it contains all the keys and symbols enumarable or not, configurable or not attached to it
+   */
   properties: PoisoningFreeMap<string | symbol, PropertyDescriptor>;
 };
 

--- a/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
+++ b/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
@@ -131,6 +131,7 @@ describe('trackDiffsOnGlobals', () => {
 function extractGlobalDetailsFor(itemName: string, item: unknown): GlobalDetails {
   return {
     name: itemName,
+    depth: 0,
     properties: toPoisoningFreeMap(
       new Map(
         [...Object.getOwnPropertyNames(item), ...Object.getOwnPropertySymbols(item)].map((keyName) => [


### PR DESCRIPTION
It will be leveraged later to be able to filter out some globals the user does not want to monitor. But for now, it's only an internal refactoring.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
