### PR TITLE
🐛(poisoning) Switch from descriptors to descriptor for Node 18

### DIFF
--- a/.yarn/versions/dbf7e0b4.yml
+++ b/.yarn/versions/dbf7e0b4.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/poisoning": patch
+
+declined:
+  - fast-check

--- a/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
+++ b/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
@@ -3,7 +3,7 @@ import { EntriesSymbol, HasSymbol } from './PoisoningFreeMap.js';
 import { AllGlobals, GlobalDetails } from './types/AllGlobals.js';
 
 const SString = String;
-const safeObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const safeObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
 const safeObjectGetOwnPropertySymbols = Object.getOwnPropertySymbols;
 const safeObjectIs = Object.is;
@@ -33,7 +33,6 @@ export function trackDiffsOnGlobals(
       continue;
     }
     const name = globalDetails.name;
-    const currentDescriptors = safeObjectGetOwnPropertyDescriptors(instance);
     const initialProperties = globalDetails.properties;
     const initialPropertiesList = [...initialProperties[EntriesSymbol]()];
 
@@ -46,7 +45,8 @@ export function trackDiffsOnGlobals(
       if (!isEligibleProperty(globalDetails, SString(propertyName))) {
         continue;
       }
-      if (!(propertyName in (currentDescriptors as any))) {
+      const currentDescriptor = safeObjectGetOwnPropertyDescriptor(instance, propertyName);
+      if (currentDescriptor === undefined) {
         observedDiffs[PushSymbol]({
           keyName: SString(propertyName),
           fullyQualifiedKeyName: name + '.' + SString(propertyName),
@@ -57,9 +57,9 @@ export function trackDiffsOnGlobals(
           globalDetails,
         });
       } else if (
-        !safeObjectIs(initialPropertyDescriptor.value, (currentDescriptors as any)[propertyName].value) ||
-        !safeObjectIs(initialPropertyDescriptor.get, (currentDescriptors as any)[propertyName].get) ||
-        !safeObjectIs(initialPropertyDescriptor.set, (currentDescriptors as any)[propertyName].set)
+        !safeObjectIs(initialPropertyDescriptor.value, currentDescriptor.value) ||
+        !safeObjectIs(initialPropertyDescriptor.get, currentDescriptor.get) ||
+        !safeObjectIs(initialPropertyDescriptor.set, currentDescriptor.set)
       ) {
         observedDiffs[PushSymbol]({
           keyName: SString(propertyName),


### PR DESCRIPTION
It seems that `Object.getOwnPropertyDescriptors` is not as reliable as `Object.getOwnPropertyDescriptor` in Node 18 when called on `globalThis`.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
