### PR TITLE
✨ Attach real errors to internal failures

### DIFF
--- a/.yarn/versions/d4e02435.yml
+++ b/.yarn/versions/d4e02435.yml
@@ -4,3 +4,4 @@ releases:
 declined:
   - "@fast-check/ava"
   - "@fast-check/jest"
+  - "@fast-check/worker"

--- a/.yarn/versions/d4e02435.yml
+++ b/.yarn/versions/d4e02435.yml
@@ -1,0 +1,6 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"

--- a/packages/fast-check/src/check/property/AsyncProperty.generic.ts
+++ b/packages/fast-check/src/check/property/AsyncProperty.generic.ts
@@ -9,7 +9,7 @@ import {
   noUndefinedAsContext,
   UndefinedContextPlaceholder,
 } from '../../arbitrary/_internals/helpers/NoUndefinedAsContext';
-import { String } from '../../utils/globals';
+import { Error, String } from '../../utils/globals';
 
 /**
  * Type of legal hook function that can be used to call `beforeEach` or `afterEach`
@@ -107,7 +107,10 @@ export class AsyncProperty<Ts> implements IAsyncPropertyWithHooks<Ts> {
       const output = await this.predicate(v);
       return output == null || output === true
         ? null
-        : { error: undefined, errorMessage: 'Property failed by returning false' };
+        : {
+            error: new Error('Property failed by returning false'),
+            errorMessage: 'Property failed by returning false',
+          };
     } catch (err) {
       // precondition failure considered as success for the first version
       if (PreconditionFailure.isFailure(err)) return err;

--- a/packages/fast-check/src/check/property/Property.generic.ts
+++ b/packages/fast-check/src/check/property/Property.generic.ts
@@ -9,7 +9,7 @@ import {
   noUndefinedAsContext,
   UndefinedContextPlaceholder,
 } from '../../arbitrary/_internals/helpers/NoUndefinedAsContext';
-import { String } from '../../utils/globals';
+import { Error, String } from '../../utils/globals';
 
 /**
  * Type of legal hook function that can be used to call `beforeEach` or `afterEach`
@@ -123,7 +123,10 @@ export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
       const output = this.predicate(v);
       return output == null || output === true
         ? null
-        : { error: undefined, errorMessage: 'Property failed by returning false' };
+        : {
+            error: new Error('Property failed by returning false'),
+            errorMessage: 'Property failed by returning false',
+          };
     } catch (err) {
       // precondition failure considered as success for the first version
       if (PreconditionFailure.isFailure(err)) return err;

--- a/packages/fast-check/src/check/property/TimeoutProperty.ts
+++ b/packages/fast-check/src/check/property/TimeoutProperty.ts
@@ -1,5 +1,6 @@
 import { Random } from '../../random/generator/Random';
 import { Stream } from '../../stream/Stream';
+import { Error } from '../../utils/globals';
 import { Value } from '../arbitrary/definition/Value';
 import { PreconditionFailure } from '../precondition/PreconditionFailure';
 import { PropertyFailure, IRawProperty } from './IRawProperty';
@@ -9,7 +10,10 @@ const timeoutAfter = (timeMs: number) => {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const promise = new Promise<PropertyFailure>((resolve) => {
     timeoutHandle = setTimeout(() => {
-      resolve({ error: undefined, errorMessage: `Property timeout: exceeded limit of ${timeMs} milliseconds` });
+      resolve({
+        error: new Error(`Property timeout: exceeded limit of ${timeMs} milliseconds`),
+        errorMessage: `Property timeout: exceeded limit of ${timeMs} milliseconds`,
+      });
     }, timeMs);
   });
   return {

--- a/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
@@ -138,7 +138,7 @@ describe('TimeoutProperty', () => {
 
     // Assert
     expect(await runPromise).toEqual({
-      error: undefined,
+      error: expect.any(Error),
       errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
     });
   });
@@ -156,7 +156,7 @@ describe('TimeoutProperty', () => {
 
     // Assert
     expect(await runPromise).toEqual({
-      error: undefined,
+      error: expect.any(Error),
       errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
     });
   });


### PR DESCRIPTION
Up-to-now when a property failed because it returned `false` or reached a time-out, we basically returned an error message but without any error backing it.

We now alos attach an instance of Error next to it, so that users wanting to format their reports in a different way can use it. It will be also leveraged by the error with cause feature which will be able to use it as a cause while it used not to put any cause in such case.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
