### PR TITLE
Add feature incompatibility warning to the docs 📝 

### DIFF
--- a/packages/fast-check/documentation/Tips.md
+++ b/packages/fast-check/documentation/Tips.md
@@ -397,6 +397,8 @@ fc.assert(
 )
 ```
 
+Note that this feature is not compatible with the use [custom examples](#add-custom-examples-next-to-generated-ones). If you want to use custom examples you cannot use `fc.context()`.
+
 ## Preview generated values
 
 Before writing down your test, it might be great to confirm that the arbitrary you will be using produce the values you want.
@@ -533,6 +535,8 @@ fc.assert(fc.property(fc.string(), fc.string(), fc.string(), myCheckFunction), {
 ```
 
 Please keep in mind that property based testing frameworks are fully able to find corner-cases with no help at all.
+
+Note that this feature is not compatible with the use of `Context`. If you want to [log within a predicate](#log-within-a-predicate), you cannot use custom examples. Alternatively, if you wish to use customm examples, you must remove `fc.context()`.
 
 ## Simplify user definable corner cases
 


### PR DESCRIPTION
This PR is an alternative to [this PR](https://github.com/dubzzz/fast-check/pull/3458), and addresses this [issue](https://github.com/dubzzz/fast-check/issues/3459). Ideally I would see a fix the incompatibility itself, but if that is off the table, I think at least a warning is in order. This allows the users themselves to decide which of the two features they want to use. 

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [x] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
