### PR TITLE
✨ No timeout for beforeEach or afterEach

### DIFF
--- a/.yarn/versions/d036f217.yml
+++ b/.yarn/versions/d036f217.yml
@@ -1,0 +1,7 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/check/property/AsyncProperty.generic.ts
+++ b/packages/fast-check/src/check/property/AsyncProperty.generic.ts
@@ -101,8 +101,18 @@ export class AsyncProperty<Ts> implements IAsyncPropertyWithHooks<Ts> {
     return this.arb.shrink(value.value_, safeContext).map(noUndefinedAsContext);
   }
 
-  async run(v: Ts): Promise<PreconditionFailure | PropertyFailure | null> {
+  async runBeforeEach(): Promise<void> {
     await this.beforeEachHook();
+  }
+
+  async runAfterEach(): Promise<void> {
+    await this.afterEachHook();
+  }
+
+  async run(v: Ts, dontRunHook?: boolean): Promise<PreconditionFailure | PropertyFailure | null> {
+    if (!dontRunHook) {
+      await this.beforeEachHook();
+    }
     try {
       const output = await this.predicate(v);
       return output == null || output === true
@@ -120,7 +130,9 @@ export class AsyncProperty<Ts> implements IAsyncPropertyWithHooks<Ts> {
       }
       return { error: err, errorMessage: String(err) };
     } finally {
-      await this.afterEachHook();
+      if (!dontRunHook) {
+        await this.afterEachHook();
+      }
     }
   }
 

--- a/packages/fast-check/src/check/property/IRawProperty.ts
+++ b/packages/fast-check/src/check/property/IRawProperty.ts
@@ -71,7 +71,7 @@ export interface IRawProperty<Ts, IsAsync extends boolean = boolean> {
    */
   run(
     v: Ts,
-    dontRunHook: boolean
+    dontRunHook?: boolean
   ):
     | (IsAsync extends true ? Promise<PreconditionFailure | PropertyFailure | null> : never)
     | (IsAsync extends false ? PreconditionFailure | PropertyFailure | null : never);

--- a/packages/fast-check/src/check/property/IRawProperty.ts
+++ b/packages/fast-check/src/check/property/IRawProperty.ts
@@ -66,13 +66,27 @@ export interface IRawProperty<Ts, IsAsync extends boolean = boolean> {
   /**
    * Check the predicate for v
    * @param v - Value of which we want to check the predicate
+   * @param dontRunHook - Do not run beforeEach and afterEach hooks within run
    * @remarks Since 0.0.7
    */
   run(
-    v: Ts
+    v: Ts,
+    dontRunHook: boolean
   ):
     | (IsAsync extends true ? Promise<PreconditionFailure | PropertyFailure | null> : never)
     | (IsAsync extends false ? PreconditionFailure | PropertyFailure | null : never);
+
+  /**
+   * Run before each hook
+   * @remarks Since 3.4.0
+   */
+  runBeforeEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
+
+  /**
+   * Run after each hook
+   * @remarks Since 3.4.0
+   */
+  runAfterEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
 }
 
 /**

--- a/packages/fast-check/src/check/property/IgnoreEqualValuesProperty.ts
+++ b/packages/fast-check/src/check/property/IgnoreEqualValuesProperty.ts
@@ -44,11 +44,11 @@ export class IgnoreEqualValuesProperty<Ts, IsAsync extends boolean> implements I
   private coveredCases: Map<string, ReturnType<IRawProperty<Ts, IsAsync>['run']>> = new Map();
 
   constructor(readonly property: IRawProperty<Ts, IsAsync>, readonly skipRuns: boolean) {
-    const sourceRunBeforeEach = this.property.runBeforeEach;
-    const sourceRunAfterEach = this.property.runAfterEach;
-    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
-      this.runBeforeEach = () => sourceRunBeforeEach();
-      this.runAfterEach = () => sourceRunAfterEach();
+    if (this.property.runBeforeEach !== undefined && this.property.runAfterEach !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runBeforeEach = () => this.property.runBeforeEach!();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runAfterEach = () => this.property.runAfterEach!();
     }
   }
 

--- a/packages/fast-check/src/check/property/IgnoreEqualValuesProperty.ts
+++ b/packages/fast-check/src/check/property/IgnoreEqualValuesProperty.ts
@@ -39,9 +39,18 @@ function fromCachedUnsafe<Ts, IsAsync extends boolean>(
 
 /** @internal */
 export class IgnoreEqualValuesProperty<Ts, IsAsync extends boolean> implements IRawProperty<Ts, IsAsync> {
+  runBeforeEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
+  runAfterEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
   private coveredCases: Map<string, ReturnType<IRawProperty<Ts, IsAsync>['run']>> = new Map();
 
-  constructor(readonly property: IRawProperty<Ts, IsAsync>, readonly skipRuns: boolean) {}
+  constructor(readonly property: IRawProperty<Ts, IsAsync>, readonly skipRuns: boolean) {
+    const sourceRunBeforeEach = this.property.runBeforeEach;
+    const sourceRunAfterEach = this.property.runAfterEach;
+    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
+      this.runBeforeEach = () => sourceRunBeforeEach();
+      this.runAfterEach = () => sourceRunAfterEach();
+    }
+  }
 
   isAsync(): IsAsync {
     return this.property.isAsync();
@@ -55,7 +64,7 @@ export class IgnoreEqualValuesProperty<Ts, IsAsync extends boolean> implements I
     return this.property.shrink(value);
   }
 
-  run(v: Ts): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
+  run(v: Ts, dontRunHook: boolean): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
     const stringifiedValue = stringify(v);
     if (this.coveredCases.has(stringifiedValue)) {
       const lastOutput = this.coveredCases.get(stringifiedValue) as ReturnType<IRawProperty<Ts, IsAsync>['run']>;
@@ -64,7 +73,7 @@ export class IgnoreEqualValuesProperty<Ts, IsAsync extends boolean> implements I
       }
       return fromCachedUnsafe(lastOutput, this.property.isAsync());
     }
-    const out = this.property.run(v);
+    const out = this.property.run(v, dontRunHook);
     this.coveredCases.set(stringifiedValue, out);
     return out;
   }

