### PR TITLE
✨(jest) Add `it.failing` and `it.concurrent` and combinations

### DIFF
--- a/.yarn/versions/439b8b25.yml
+++ b/.yarn/versions/439b8b25.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": minor

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -39,7 +39,7 @@ Please note that the properties accepted by `@fast-check/jest` as input can eith
 
 If you want to forward custom parameters to fast-check, `testProp` accepts an optional `fc.Parameters` ([more](https://github.com/dubzzz/fast-check/blob/main/documentation/1-Guides/Runners.md#runners)).
 
-`@fast-check/jest` also comes with `.only`, `.skip` and `.todo` from jest.
+`@fast-check/jest` also comes with `.only`, `.skip`, `.todo` and `.concurrent` from jest. It also accepts more complex ones such as `.concurrent.failing` or `.concurrent.only.failing`.
 
 ```javascript
 import { itProp, testProp, fc } from '@fast-check/jest';

--- a/packages/jest/test.sh
+++ b/packages/jest/test.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
-npm run jest-test >test/out.log 2>&1
+yarn jest-test >test/out.log 2>&1
 
 for expectedContent in \
         "● should fail on falsy synchronous property" \
         "● should fail on falsy asynchronous property" \
         "● should fail with seed=4242 and path=\"25\" (with seed=4242)" \
+        "● should fail because passing (with seed=48)" \
         "● itProp › should fail on falsy synchronous property" \
         "● itProp › should fail on falsy asynchronous property" \
-        "● itProp › should fail with seed=4242 and path=\"25\" (with seed=4242)"
+        "● itProp › should fail with seed=4242 and path=\"25\" (with seed=4242)" \
+        "● itProp › should fail because passing (with seed=48)" \
+        "● itProp › should fail for concurrent (with seed=4848)" \
+        "● itProp › should fail for concurrent because passing (with seed=4848)"
 do
     cat test/out.log | grep "${expectedContent}" >/dev/null 2>&1
     if [ $? -ne 0 ]; then

--- a/packages/jest/test/itProp.spec.ts
+++ b/packages/jest/test/itProp.spec.ts
@@ -29,4 +29,16 @@ describe('itProp', () => {
   // itProp.skip
 
   itProp.skip('should never be executed', [fc.boolean()], (a) => a, { seed: 48 });
+
+  // itProp.failing
+
+  itProp.failing('should fail because passing', [fc.boolean()], (_a) => true, { seed: 48 });
+
+  // itProp.concurrent
+
+  itProp.concurrent('should fail for concurrent', [fc.boolean()], (_a) => false, { seed: 4848 });
+
+  // itProp.concurrent.failing
+
+  itProp.concurrent.failing('should fail for concurrent because passing', [fc.boolean()], (_a) => true, { seed: 4848 });
 });

--- a/packages/jest/test/testProp.spec.ts
+++ b/packages/jest/test/testProp.spec.ts
@@ -27,3 +27,7 @@ testProp('should fail with seed=4242 and path="25"', [fc.constant(null)], (_unus
 // testProp.skip
 
 testProp.skip('should never be executed', [fc.boolean()], (a) => a, { seed: 48 });
+
+// testProp.failing
+
+testProp.failing('should fail because passing', [fc.boolean()], (_a) => true, { seed: 48 });


### PR DESCRIPTION
Jest comes with many ways to combine all the `it`, `test` with `skip`, `failing` and others altogether. While so far we decided not to support `each`, we added support for all the other ones.

So you'll now be able to run any of those:
```ts
itProp(...)
itProp.only(...)
itProp.only.failing(...)
itProp.failing(...)
itProp.skip(...)
itProp.skip.failing(...)
itProp.todo(...)
itProp.concurrent(...)
itProp.concurrent.only(...)
itProp.concurrent.only.failing(...)
itProp.concurrent.failing(...)
itProp.concurrent.skip(...)
itProp.concurrent.skip.failing(...)
testProp(...)
testProp.only(...)
testProp.only.failing(...)
testProp.failing(...)
testProp.skip(...)
testProp.skip.failing(...)
testProp.todo(...)
testProp.concurrent(...)
testProp.concurrent.only(...)
testProp.concurrent.only.failing(...)
testProp.concurrent.failing(...)
testProp.concurrent.skip(...)
testProp.concurrent.skip.failing(...)
```

Fixes #3202

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
