### PR TITLE
🏷️(jest) Wrongly typed `itProp` when receiving `examples`

### DIFF
--- a/.yarn/versions/4ac099e8.yml
+++ b/.yarn/versions/4ac099e8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": patch

--- a/packages/jest/src/jest-fast-check.ts
+++ b/packages/jest/src/jest-fast-check.ts
@@ -16,14 +16,14 @@ function wrapProp<Ts extends [any] | any[]>(prop: Prop<Ts>): PromiseProp<Ts> {
   return (...args: Ts) => Promise.resolve(prop(...args));
 }
 
-function internalTestPropExecute<Ts extends [any] | any[]>(
+function internalTestPropExecute<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
   testFn: It | It['only' | 'skip' | 'failing' | 'concurrent'] | It['concurrent']['only' | 'skip' | 'failing'],
   label: string,
   arbitraries: ArbitraryTuple<Ts>,
   prop: Prop<Ts>,
-  params?: fc.Parameters<Ts>
+  params?: fc.Parameters<TsParameters>
 ): void {
-  const customParams: fc.Parameters<Ts> = { ...params };
+  const customParams: fc.Parameters<TsParameters> = { ...params };
   if (customParams.seed === undefined) {
     const seedFromGlobals = fc.readConfigureGlobal().seed;
     if (seedFromGlobals !== undefined) {
@@ -48,11 +48,11 @@ function internalTestPropExecute<Ts extends [any] | any[]>(
 
 // Mimic Failing from @jest/types
 function internalTestPropFailing(testFn: It['failing'] | It['concurrent']['failing']) {
-  function base<Ts extends [any] | any[]>(
+  function base<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
     label: string,
     arbitraries: ArbitraryTuple<Ts>,
     prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
+    params?: fc.Parameters<TsParameters>
   ): void {
     internalTestPropExecute(testFn, label, arbitraries, prop, params);
   }
@@ -64,11 +64,11 @@ function internalTestPropFailing(testFn: It['failing'] | It['concurrent']['faili
 
 // Mimic ItBase from @jest/types
 function internalTestPropBase(testFn: It['only' | 'skip'] | It['concurrent']['only' | 'skip']) {
-  function base<Ts extends [any] | any[]>(
+  function base<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
     label: string,
     arbitraries: ArbitraryTuple<Ts>,
     prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
+    params?: fc.Parameters<TsParameters>
   ): void {
     internalTestPropExecute(testFn, label, arbitraries, prop, params);
   }
@@ -80,11 +80,11 @@ function internalTestPropBase(testFn: It['only' | 'skip'] | It['concurrent']['on
 
 // Mimic ItConcurrentExtended from @jest/types
 function internalTestPropConcurrent(testFn: It | It['concurrent']) {
-  function base<Ts extends [any] | any[]>(
+  function base<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
     label: string,
     arbitraries: ArbitraryTuple<Ts>,
     prop: Prop<Ts>,
-    params?: fc.Parameters<Ts>
+    params?: fc.Parameters<TsParameters>
   ): void {
     internalTestPropExecute(testFn, label, arbitraries, prop, params);
   }

--- a/packages/jest/test/types.ts
+++ b/packages/jest/test/types.ts
@@ -1,0 +1,13 @@
+import { itProp, fc } from '@fast-check/jest';
+
+// should accept examples with stricter types than arbitraries without requiring explicit typings
+// case coming from: https://github.com/facebook/jest/pull/13493
+itProp('test', [fc.anything(), fc.anything()], (_a, _b) => undefined, { examples: [[0, 5e-324]] });
+
+// should accept examples with same types as arbitraries without requiring explicit typings
+// case coming from: https://github.com/facebook/jest/pull/13493
+itProp('test', [fc.double(), fc.double()], (_a, _b) => undefined, { examples: [[0, 5e-324]] });
+
+declare const var1: number | string;
+// @ts-expect-error - should reject examples with types more generic than passed arbitraries
+itProp('test', [fc.double(), fc.double()], (_a, _b) => undefined, { examples: [[var1, var1]] });


### PR DESCRIPTION
This typing issue has been detected thanks to the PR https://github.com/facebook/jest/pull/13493. It showed a mismatch behaviour between fast-check and @fast-check/jest. With this PR we patch the issue and make sure it will not happen again by adding dedicated tests on it.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