--- a/packages/fast-check/src/check/property/Property.generic.ts
+++ b/packages/fast-check/src/check/property/Property.generic.ts
@@ -117,8 +117,18 @@ export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
     return this.arb.shrink(value.value_, safeContext).map(noUndefinedAsContext);
   }
 
-  run(v: Ts): PreconditionFailure | PropertyFailure | null {
+  runBeforeEach(): void {
     this.beforeEachHook();
+  }
+
+  runAfterEach(): void {
+    this.afterEachHook();
+  }
+
+  run(v: Ts, dontRunHook?: boolean): PreconditionFailure | PropertyFailure | null {
+    if (!dontRunHook) {
+      this.beforeEachHook();
+    }
     try {
       const output = this.predicate(v);
       return output == null || output === true
@@ -136,7 +146,9 @@ export class Property<Ts> implements IProperty<Ts>, IPropertyWithHooks<Ts> {
       }
       return { error: err, errorMessage: String(err) };
     } finally {
-      this.afterEachHook();
+      if (!dontRunHook) {
+        this.afterEachHook();
+      }
     }
   }
 

--- a/packages/fast-check/src/check/property/SkipAfterProperty.ts
+++ b/packages/fast-check/src/check/property/SkipAfterProperty.ts
@@ -17,11 +17,11 @@ export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawPrope
     readonly interruptExecution: boolean
   ) {
     this.skipAfterTime = this.getTime() + timeLimit;
-    const sourceRunBeforeEach = this.property.runBeforeEach;
-    const sourceRunAfterEach = this.property.runAfterEach;
-    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
-      this.runBeforeEach = () => sourceRunBeforeEach();
-      this.runAfterEach = () => sourceRunAfterEach();
+    if (this.property.runBeforeEach !== undefined && this.property.runAfterEach !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runBeforeEach = () => this.property.runBeforeEach!();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runAfterEach = () => this.property.runAfterEach!();
     }
   }
 

--- a/packages/fast-check/src/check/property/SkipAfterProperty.ts
+++ b/packages/fast-check/src/check/property/SkipAfterProperty.ts
@@ -6,7 +6,10 @@ import { IRawProperty } from './IRawProperty';
 
 /** @internal */
 export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawProperty<Ts, IsAsync> {
+  runBeforeEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
+  runAfterEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
   private skipAfterTime: number;
+
   constructor(
     readonly property: IRawProperty<Ts, IsAsync>,
     readonly getTime: () => number,
@@ -14,6 +17,12 @@ export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawPrope
     readonly interruptExecution: boolean
   ) {
     this.skipAfterTime = this.getTime() + timeLimit;
+    const sourceRunBeforeEach = this.property.runBeforeEach;
+    const sourceRunAfterEach = this.property.runAfterEach;
+    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
+      this.runBeforeEach = () => sourceRunBeforeEach();
+      this.runAfterEach = () => sourceRunAfterEach();
+    }
   }
 
   isAsync(): IsAsync {
@@ -28,7 +37,7 @@ export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawPrope
     return this.property.shrink(value);
   }
 
-  run(v: Ts): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
+  run(v: Ts, dontRunHook: boolean): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
     if (this.getTime() >= this.skipAfterTime) {
       const preconditionFailure = new PreconditionFailure(this.interruptExecution);
       if (this.isAsync()) {
@@ -37,6 +46,6 @@ export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawPrope
         return preconditionFailure as any; // !IsAsync => PreconditionFailure | string | null
       }
     }
-    return this.property.run(v);
+    return this.property.run(v, dontRunHook);
   }
 }

