### PR TITLE
⚡️(worker) Share workers across runs of the predicate

### DIFF
--- a/.yarn/versions/cc9a3bc5.yml
+++ b/.yarn/versions/cc9a3bc5.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/worker": patch

--- a/packages/worker/src/internals/MainThreadRunner.ts
+++ b/packages/worker/src/internals/MainThreadRunner.ts
@@ -1,11 +1,6 @@
-import { Worker } from 'node:worker_threads';
 import fc from 'fast-check';
-import {
-  type WorkerToMainThreadMessage,
-  type PropertyArbitraries,
-  type WorkerProperty,
-  type MainThreadToWorkerMessage,
-} from './SharedTypes.js';
+import { type PropertyArbitraries, type WorkerProperty } from './SharedTypes.js';
+import { WorkerPool } from './worker-pool/WorkerPool.js';
 
 /**
  * Create a property able to run in the main thread and firing workers whenever required
@@ -18,37 +13,14 @@ import {
 export function runMainThread<Ts extends [unknown, ...unknown[]]>(
   workerFileUrl: URL,
   workerId: number,
-  arbitraries: PropertyArbitraries<Ts>,
-  onNewWorker: (worker: Worker) => void
-): WorkerProperty<Ts> {
-  let lastRunId = -1;
-  return fc.asyncProperty<Ts>(...arbitraries, async (...inputs) => {
+  arbitraries: PropertyArbitraries<Ts>
+): { property: WorkerProperty<Ts>; terminateAllWorkers: () => Promise<void> } {
+  const pool = new WorkerPool<boolean | void, Ts>(workerFileUrl, workerId);
+  const property = fc.asyncProperty<Ts>(...arbitraries, async (...inputs) => {
     return new Promise((resolve, reject) => {
-      const currentRunId = ++lastRunId;
-      const worker = new Worker(workerFileUrl, { workerData: { currentWorkerId: workerId } });
-      onNewWorker(worker);
-
-      // Register to the worker
-      worker.on('message', (data: WorkerToMainThreadMessage) => {
-        if (data.runId !== currentRunId) {
-          return;
-        }
-        if (data.success) {
-          resolve(data.output);
-        } else {
-          reject(data.error);
-        }
-      });
-      worker.on('error', (err) => {
-        reject(err);
-      });
-      worker.on('exit', (code) => {
-        reject(new Error(`Worker stopped with exit code ${code}`));
-      });
-
-      // Start the worker
-      const message: MainThreadToWorkerMessage<Ts> = { inputs, runId: currentRunId };
-      worker.postMessage(message);
+      pool.acquireOne(inputs, resolve, reject);
     });
   });
+  const terminateAllWorkers = () => pool.terminateAllWorkers();
+  return { property, terminateAllWorkers };
 }

--- a/packages/worker/src/internals/SharedTypes.ts
+++ b/packages/worker/src/internals/SharedTypes.ts
@@ -1,4 +1,5 @@
 import type { Arbitrary, IAsyncPropertyWithHooks } from 'fast-check';
+import { type PoolToWorkerMessage, type WorkerToPoolMessage } from './worker-pool/BasicPool';
 
 export type PropertyArbitraries<Ts extends unknown[]> = {
   [K in keyof Ts]: Arbitrary<Ts[K]>;
@@ -6,9 +7,6 @@ export type PropertyArbitraries<Ts extends unknown[]> = {
 export type PropertyPredicate<Ts extends unknown[]> = (...args: Ts) => boolean | void | Promise<boolean | void>;
 export type WorkerProperty<Ts> = IAsyncPropertyWithHooks<Ts>;
 
-export type MainThreadToWorkerMessage<Ts> = { runId: number; inputs: Ts };
+export type MainThreadToWorkerMessage<Ts> = PoolToWorkerMessage<Ts>;
 
-export type WorkerToMainThreadMessage = { runId: number } & (
-  | { success: true; output: boolean | void }
-  | { success: false; error: unknown }
-);
+export type WorkerToMainThreadMessage = WorkerToPoolMessage<boolean | void>;

--- a/packages/worker/src/internals/WorkerRunner.ts
+++ b/packages/worker/src/internals/WorkerRunner.ts
@@ -1,7 +1,7 @@
 import { type MessagePort } from 'node:worker_threads';
 import {
-  type PropertyPredicate,
   type MainThreadToWorkerMessage,
+  type PropertyPredicate,
   type WorkerToMainThreadMessage,
 } from './SharedTypes.js';
 
@@ -11,11 +11,9 @@ import {
  * @param predicate - the predicate to assess
  */
 export function runWorker<Ts extends unknown[]>(parentPort: MessagePort, predicate: PropertyPredicate<Ts>): void {
-  // TODO - Workers should be able to be re-used through executions of the same predicate
-  // in order to increase the overall performance of a worker-based version
-  parentPort.once('message', (payload: MainThreadToWorkerMessage<Ts>) => {
-    const { inputs, runId } = payload;
-    Promise.resolve(predicate(...inputs)).then(
+  parentPort.on('message', (message: MainThreadToWorkerMessage<Ts>) => {
+    const { payload, runId } = message;
+    Promise.resolve(predicate(...payload)).then(
       (output) => {
         const message: WorkerToMainThreadMessage = { success: true, output, runId };
         parentPort.postMessage(message);

--- a/packages/worker/src/internals/worker-pool/BasicPool.ts
+++ b/packages/worker/src/internals/worker-pool/BasicPool.ts
@@ -1,0 +1,123 @@
+import { Worker } from 'node:worker_threads';
+
+export type OnSuccessCallback<TSuccess> = (value: TSuccess) => void;
+export type OnErrorCallback = (error: unknown) => void;
+
+/**
+ * Worker API
+ */
+type PooledWorker<TSuccess, TPayload> = {
+  isAvailable: () => boolean;
+  isFaulty: () => boolean;
+  register: (payload: TPayload, onSuccess: OnSuccessCallback<TSuccess>, onFailure: OnErrorCallback) => void;
+};
+
+/**
+ * Worker internal API
+ */
+type InternalPooledWorker<TSuccess, TPayload> = PooledWorker<TSuccess, TPayload> & {
+  worker: Worker;
+};
+
+/**
+ * Message exchanged from the pool to the worker
+ */
+export type PoolToWorkerMessage<TPayload> = { runId: number; payload: TPayload };
+
+/**
+ * Message exchanged from the worker to the pool
+ */
+export type WorkerToPoolMessage<TSuccess> = { runId: number } & (
+  | { success: true; output: TSuccess }
+  | { success: false; error: unknown }
+);
+
+/**
+ * Basic pool for workers, providing the ability to spawn new workers,
+ * get the first available one and terminate them all
+ */
+export class BasicPool<TSuccess, TPayload> {
+  private readonly workers: InternalPooledWorker<TSuccess, TPayload>[] = [];
+
+  /**
+   * Instantiate a new pool of workers
+   * @param workerFileUrl - URL of the script for workers
+   * @param workerId - Id of the worker to be passed to the worker at launch time
+   */
+  constructor(private readonly workerFileUrl: URL, private readonly workerId: number) {}
+
+  /**
+   * Spawn a new instance of worker ready to handle new tasks
+   */
+  public spawnNewWorker(): PooledWorker<TSuccess, TPayload> {
+    let runIdInWorker = -1;
+    let faulty = false;
+    let registration: {
+      currentRunId: number;
+      onSuccess: OnSuccessCallback<TSuccess>;
+      onFailure: OnErrorCallback;
+    } | null = null;
+    const worker = new Worker(this.workerFileUrl, { workerData: { currentWorkerId: this.workerId } });
+
+    worker.on('message', (data: WorkerToPoolMessage<TSuccess>): void => {
+      if (registration === null || data.runId !== registration.currentRunId) {
+        return;
+      }
+      if (data.success) {
+        registration.onSuccess(data.output);
+      } else {
+        registration.onFailure(data.error);
+      }
+      registration = null;
+    });
+
+    worker.on('error', (err): void => {
+      faulty = true;
+      if (registration !== null) {
+        registration.onFailure(err);
+      }
+    });
+
+    worker.on('exit', (code): void => {
+      faulty = true;
+      if (registration !== null) {
+        registration.onFailure(new Error(`Worker stopped with exit code ${code}`));
+      }
+    });
+
+    const isFaulty = () => faulty;
+    const isAvailable = () => !isFaulty() && registration === null;
+
+    const pooledWorker: InternalPooledWorker<TSuccess, TPayload> = {
+      worker,
+      isAvailable,
+      isFaulty,
+      register: (payload, onSuccess, onFailure) => {
+        if (!isAvailable()) {
+          throw new Error('This instance of PooledWorker is currently in use');
+        }
+        const currentRunId = ++runIdInWorker;
+        registration = { currentRunId, onSuccess, onFailure };
+        const message: PoolToWorkerMessage<TPayload> = { payload, runId: currentRunId };
+        worker.postMessage(message);
+      },
+    };
+    this.workers.push(pooledWorker);
+    return pooledWorker;
+  }
+
+  /**
+   * Get the first available worker of the pool if any
+   */
+  public getFirstAvailableWorker(): PooledWorker<TSuccess, TPayload> | undefined {
+    return this.workers.find((w) => w.isAvailable());
+  }
+
+  /**
+   * Terminate all registered workers and drop them definitely for the pool
+   */
+  public terminateAllWorkers(): Promise<void> {
+    const dropped = this.workers.splice(0, this.workers.length); // clear all workers
+    return Promise.all(dropped.map((w) => w.worker.terminate())).then(() => undefined);
+  }
+}

--- a/packages/worker/src/internals/worker-pool/WorkerPool.ts
+++ b/packages/worker/src/internals/worker-pool/WorkerPool.ts
@@ -1,0 +1,23 @@
+import { BasicPool, OnErrorCallback, OnSuccessCallback } from './BasicPool';
+
+/**
+ * Advanced pool for workers
+ */
+export class WorkerPool<TSuccess, TPayload> {
+  private readonly pool: BasicPool<TSuccess, TPayload>;
+
+  constructor(workerFileUrl: URL, workerId: number) {
+    this.pool = new BasicPool<TSuccess, TPayload>(workerFileUrl, workerId);
+  }
+
+  /** Take one worker from the pool if any is available to handle queries or spawn a new one */
+  public acquireOne(payload: TPayload, onSuccess: OnSuccessCallback<TSuccess>, onFailure: OnErrorCallback): void {
+    const worker = this.pool.getFirstAvailableWorker() || this.pool.spawnNewWorker();
+    return worker.register(payload, onSuccess, onFailure);
+  }
+
+  /** Terminate any spawned worker */
+  public terminateAllWorkers(): Promise<void> {
+    return this.pool.terminateAllWorkers();
+  }
+}

--- a/packages/worker/test/internals/worker-pool/BasicPool.spec.ts
+++ b/packages/worker/test/internals/worker-pool/BasicPool.spec.ts
@@ -1,0 +1,206 @@
+import { BasicPool, PoolToWorkerMessage, WorkerToPoolMessage } from '../../../src/internals/worker-pool/BasicPool.js';
+import * as WorkerThreadsMock from 'node:worker_threads';
+
+describe('BasicPool', () => {
+  it('should instantly register handlers when spawning workers', () => {
+    // Arrange
+    const { Worker, on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const pool = new BasicPool(workerFileUrl, workerId);
+
+    // Act
+    pool.spawnNewWorker();
+
+    // Assert
+    expect(Worker).toHaveBeenCalledTimes(1);
+    expect(Worker).toHaveBeenCalledWith(workerFileUrl, { workerData: { currentWorkerId: workerId } });
+    expect(on).toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('should spawn workers marked as available and not faulty', () => {
+    // Arrange
+    mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const pool = new BasicPool(workerFileUrl, workerId);
+
+    // Act
+    const worker = pool.spawnNewWorker();
+
+    // Assert
+    expect(worker.isAvailable()).toBe(true);
+    expect(worker.isFaulty()).toBe(false);
+  });
+
+  it('should mark the worker as not available but not faulty while waiting answers', () => {
+    // Arrange
+    const { postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+
+    // Act
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Assert
+    expect(worker.isAvailable()).toBe(false);
+    expect(worker.isFaulty()).toBe(false);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('should call success handler and release the worker as soon as receiving a successful answer', () => {
+    // Arrange
+    const { on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const successMessage = 'success!';
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Act
+    const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
+    const receivedRunId = receivedMessage.runId;
+    const message: WorkerToPoolMessage<string> = { runId: receivedRunId, success: true, output: successMessage };
+    const onMessageHandler = on.mock.calls.find(([eventName]) => eventName === 'message')![1];
+    onMessageHandler(message); // emulate success
+
+    // Assert
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(successMessage);
+    expect(worker.isAvailable()).toBe(true);
+    expect(worker.isFaulty()).toBe(false);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('should call failure handler and release the worker as soon as receiving a failed answer', () => {
+    // Arrange
+    const { on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const errorMessage = 'oups there was an error!';
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Act
+    const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
+    const receivedRunId = receivedMessage.runId;
+    const message: WorkerToPoolMessage<string> = { runId: receivedRunId, success: false, error: errorMessage };
+    const onMessageHandler = on.mock.calls.find(([eventName]) => eventName === 'message')![1];
+    onMessageHandler(message); // emulate failure
+
+    // Assert
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledWith(errorMessage);
+    expect(worker.isAvailable()).toBe(true);
+    expect(worker.isFaulty()).toBe(false);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should ignore success or failures not related to the current run', () => {
+    // Arrange
+    const { on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Act
+    const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
+    const receivedRunId = receivedMessage.runId;
+    const message1: WorkerToPoolMessage<string> = { runId: receivedRunId - 1, success: true, output: 'm1' };
+    const message2: WorkerToPoolMessage<string> = { runId: receivedRunId + 1, success: true, output: 'm2' };
+    const message3: WorkerToPoolMessage<string> = { runId: receivedRunId + 1, success: false, error: 'm3' };
+    const onMessageHandler = on.mock.calls.find(([eventName]) => eventName === 'message')![1];
+    onMessageHandler(message1);
+    onMessageHandler(message2);
+    onMessageHandler(message3);
+
+    // Assert
+    expect(worker.isAvailable()).toBe(false); // still waiting messages for 'receivedRunId'
+    expect(worker.isFaulty()).toBe(false);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('should call failure handler and mark the worker as faulty when receiving error message', () => {
+    // Arrange
+    const { on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Act
+    const onErrorHandler = on.mock.calls.find(([eventName]) => eventName === 'error')![1];
+    onErrorHandler(new Error('boom!')); // emulate error message
+
+    // Assert
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(worker.isAvailable()).toBe(false); // we don't want to recover such worker
+    expect(worker.isFaulty()).toBe(true);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should call failure handler and mark the worker as faulty when receiving exit message', () => {
+    // Arrange
+    const { on, postMessage } = mockWorker();
+    const workerFileUrl = new URL('file:///worker.cjs');
+    const workerId = 0;
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+    const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+    const worker = pool.spawnNewWorker();
+    worker.register('to-worker', onSuccess, onFailure);
+
+    // Act
+    const exitCode = 101;
+    const onExitHandler = on.mock.calls.find(([eventName]) => eventName === 'exit')![1];
+    onExitHandler(exitCode); // emulate exit message
+
+    // Assert
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(worker.isAvailable()).toBe(false); // we don't want to recover such worker
+    expect(worker.isFaulty()).toBe(true);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+// Helpers
+
+function mockWorker() {
+  const Worker = jest.spyOn(WorkerThreadsMock, 'Worker');
+  const on = jest.fn();
+  const postMessage = jest.fn();
+  Worker.mockImplementation(
+    () =>
+      ({
+        on,
+        postMessage,
+      } as unknown as WorkerThreadsMock.Worker)
+  );
+  return { Worker, on, postMessage };
+}

--- a/packages/worker/test/main.spec.ts
+++ b/packages/worker/test/main.spec.ts
@@ -8,35 +8,49 @@ import { passingProperty, failingProperty, blockEventLoopProperty } from './main
 
 if (isMainThread) {
   describe('workerProperty', () => {
-    const assertOptions: fc.Parameters<unknown> = { timeout: 1000, numRuns: 5, endOnFailure: true };
+    const jestTimeout = 10000;
+    const assertTimeout = 1000;
+    const assertOptions: fc.Parameters<unknown> = { timeout: assertTimeout };
 
-    it('should not timeout when predicate iterate up to the end really quickly', async () => {
-      // Arrange / Act / Assert
-      try {
-        await expect(fc.assert(passingProperty, assertOptions)).resolves.not.toThrow();
-      } finally {
-        clearAllWorkersFor(passingProperty);
-      }
-    }, 10000);
+    it(
+      'should not timeout when predicate iterates up to the end really quickly',
+      async () => {
+        // Arrange / Act / Assert
+        try {
+          await expect(fc.assert(passingProperty, assertOptions)).resolves.not.toThrow();
+        } finally {
+          clearAllWorkersFor(passingProperty);
+        }
+      },
+      jestTimeout
+    );
 
-    it('should not timeout but report failing predicates', async () => {
-      // Arrange / Act / Assert
-      try {
-        await expect(fc.assert(failingProperty, assertOptions)).rejects.toThrowError(/I'm a failing property/);
-      } finally {
-        clearAllWorkersFor(failingProperty);
-      }
-    }, 10000);
+    it(
+      'should not timeout but report failing predicates',
+      async () => {
+        // Arrange / Act / Assert
+        try {
+          await expect(fc.assert(failingProperty, assertOptions)).rejects.toThrowError(/I'm a failing property/);
+        } finally {
+          clearAllWorkersFor(failingProperty);
+        }
+      },
+      jestTimeout
+    );
 
-    it('should timeout when predicate fully block the event loop', async () => {
-      // Arrange / Act / Assert
-      try {
-        await expect(fc.assert(blockEventLoopProperty, assertOptions)).rejects.toThrowError(
-          /Property timeout: exceeded limit of 1000 milliseconds/
-        );
-      } finally {
-        clearAllWorkersFor(blockEventLoopProperty);
-      }
-    }, 10000);
+    it(
+      'should timeout when predicate fully blocks the event loop',
+      async () => {
+        // Arrange / Act / Assert
+        try {
+          await expect(
+            fc.assert(blockEventLoopProperty, { ...assertOptions, numRuns: 5, endOnFailure: true })
+          ).rejects.toThrowError(/Property timeout: exceeded limit of 1000 milliseconds/);
+        } finally {
+          clearAllWorkersFor(blockEventLoopProperty);
+        }
+      },
+      jestTimeout
+    );
   });
 }


### PR DESCRIPTION
For better performances, we now share workers accross distinct runs of the predicate (as soon as the worker can be re-used safely). It highly increase the performance of the worker mode in nominal cases while letting the one of timeout code a bit as-is.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
