### PR TITLE
✨ Add `document.all` in falsy values

### DIFF
--- a/packages/fast-check/src/arbitrary/falsy.ts
+++ b/packages/fast-check/src/arbitrary/falsy.ts
@@ -28,7 +28,14 @@ export type FalsyValue<TConstraints extends FalsyContraints = {}> =
   | ''
   | typeof NaN
   | undefined
+  | HTMLAllCollection
   | (TConstraints extends { withBigInt: true } ? 0n : never);
+
+const allDefaultFalsyValuesBase: FalsyValue[] = [false, null, undefined, 0, '', NaN];
+const allDefaultFalsyValues: FalsyValue[] =
+  typeof document !== 'undefined' && document.all !== undefined
+    ? [...allDefaultFalsyValuesBase, document.all]
+    : allDefaultFalsyValuesBase;
 
 /**
  * For falsy values:
@@ -49,7 +56,7 @@ export function falsy<TConstraints extends FalsyContraints>(
   constraints?: TConstraints
 ): Arbitrary<FalsyValue<TConstraints>> {
   if (!constraints || !constraints.withBigInt) {
-    return constantFrom<FalsyValue[]>(false, null, undefined, 0, '', NaN);
+    return constantFrom<FalsyValue[]>(...allDefaultFalsyValues);
   }
-  return constantFrom<FalsyValue<TConstraints>[]>(false, null, undefined, 0, '', NaN, BigInt(0) as any);
+  return constantFrom<FalsyValue<TConstraints>[]>(...allDefaultFalsyValues, BigInt(0) as any);
 }


### PR DESCRIPTION
While it can be considered as a bug fix, making it as such would imply breaking replay capabilities within a patch (the patch would not be able to replay things failing before it). As a consequence and because it's more a feature than a bug fix let's flag it as a feature.

Fixes #745

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