--- a/packages/fast-check/src/check/property/TimeoutProperty.ts
+++ b/packages/fast-check/src/check/property/TimeoutProperty.ts
@@ -30,11 +30,11 @@ export class TimeoutProperty<Ts> implements IRawProperty<Ts, true> {
   runAfterEach?: () => Promise<void>;
 
   constructor(readonly property: IRawProperty<Ts>, readonly timeMs: number) {
-    const sourceRunBeforeEach = this.property.runBeforeEach;
-    const sourceRunAfterEach = this.property.runAfterEach;
-    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
-      this.runBeforeEach = () => Promise.resolve(sourceRunBeforeEach());
-      this.runAfterEach = () => Promise.resolve(sourceRunAfterEach());
+    if (this.property.runBeforeEach !== undefined && this.property.runAfterEach !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runBeforeEach = () => Promise.resolve(this.property.runBeforeEach!());
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runAfterEach = () => Promise.resolve(this.property.runAfterEach!());
     }
   }
 

--- a/packages/fast-check/src/check/property/UnbiasedProperty.ts
+++ b/packages/fast-check/src/check/property/UnbiasedProperty.ts
@@ -9,11 +9,11 @@ export class UnbiasedProperty<Ts, IsAsync extends boolean> implements IRawProper
   runAfterEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
 
   constructor(readonly property: IRawProperty<Ts, IsAsync>) {
-    const sourceRunBeforeEach = this.property.runBeforeEach;
-    const sourceRunAfterEach = this.property.runAfterEach;
-    if (sourceRunBeforeEach !== undefined && sourceRunAfterEach !== undefined) {
-      this.runBeforeEach = () => sourceRunBeforeEach();
-      this.runAfterEach = () => sourceRunAfterEach();
+    if (this.property.runBeforeEach !== undefined && this.property.runAfterEach !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runBeforeEach = () => this.property.runBeforeEach!();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.runAfterEach = () => this.property.runAfterEach!();
     }
   }
 

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -27,9 +27,18 @@ function runIt<Ts>(
   verbose: VerbosityLevel,
   interruptedAsFailure: boolean
 ): RunExecution<Ts> {
+  const isModernProperty = property.runBeforeEach !== undefined && property.runAfterEach !== undefined;
   const runner = new RunnerIterator(sourceValues, shrink, verbose, interruptedAsFailure);
   for (const v of runner) {
-    const out = property.run(v) as PreconditionFailure | PropertyFailure | null;
+    if (isModernProperty) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      property.runBeforeEach!();
+    }
+    const out = property.run(v, isModernProperty) as PreconditionFailure | PropertyFailure | null;
+    if (isModernProperty) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      property.runAfterEach!();
+    }
     runner.handleResult(out);
   }
   return runner.runExecution;
@@ -43,9 +52,18 @@ async function asyncRunIt<Ts>(
   verbose: VerbosityLevel,
   interruptedAsFailure: boolean
 ): Promise<RunExecution<Ts>> {
+  const isModernProperty = property.runBeforeEach !== undefined && property.runAfterEach !== undefined;
   const runner = new RunnerIterator(sourceValues, shrink, verbose, interruptedAsFailure);
   for (const v of runner) {
-    const out = await property.run(v);
+    if (isModernProperty) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await property.runBeforeEach!();
+    }
+    const out = await property.run(v, isModernProperty);
+    if (isModernProperty) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await property.runAfterEach!();
+    }
     runner.handleResult(out);
   }
   return runner.runExecution;

