### PR TITLE
🐛(poisoning) Even more resiliency against poisoning

### DIFF
--- a/.yarn/versions/ae0bb4e3.yml
+++ b/.yarn/versions/ae0bb4e3.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/poisoning": patch
+
+declined:
+  - fast-check

--- a/packages/poisoning/src/internals/PoisoningFreeArray.ts
+++ b/packages/poisoning/src/internals/PoisoningFreeArray.ts
@@ -1,3 +1,4 @@
+const safeArrayFrom = Array.from;
 const safeArrayMap = Array.prototype.map;
 const safeArrayPush = Array.prototype.push;
 const safeArrayShift = Array.prototype.shift;
@@ -22,7 +23,7 @@ export type PoisoningFreeArray<T> = Array<T> & {
 };
 
 /** Alter an instance of Array to include non-poisonable methods */
-export function toPoisoningFreeArray<T>(instance: T[]): PoisoningFreeArray<T> {
+function toPoisoningFreeArray<T>(instance: T[]): PoisoningFreeArray<T> {
   safeObjectDefineProperty(instance, MapSymbol, {
     value: safeArrayMap,
     configurable: false,
@@ -49,3 +50,10 @@ export function toPoisoningFreeArray<T>(instance: T[]): PoisoningFreeArray<T> {
   });
   return instance as PoisoningFreeArray<T>;
 }
+
+/** Factory responsible to build instances of PoisoningFreeArray */
+export const PoisoningFreeArray = {
+  from<T>(arrayLike: ArrayLike<T>): PoisoningFreeArray<T> {
+    return toPoisoningFreeArray(safeArrayFrom(arrayLike));
+  },
+};

--- a/packages/poisoning/src/internals/PoisoningFreeMap.ts
+++ b/packages/poisoning/src/internals/PoisoningFreeMap.ts
@@ -1,3 +1,4 @@
+const SMap = Map;
 const safeMapGet = Map.prototype.get;
 const safeMapHas = Map.prototype.has;
 const safeMapEntries = Map.prototype.entries;
@@ -22,7 +23,7 @@ export type PoisoningFreeMap<K, V> = Map<K, V> & {
 };
 
 /** Alter an instance of Map to include non-poisonable methods */
-export function toPoisoningFreeMap<K, V>(instance: Map<K, V>): PoisoningFreeMap<K, V> {
+function toPoisoningFreeMap<K, V>(instance: Map<K, V>): PoisoningFreeMap<K, V> {
   safeObjectDefineProperty(instance, GetSymbol, {
     value: safeMapGet,
     configurable: false,
@@ -49,3 +50,10 @@ export function toPoisoningFreeMap<K, V>(instance: Map<K, V>): PoisoningFreeMap<
   });
   return instance as PoisoningFreeMap<K, V>;
 }
+
+/** Factory responsible to build instances of PoisoningFreeMap */
+export const PoisoningFreeMap = {
+  from<K, V>(ins?: readonly (readonly [K, V])[] | Iterable<readonly [K, V]> | null): PoisoningFreeMap<K, V> {
+    return toPoisoningFreeMap(new SMap(ins));
+  },
+};

--- a/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
+++ b/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
@@ -1,7 +1,8 @@
-import { PoisoningFreeArray, toPoisoningFreeArray, PushSymbol } from './PoisoningFreeArray.js';
+import { PoisoningFreeArray, PushSymbol } from './PoisoningFreeArray.js';
 import { EntriesSymbol, HasSymbol } from './PoisoningFreeMap.js';
 import { AllGlobals } from './types/AllGlobals.js';
 
+const SString = String;
 const safeObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 const safeObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
 const safeObjectGetOwnPropertySymbols = Object.getOwnPropertySymbols;
@@ -17,7 +18,7 @@ type DiffOnGlobal = {
 /** Compute the diff between two versions of globals */
 export function trackDiffsOnGlobals(initialGlobals: AllGlobals): DiffOnGlobal[] {
   const allInitialGlobals = [...initialGlobals[EntriesSymbol]()];
-  const observedDiffs: PoisoningFreeArray<DiffOnGlobal> = toPoisoningFreeArray<DiffOnGlobal>([]);
+  const observedDiffs = PoisoningFreeArray.from<DiffOnGlobal>([]);
 
   for (let index = 0; index !== allInitialGlobals.length; ++index) {
     const instance = allInitialGlobals[index][0];
@@ -34,7 +35,7 @@ export function trackDiffsOnGlobals(initialGlobals: AllGlobals): DiffOnGlobal[] 
 
       if (!(propertyName in (currentDescriptors as any))) {
         observedDiffs[PushSymbol]({
-          keyName: name + '.' + String(propertyName),
+          keyName: name + '.' + SString(propertyName),
           type: 'removed',
           patch: () => {
             safeObjectDefineProperty(instance, propertyName, initialPropertyDescriptor);
@@ -46,7 +47,7 @@ export function trackDiffsOnGlobals(initialGlobals: AllGlobals): DiffOnGlobal[] 
         !safeObjectIs(initialPropertyDescriptor.set, (currentDescriptors as any)[propertyName].set)
       ) {
         observedDiffs[PushSymbol]({
-          keyName: name + '.' + String(propertyName),
+          keyName: name + '.' + SString(propertyName),
           type: 'changed',
           patch: () => {
             safeObjectDefineProperty(instance, propertyName, initialPropertyDescriptor);
@@ -64,7 +65,7 @@ export function trackDiffsOnGlobals(initialGlobals: AllGlobals): DiffOnGlobal[] 
       const propertyName = currentDescriptorsList[descriptorIndex];
       if (!initialProperties[HasSymbol](propertyName)) {
         observedDiffs[PushSymbol]({
-          keyName: name + '.' + String(propertyName),
+          keyName: name + '.' + SString(propertyName),
           type: 'added',
           patch: () => {
             delete (instance as any)[propertyName];

--- a/packages/poisoning/test/internals/PoisoningFreeArray.spec.ts
+++ b/packages/poisoning/test/internals/PoisoningFreeArray.spec.ts
@@ -1,4 +1,4 @@
-import { MapSymbol, PushSymbol, SortSymbol, toPoisoningFreeArray } from '../../src/internals/PoisoningFreeArray.js';
+import { MapSymbol, PushSymbol, SortSymbol, PoisoningFreeArray } from '../../src/internals/PoisoningFreeArray.js';
 
 describe('PoisoningFreeArray', () => {
   it.each`
@@ -14,12 +14,15 @@ describe('PoisoningFreeArray', () => {
     try {
       // Act
       delete Array.prototype[originalName]; // deleting original before calling toPoisoningFree*
-      toPoisoningFreeArray(sourceArray);
+      const newArray = PoisoningFreeArray.from(sourceArray);
 
       // Assert
-      expect(symbol in sourceArray).toBe(true); // check symbol exists on altered instances...
-      expect(sourceArray[symbol]).toBe(originalMethod);
-      expect(symbol in []).toBe(false); // ...but not on untouched ones...
+      expect(symbol in newArray).toBe(true); // check symbol exists on output...
+      expect(newArray[symbol]).toBe(originalMethod);
+      expect(newArray).toBeInstanceOf(Array);
+      expect(symbol in sourceArray).toBe(false); // ...but did not altered received instances...
+      expect(sourceArray[symbol]).toBe(undefined);
+      expect(symbol in []).toBe(false); // ...nor future instances...
       expect(symbol in Array.prototype).toBe(false);
       expect(originalName in []).toBe(false); // ...and that source method has been properly dropped
     } finally {

--- a/packages/poisoning/test/internals/PoisoningFreeMap.spec.ts
+++ b/packages/poisoning/test/internals/PoisoningFreeMap.spec.ts
@@ -3,7 +3,7 @@ import {
   GetSymbol,
   HasSymbol,
   SetSymbol,
-  toPoisoningFreeMap,
+  PoisoningFreeMap,
 } from '../../src/internals/PoisoningFreeMap.js';
 
 describe('PoisoningFreeMap', () => {
@@ -16,16 +16,16 @@ describe('PoisoningFreeMap', () => {
   `('should only expose safe $originalName on the altered instances', ({ originalName, symbol }) => {
     // Arrange
     const originalMethod = (Map as any).prototype[originalName];
-    const sourceMap = new Map<unknown, unknown>();
 
     try {
       // Act
       delete (Map as any).prototype[originalName]; // deleting original before calling toPoisoningFree*
-      toPoisoningFreeMap(sourceMap);
+      const newMap = PoisoningFreeMap.from();
 
       // Assert
-      expect(symbol in sourceMap).toBe(true); // check symbol exists on altered instances...
-      expect((sourceMap as any)[symbol]).toBe(originalMethod);
+      expect(symbol in newMap).toBe(true); // check symbol exists on output...
+      expect((newMap as any)[symbol]).toBe(originalMethod);
+      expect(newMap).toBeInstanceOf(Map);
       expect(symbol in new Map()).toBe(false); // ...but not on untouched ones...
       expect(symbol in Map.prototype).toBe(false);
       expect(originalName in new Map()).toBe(false); // ...and that source method has been properly dropped

--- a/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
+++ b/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
@@ -1,4 +1,4 @@
-import { toPoisoningFreeMap } from '../../src/internals/PoisoningFreeMap.js';
+import { PoisoningFreeMap } from '../../src/internals/PoisoningFreeMap.js';
 import { trackDiffsOnGlobals } from '../../src/internals/TrackDiffsOnGlobal.js';
 import { AllGlobals, GlobalDetails } from '../../src/internals/types/AllGlobals.js';
 
@@ -6,9 +6,9 @@ describe('trackDiffsOnGlobals', () => {
   it('should detect added entries', () => {
     // Arrange
     const globalA: any = {};
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     globalA.a = 2; // adding key onto a tracked global
 
     // Act
@@ -26,9 +26,9 @@ describe('trackDiffsOnGlobals', () => {
     // Arrange
     const addedSymbol = Symbol('my-symbol');
     const globalA: any = {};
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     globalA[addedSymbol] = 2; // adding key onto a tracked global
 
     // Act
@@ -45,9 +45,9 @@ describe('trackDiffsOnGlobals', () => {
   it('should detect added non-enumerable entries', () => {
     // Arrange
     const globalA: any = {};
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     Object.defineProperty(globalA, 'a', { configurable: true, enumerable: false, writable: false, value: 2 }); // adding key onto a tracked global
 
     // Act
@@ -64,9 +64,9 @@ describe('trackDiffsOnGlobals', () => {
   it('should detect removed entries', () => {
     // Arrange
     const globalA: any = { a: 2 };
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     delete globalA.a; // deleting key from a tracked global
 
     // Act
@@ -83,9 +83,9 @@ describe('trackDiffsOnGlobals', () => {
   it('should detect changed entries', () => {
     // Arrange
     const globalA: any = { a: 2 };
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     globalA.a = 3; // updating value linked to a key from a tracked global
 
     // Act
@@ -107,9 +107,9 @@ describe('trackDiffsOnGlobals', () => {
     const helloOverride = () => {};
     const globalA = new BaseA();
     globalA.hello = helloOverride; // 'a' now defines 'hello' as one of its own properties
-    const allGlobals: AllGlobals = toPoisoningFreeMap(
-      new Map<unknown, GlobalDetails>([[globalA, extractGlobalDetailsFor('globalA', globalA)]])
-    );
+    const allGlobals: AllGlobals = PoisoningFreeMap.from<unknown, GlobalDetails>([
+      [globalA, extractGlobalDetailsFor('globalA', globalA)],
+    ]);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     delete globalA.hello; // deleting hello from globalA but globalA.hello can still be called (prototype call)
@@ -132,13 +132,11 @@ function extractGlobalDetailsFor(itemName: string, item: unknown): GlobalDetails
   return {
     name: itemName,
     depth: 0,
-    properties: toPoisoningFreeMap(
-      new Map(
-        [...Object.getOwnPropertyNames(item), ...Object.getOwnPropertySymbols(item)].map((keyName) => [
-          keyName,
-          Object.getOwnPropertyDescriptor(item, keyName)!,
-        ])
-      )
+    properties: PoisoningFreeMap.from(
+      [...Object.getOwnPropertyNames(item), ...Object.getOwnPropertySymbols(item)].map((keyName) => [
+        keyName,
+        Object.getOwnPropertyDescriptor(item, keyName)!,
+      ])
     ),
   };
 }


### PR DESCRIPTION
Just adding some more resiliency against poisoning attacks in poisoning package itself. Now dropping String, Array or Map, should not be that harmful for poisoning to run.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