--- a/packages/fast-check/test/e2e/Timeout.spec.ts
+++ b/packages/fast-check/test/e2e/Timeout.spec.ts
@@ -1,0 +1,28 @@
+import * as fc from '../../src/fast-check';
+import { seed } from './seed';
+
+describe(`Timeout (seed: ${seed})`, () => {
+  it('should always run beforeEach and afterEach even in case of timeout', async () => {
+    let numRuns = 0;
+    const beforeEach = jest.fn().mockResolvedValue(undefined);
+    const afterEach = jest.fn().mockResolvedValue(undefined);
+    const out = await fc.check(
+      fc
+        .asyncProperty(fc.integer().noShrink(), async (_x) => {
+          ++numRuns;
+          await new Promise(() => {}); // never ending promise
+        })
+        .beforeEach(beforeEach)
+        .afterEach(afterEach),
+      { timeout: 0 }
+    );
+    expect(out.failed).toBe(true);
+    expect(out.interrupted).toBe(false);
+    expect(out.numRuns).toBe(1); // only once, it timeouts on first run and then shrink (no-shrink here)
+    expect(out.numShrinks).toBe(0);
+    expect(out.numSkips).toBe(0);
+    expect(numRuns).toBe(1);
+    expect(beforeEach).toHaveBeenCalledTimes(1);
+    expect(afterEach).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fast-check/test/unit/check/property/AsyncProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/AsyncProperty.spec.ts
@@ -12,7 +12,7 @@ import { Stream } from '../../../../src/stream/Stream';
 import { PropertyFailure } from '../../../../src/check/property/IRawProperty';
 import fc from 'fast-check';
 
-describe.each([[true], [false]])('AsyncProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
+describe.each([[true], [false]])('AsyncProperty (dontRunHook: %p)', (dontRunHook) => {
   afterEach(() => resetConfigureGlobal());
 
   it('Should fail if predicate fails', async () => {

--- a/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
@@ -2,7 +2,7 @@ import { IgnoreEqualValuesProperty } from '../../../../src/check/property/Ignore
 import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure';
 import { fakeProperty } from './__test-helpers__/PropertyHelpers';
 
-describe.each([[true], [false]])('IgnoreEqualValuesProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
+describe.each([[true], [false]])('IgnoreEqualValuesProperty (dontRunHook: %p)', (dontRunHook) => {
   it.each`
     skipRuns
     ${false}

--- a/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
@@ -2,22 +2,33 @@ import { IgnoreEqualValuesProperty } from '../../../../src/check/property/Ignore
 import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure';
 import { fakeProperty } from './__test-helpers__/PropertyHelpers';
 
-describe('IgnoreEqualValuesProperty', () => {
+describe.each([[true], [false]])('IgnoreEqualValuesProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
   it.each`
     skipRuns
     ${false}
     ${true}
   `('should not call run on the decorated property when property is run on the same value', ({ skipRuns }) => {
     // Arrange
-    const { instance: decoratedProperty, run } = fakeProperty();
+    const { instance: decoratedProperty, run, runBeforeEach, runAfterEach } = fakeProperty();
 
     // Act
     const property = new IgnoreEqualValuesProperty(decoratedProperty, skipRuns);
-    property.run(1);
-    property.run(1);
+    if (dontRunHook) {
+      property.runBeforeEach!();
+      property.run(1, true);
+      property.runAfterEach!();
+      property.runBeforeEach!();
+      property.run(1, true);
+      property.runAfterEach!();
+    } else {
+      property.run(1, false);
+      property.run(1, false);
+    }
 
     // Assert
     expect(run).toHaveBeenCalledTimes(1);
+    expect(runBeforeEach).toHaveBeenCalledTimes(2);
+    expect(runAfterEach).toHaveBeenCalledTimes(2);
   });
 
   it.each`
@@ -40,8 +51,19 @@ describe('IgnoreEqualValuesProperty', () => {
 
       // Act
       const property = new IgnoreEqualValuesProperty(decoratedProperty, false);
-      const initialRunOutput = property.run(null);
-      const secondRunOutput = property.run(null);
+      let initialRunOutput: ReturnType<typeof property.run>;
+      let secondRunOutput: ReturnType<typeof property.run>;
+      if (dontRunHook) {
+        property.runBeforeEach!();
+        initialRunOutput = property.run(null, true);
+        property.runAfterEach!();
+        property.runBeforeEach!();
+        secondRunOutput = property.run(null, true);
+        property.runAfterEach!();
+      } else {
+        initialRunOutput = property.run(null, false);
+        secondRunOutput = property.run(null, false);
+      }
 
       // Assert
       expect(secondRunOutput).toBe(initialRunOutput);
@@ -68,8 +90,19 @@ describe('IgnoreEqualValuesProperty', () => {
 
       // Act
       const property = new IgnoreEqualValuesProperty(decoratedProperty, true);
-      const initialRunOutput = await property.run(null);
-      const secondRunOutput = await property.run(null);
+      let initialRunOutput: ReturnType<typeof property.run>;
+      let secondRunOutput: ReturnType<typeof property.run>;
+      if (dontRunHook) {
+        await property.runBeforeEach!();
+        initialRunOutput = await property.run(null, true);
+        await property.runAfterEach!();
+        await property.runBeforeEach!();
+        secondRunOutput = await property.run(null, true);
+        await property.runAfterEach!();
+      } else {
+        initialRunOutput = await property.run(null, false);
+        secondRunOutput = await property.run(null, false);
+      }
 
       // Assert
       if (initialRunOutput === null) {
@@ -89,14 +122,25 @@ describe('IgnoreEqualValuesProperty', () => {
     ${true}
   `('should run decorated property when property is run on another value', ({ skipRuns }) => {
     // Arrange
-    const { instance: decoratedProperty, run } = fakeProperty();
+    const { instance: decoratedProperty, run, runBeforeEach, runAfterEach } = fakeProperty();
 
     // Act
     const property = new IgnoreEqualValuesProperty(decoratedProperty, skipRuns);
-    property.run(1);
-    property.run(2);
+    if (dontRunHook) {
+      property.runBeforeEach!();
+      property.run(1, true);
+      property.runAfterEach!();
+      property.runBeforeEach!();
+      property.run(2, true);
+      property.runAfterEach!();
+    } else {
+      property.run(1, false);
+      property.run(2, false);
+    }
 
     // Assert
     expect(run).toHaveBeenCalledTimes(2);
+    expect(runBeforeEach).toHaveBeenCalledTimes(2);
+    expect(runAfterEach).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
@@ -29,8 +29,14 @@ describe.each([[true], [false]])('IgnoreEqualValuesProperty (dontRunHook: %p)', 
 
       // Assert
       expect(run).toHaveBeenCalledTimes(1);
-      expect(runBeforeEach).toHaveBeenCalledTimes(2);
-      expect(runAfterEach).toHaveBeenCalledTimes(2);
+      if (dontRunHook) {
+        // We may not want to run them twice but once in such context, but so far we do
+        expect(runBeforeEach).toHaveBeenCalledTimes(2);
+        expect(runAfterEach).toHaveBeenCalledTimes(2);
+      } else {
+        expect(runBeforeEach).toHaveBeenCalledTimes(1);
+        expect(runAfterEach).toHaveBeenCalledTimes(1);
+      }
     }
   );
 

--- a/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/IgnoreEqualValuesProperty.spec.ts
@@ -7,29 +7,32 @@ describe.each([[true], [false]])('IgnoreEqualValuesProperty (dontRunHook: %p)', 
     skipRuns
     ${false}
     ${true}
-  `('should not call run on the decorated property when property is run on the same value', ({ skipRuns }) => {
-    // Arrange
-    const { instance: decoratedProperty, run, runBeforeEach, runAfterEach } = fakeProperty();
+  `(
+    'should not call run on the decorated property when property is run on the same value for skipRuns=$skipRuns',
+    ({ skipRuns }) => {
+      // Arrange
+      const { instance: decoratedProperty, run, runBeforeEach, runAfterEach } = fakeProperty();
 
-    // Act
-    const property = new IgnoreEqualValuesProperty(decoratedProperty, skipRuns);
-    if (dontRunHook) {
-      property.runBeforeEach!();
-      property.run(1, true);
-      property.runAfterEach!();
-      property.runBeforeEach!();
-      property.run(1, true);
-      property.runAfterEach!();
-    } else {
-      property.run(1, false);
-      property.run(1, false);
+      // Act
+      const property = new IgnoreEqualValuesProperty(decoratedProperty, skipRuns);
+      if (dontRunHook) {
+        property.runBeforeEach!();
+        property.run(1, true);
+        property.runAfterEach!();
+        property.runBeforeEach!();
+        property.run(1, true);
+        property.runAfterEach!();
+      } else {
+        property.run(1, false);
+        property.run(1, false);
+      }
+
+      // Assert
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(runBeforeEach).toHaveBeenCalledTimes(2);
+      expect(runAfterEach).toHaveBeenCalledTimes(2);
     }
-
-    // Assert
-    expect(run).toHaveBeenCalledTimes(1);
-    expect(runBeforeEach).toHaveBeenCalledTimes(2);
-    expect(runAfterEach).toHaveBeenCalledTimes(2);
-  });
+  );
 
   it.each`
     originalValue                           | originalValuePretty            | isAsync

--- a/packages/fast-check/test/unit/check/property/Property.spec.ts
+++ b/packages/fast-check/test/unit/check/property/Property.spec.ts
@@ -12,7 +12,7 @@ import { Stream } from '../../../../src/stream/Stream';
 import { PropertyFailure } from '../../../../src/check/property/IRawProperty';
 import fc from 'fast-check';
 
-describe.each([[true], [false]])('Property (dontRunHook: $dontRunHook)', (dontRunHook) => {
+describe.each([[true], [false]])('Property (dontRunHook: %p)', (dontRunHook) => {
   afterEach(() => resetConfigureGlobal());
 
   it('Should fail if predicate fails', () => {

--- a/packages/fast-check/test/unit/check/property/Property.spec.ts
+++ b/packages/fast-check/test/unit/check/property/Property.spec.ts
@@ -12,14 +12,20 @@ import { Stream } from '../../../../src/stream/Stream';
 import { PropertyFailure } from '../../../../src/check/property/IRawProperty';
 import fc from 'fast-check';
 
-describe('Property', () => {
+describe.each([[true], [false]])('Property (dontRunHook: $dontRunHook)', (dontRunHook) => {
   afterEach(() => resetConfigureGlobal());
 
   it('Should fail if predicate fails', () => {
     const p = property(stubArb.single(8), (_arg: number) => {
       return false;
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).not.toBe(null); // property fails
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).not.toBe(null); // property fails
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
   });
   it('Should fail if predicate throws an Error', () => {
     // Arrange
@@ -30,7 +36,13 @@ describe('Property', () => {
     });
 
     // Act
-    const out = p.run(p.generate(stubRng.mutable.nocall()).value);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    const out = p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
 
     // Assert
     expect((out as PropertyFailure).errorMessage).toContain('predicate throws');
@@ -44,7 +56,13 @@ describe('Property', () => {
     });
 
     // Act
-    const out = p.run(p.generate(stubRng.mutable.nocall()).value);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    const out = p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
 
     // Assert
     expect(out).toEqual({
@@ -62,7 +80,13 @@ describe('Property', () => {
         });
 
         // Act
-        const out = p.run(p.generate(stubRng.mutable.nocall()).value);
+        if (dontRunHook) {
+          p.runBeforeEach!();
+        }
+        const out = p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook);
+        if (dontRunHook) {
+          p.runAfterEach!();
+        }
 
         // Assert
         expect(out).toEqual({ error: stuff, errorMessage: expect.any(String) });
@@ -76,7 +100,13 @@ describe('Property', () => {
       doNotResetThisValue = true;
       return false;
     });
-    const out = p.run(p.generate(stubRng.mutable.nocall()).value);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    const out = p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(PreconditionFailure.isFailure(out)).toBe(true);
     expect(doNotResetThisValue).toBe(false); // does not run code after the failing precondition
   });
@@ -84,11 +114,23 @@ describe('Property', () => {
     const p = property(stubArb.single(8), (_arg: number) => {
       return true;
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
   });
   it('Should succeed if predicate does not return anything', () => {
     const p = property(stubArb.single(8), (_arg: number) => {});
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
   });
   it('Should call and forward arbitraries one time', () => {
     let oneCallToPredicate = false;
@@ -108,7 +150,13 @@ describe('Property', () => {
     for (let idx = 0; idx !== arbs.length; ++idx) {
       expect(arbs[idx].calledOnce).toBe(false); // property creation does not trigger call to generator #${idx + 1}
     }
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(oneCallToPredicate).toBe(true);
     for (let idx = 0; idx !== arbs.length; ++idx) {
       expect(arbs[idx].calledOnce).toBe(true); //  Generator #${idx + 1} called by run
@@ -163,7 +211,13 @@ describe('Property', () => {
         previousBeforeEach();
         prob.beforeEachCalled = true;
       });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
   });
   it('Should execute both global and local beforeEach hooks before the test', () => {
     const globalBeforeEach = jest.fn();
@@ -179,7 +233,13 @@ describe('Property', () => {
       prob.beforeEachCalled = true;
       globalBeforeEach();
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(globalBeforeEach).toBeCalledTimes(1);
   });
   it('Should use global beforeEach as default if specified', () => {
@@ -192,7 +252,13 @@ describe('Property', () => {
       prob.beforeEachCalled = false;
       return beforeEachCalled;
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
   });
   it('should fail if global asyncBeforeEach has been set', () => {
     configureGlobal({
@@ -216,7 +282,13 @@ describe('Property', () => {
         previousAfterEach();
         callOrder.push('after afterEach');
       });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(callOrder).toEqual(['test', 'afterEach', 'after afterEach']);
   });
   it('Should execute afterEach after the test on failure', () => {
@@ -225,7 +297,13 @@ describe('Property', () => {
       callOrder.push('test');
       return false;
     }).afterEach(() => callOrder.push('afterEach'));
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).not.toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).not.toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(callOrder).toEqual(['test', 'afterEach']);
   });
   it('Should execute afterEach after the test on uncaught exception', () => {
@@ -234,7 +312,13 @@ describe('Property', () => {
       callOrder.push('test');
       throw new Error('uncaught');
     }).afterEach(() => callOrder.push('afterEach'));
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).not.toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).not.toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(callOrder).toEqual(['test', 'afterEach']);
   });
   it('Should use global afterEach as default if specified', () => {
@@ -246,7 +330,13 @@ describe('Property', () => {
       callOrder.push('test');
       return false;
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).not.toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).not.toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(callOrder).toEqual(['test', 'afterEach']);
   });
   it('Should execute both global and local afterEach hooks', () => {
@@ -261,7 +351,13 @@ describe('Property', () => {
       callOrder.push('afterEach');
       globalAfterEach();
     });
-    expect(p.run(p.generate(stubRng.mutable.nocall()).value)).toBe(null);
+    if (dontRunHook) {
+      p.runBeforeEach!();
+    }
+    expect(p.run(p.generate(stubRng.mutable.nocall()).value, dontRunHook)).toBe(null);
+    if (dontRunHook) {
+      p.runAfterEach!();
+    }
     expect(callOrder).toEqual(['test', 'afterEach', 'globalAfterEach']);
   });
   it('should fail if global asyncAfterEach has been set', () => {

--- a/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
@@ -129,8 +129,14 @@ describe.each([[true], [false]])('SkipAfterProperty (dontRunHook: %p)', (dontRun
     expect(generate).not.toHaveBeenCalled();
     expect(shrink).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
-    expect(runBeforeEach).not.toHaveBeenCalled();
-    expect(runAfterEach).not.toHaveBeenCalled();
+    if (dontRunHook) {
+      // We may not want to run them in such context
+      expect(runBeforeEach).toHaveBeenCalledTimes(1);
+      expect(runAfterEach).toHaveBeenCalledTimes(1);
+    } else {
+      expect(runBeforeEach).not.toHaveBeenCalled();
+      expect(runAfterEach).not.toHaveBeenCalled();
+    }
   });
 
   it('should forward falsy interrupt flag to the precondition failure', async () => {

--- a/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
@@ -130,7 +130,7 @@ describe.each([[true], [false]])('SkipAfterProperty (dontRunHook: %p)', (dontRun
     expect(shrink).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
     if (dontRunHook) {
-      // We may not want to run them in such context
+      // We may not want to run them in such context, but so far we do
       expect(runBeforeEach).toHaveBeenCalledTimes(1);
       expect(runAfterEach).toHaveBeenCalledTimes(1);
     } else {

--- a/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/SkipAfterProperty.spec.ts
@@ -7,7 +7,7 @@ import { Value } from '../../../../src/check/arbitrary/definition/Value';
 const startTimeMs = 200;
 const timeLimitMs = 100;
 
-describe.each([[true], [false]])('SkipAfterProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
+describe.each([[true], [false]])('SkipAfterProperty (dontRunHook: %p)', (dontRunHook) => {
   it('should call timer at construction', async () => {
     // Arrange
     const timerMock = jest.fn();

--- a/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
@@ -3,7 +3,7 @@ import { TimeoutProperty } from '../../../../src/check/property/TimeoutProperty'
 import { fakeRandom } from '../../arbitrary/__test-helpers__/RandomHelpers';
 import { fakeProperty } from './__test-helpers__/PropertyHelpers';
 
-describe('TimeoutProperty', () => {
+describe.each([[true], [false]])('TimeoutProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
   beforeEach(() => {
     jest.clearAllTimers();
   });
@@ -30,18 +30,28 @@ describe('TimeoutProperty', () => {
   it('should forward inputs to run', async () => {
     // Arrange
     jest.useFakeTimers();
-    const { instance: decoratedProperty, run } = fakeProperty(true);
+    const { instance: decoratedProperty, run, runBeforeEach, runAfterEach } = fakeProperty(true);
     const expectedRunInput = { anything: Symbol('something') };
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 10);
-    const runPromise = timeoutProp.run(expectedRunInput);
-    jest.advanceTimersByTime(10);
-    await runPromise;
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      const runPromise = timeoutProp.run(expectedRunInput, true);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+      await timeoutProp.runAfterEach!();
+    } else {
+      const runPromise = timeoutProp.run(expectedRunInput, false);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+    }
 
     // Assert
     expect(run).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledWith(expectedRunInput);
+    expect(runBeforeEach).toHaveBeenCalledTimes(1);
+    expect(runAfterEach).toHaveBeenCalledTimes(1);
   });
 
   it('should not timeout if it succeeds in time', async () => {
@@ -56,9 +66,18 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 100);
-    const runPromise = timeoutProp.run({});
-    jest.advanceTimersByTime(10);
-    await runPromise;
+    let runPromise: ReturnType<typeof timeoutProp.run>;
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      runPromise = timeoutProp.run({}, true);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+      await timeoutProp.runAfterEach!();
+    } else {
+      runPromise = timeoutProp.run({}, false);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+    }
 
     // Assert
     expect(await runPromise).toBe(null);
@@ -78,9 +97,18 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 100);
-    const runPromise = timeoutProp.run({});
-    jest.advanceTimersByTime(10);
-    await runPromise;
+    let runPromise: ReturnType<typeof timeoutProp.run>;
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      runPromise = timeoutProp.run({}, true);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+      await timeoutProp.runAfterEach!();
+    } else {
+      runPromise = timeoutProp.run({}, false);
+      jest.advanceTimersByTime(10);
+      await runPromise;
+    }
 
     // Assert
     expect(await runPromise).toBe(errorFromUnderlying);
@@ -96,7 +124,13 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 100);
-    await timeoutProp.run({});
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      await timeoutProp.run({}, true);
+      await timeoutProp.runAfterEach!();
+    } else {
+      await timeoutProp.run({}, false);
+    }
 
     // Assert
     expect(setTimeout).toBeCalledTimes(1);
@@ -114,7 +148,13 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 100);
-    await timeoutProp.run({});
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      await timeoutProp.run({}, true);
+      await timeoutProp.runAfterEach!();
+    } else {
+      await timeoutProp.run({}, false);
+    }
 
     // Assert
     expect(setTimeout).toBeCalledTimes(1);
@@ -133,7 +173,13 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 10);
-    const runPromise = timeoutProp.run({});
+    let runPromise: ReturnType<typeof timeoutProp.run>;
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      runPromise = timeoutProp.run({}, true);
+    } else {
+      runPromise = timeoutProp.run({}, false);
+    }
     jest.advanceTimersByTime(10);
 
     // Assert
@@ -141,6 +187,7 @@ describe('TimeoutProperty', () => {
       error: expect.any(Error),
       errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
     });
+    await timeoutProp.runAfterEach!();
   });
 
   it('Should timeout if it never ends', async () => {
@@ -151,7 +198,13 @@ describe('TimeoutProperty', () => {
 
     // Act
     const timeoutProp = new TimeoutProperty(decoratedProperty, 10);
-    const runPromise = timeoutProp.run({});
+    let runPromise: ReturnType<typeof timeoutProp.run>;
+    if (dontRunHook) {
+      await timeoutProp.runBeforeEach!();
+      runPromise = timeoutProp.run({}, true);
+    } else {
+      runPromise = timeoutProp.run({}, false);
+    }
     jest.advanceTimersByTime(10);
 
     // Assert
@@ -159,5 +212,6 @@ describe('TimeoutProperty', () => {
       error: expect.any(Error),
       errorMessage: `Property timeout: exceeded limit of 10 milliseconds`,
     });
+    await timeoutProp.runAfterEach!();
   });
 });

--- a/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
@@ -3,7 +3,7 @@ import { TimeoutProperty } from '../../../../src/check/property/TimeoutProperty'
 import { fakeRandom } from '../../arbitrary/__test-helpers__/RandomHelpers';
 import { fakeProperty } from './__test-helpers__/PropertyHelpers';
 
-describe.each([[true], [false]])('TimeoutProperty (dontRunHook: $dontRunHook)', (dontRunHook) => {
+describe.each([[true], [false]])('TimeoutProperty (dontRunHook: %p)', (dontRunHook) => {
   beforeEach(() => {
     jest.clearAllTimers();
   });

--- a/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/TimeoutProperty.spec.ts
@@ -83,6 +83,52 @@ describe.each([[true], [false]])('TimeoutProperty (dontRunHook: $dontRunHook)', 
     expect(await runPromise).toBe(null);
   });
 
+  if (dontRunHook) {
+    it('should not timeout if it succeeds in time while timeout in beforeEach', async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { instance: decoratedProperty, runBeforeEach } = fakeProperty(true);
+      runBeforeEach.mockReturnValueOnce(
+        new Promise(function (resolve) {
+          setTimeout(() => resolve(), 10);
+        })
+      );
+
+      // Act
+      const timeoutProp = new TimeoutProperty(decoratedProperty, 5);
+      await timeoutProp.runBeforeEach!();
+      jest.advanceTimersByTime(10);
+      const runPromise = timeoutProp.run({}, true);
+      await runPromise;
+      await timeoutProp.runAfterEach!();
+
+      // Assert
+      expect(await runPromise).toBe(null);
+    });
+
+    it('should not timeout if it succeeds in time', async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { instance: decoratedProperty, runAfterEach } = fakeProperty(true);
+      runAfterEach.mockReturnValueOnce(
+        new Promise(function (resolve) {
+          setTimeout(() => resolve(), 10);
+        })
+      );
+
+      // Act
+      const timeoutProp = new TimeoutProperty(decoratedProperty, 5);
+      await timeoutProp.runBeforeEach!();
+      const runPromise = timeoutProp.run({}, true);
+      await runPromise;
+      await timeoutProp.runAfterEach!();
+      jest.advanceTimersByTime(10);
+
+      // Assert
+      expect(await runPromise).toBe(null);
+    });
+  }
+
   it('should not timeout if it fails in time', async () => {
     // Arrange
     const errorFromUnderlying = { error: undefined, errorMessage: 'plop' };

--- a/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
+++ b/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
@@ -13,9 +13,14 @@ export function fakeProperty<T = unknown, TIsAsync extends boolean = boolean>(
   }
   const generate = jest.fn();
   const shrink = jest.fn();
-  const run = jest.fn();
   const runBeforeEach = jest.fn();
   const runAfterEach = jest.fn();
+  const run = jest.fn().mockImplementation((_, dontRunHooks) => {
+    if (!dontRunHooks) {
+      runBeforeEach();
+      runAfterEach();
+    }
+  });
   class MyProperty implements IRawProperty<unknown, boolean> {
     isAsync = isAsync;
     generate = generate;

--- a/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
+++ b/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
@@ -6,7 +6,7 @@ import { IRawProperty } from '../../../../../src/check/property/IRawProperty';
  */
 export function fakeProperty<T = unknown, TIsAsync extends boolean = boolean>(
   isAsyncResponse?: TIsAsync
-): { instance: IRawProperty<T, TIsAsync> } & MaybeMocked<IRawProperty<T, TIsAsync>> {
+): { instance: IRawProperty<T, TIsAsync> } & MaybeMocked<Required<IRawProperty<T, TIsAsync>>> {
   const isAsync = jest.fn();
   if (isAsyncResponse !== undefined) {
     isAsync.mockReturnValue(isAsyncResponse);

--- a/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
+++ b/packages/fast-check/test/unit/check/property/__test-helpers__/PropertyHelpers.ts
@@ -14,11 +14,15 @@ export function fakeProperty<T = unknown, TIsAsync extends boolean = boolean>(
   const generate = jest.fn();
   const shrink = jest.fn();
   const run = jest.fn();
+  const runBeforeEach = jest.fn();
+  const runAfterEach = jest.fn();
   class MyProperty implements IRawProperty<unknown, boolean> {
     isAsync = isAsync;
     generate = generate;
     shrink = shrink;
     run = run;
+    runBeforeEach = runBeforeEach;
+    runAfterEach = runAfterEach;
   }
-  return { instance: new MyProperty(), isAsync, generate, shrink, run };
+  return { instance: new MyProperty(), isAsync, generate, shrink, run, runBeforeEach, runAfterEach };
 }


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Timeout must only focus on the code under tests, in other words the predicate. It should not be triggered because of a beforeEach being too long, or a afterEach being too long.

beforeEach and afterEach must always be run, no matter if the property timeout or not. We want to get closer to the behaviour followed by existing test runners such as jest, see:

```js
beforeAll(() => console.log("before all"));
beforeEach(() => console.log("before each"));
afterEach(() => console.log("after each"));
afterAll(() => console.log("after all"));

test("timeouting...", async () => {
  console.log("start");
  await new Promise(() => {});
  console.log("end");
}, 100);
```

Which prints:
```txt
before all
before each
start
after each
after all
```

And still runs the code after the timeout as it cannot stops it (case where the Promise resolve after N>100ms):
```txt
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "end".
```

Fixes #3236

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
