### PR TITLE
✨ Interrupt predicates when `interruptAfterTimeLimit`

### DIFF
--- a/.yarn/versions/cb9adede.yml
+++ b/.yarn/versions/cb9adede.yml
@@ -1,0 +1,7 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/check/property/SkipAfterProperty.ts
+++ b/packages/fast-check/src/check/property/SkipAfterProperty.ts
@@ -5,6 +5,23 @@ import { PreconditionFailure } from '../precondition/PreconditionFailure';
 import { IRawProperty } from './IRawProperty';
 
 /** @internal */
+function interruptAfter(timeMs: number) {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const promise = new Promise<PreconditionFailure>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      const preconditionFailure = new PreconditionFailure(true);
+      resolve(preconditionFailure);
+    }, timeMs);
+  });
+  return {
+    // `timeoutHandle` will always be initialised at this point: body of `new Promise` has already been executed
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    clear: () => clearTimeout(timeoutHandle!),
+    promise,
+  };
+}
+
+/** @internal */
 export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawProperty<Ts, IsAsync> {
   runBeforeEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
   runAfterEach?: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
@@ -38,13 +55,20 @@ export class SkipAfterProperty<Ts, IsAsync extends boolean> implements IRawPrope
   }
 
   run(v: Ts, dontRunHook: boolean): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
-    if (this.getTime() >= this.skipAfterTime) {
+    const remainingTime = this.skipAfterTime - this.getTime();
+    if (remainingTime <= 0) {
       const preconditionFailure = new PreconditionFailure(this.interruptExecution);
       if (this.isAsync()) {
         return Promise.resolve(preconditionFailure) as any; // IsAsync => Promise<PreconditionFailure | string | null>
       } else {
         return preconditionFailure as any; // !IsAsync => PreconditionFailure | string | null
       }
+    }
+    if (this.interruptExecution && this.isAsync()) {
+      const t = interruptAfter(remainingTime);
+      const propRun = Promise.race([this.property.run(v, dontRunHook), t.promise]);
+      propRun.then(t.clear, t.clear); // always clear timeout handle - catch should never occur
+      return propRun as any; // IsAsync => Promise<PreconditionFailure | string | null>
     }
     return this.property.run(v, dontRunHook);
   }

--- a/packages/fast-check/src/check/runner/reporter/RunExecution.ts
+++ b/packages/fast-check/src/check/runner/reporter/RunExecution.ts
@@ -129,8 +129,7 @@ export class RunExecution<Ts> {
 
     // Either 'too many skips' or 'interrupted' with flag interruptedAsFailure enabled
     // The two cases are exclusive (the two cannot be true at the same time)
-    const considerInterruptedAsFailure = this.interruptedAsFailure || this.numSuccesses === 0;
-    const failed = this.numSkips > maxSkips || (this.interrupted && considerInterruptedAsFailure);
+    const failed = this.numSkips > maxSkips || (this.interrupted && this.interruptedAsFailure);
 
     // -- Let's suppose: this.numSkips > maxSkips
     // In the context of RunnerIterator we pull values from the stream

--- a/packages/fast-check/src/check/runner/reporter/RunExecution.ts
+++ b/packages/fast-check/src/check/runner/reporter/RunExecution.ts
@@ -129,7 +129,8 @@ export class RunExecution<Ts> {
 
     // Either 'too many skips' or 'interrupted' with flag interruptedAsFailure enabled
     // The two cases are exclusive (the two cannot be true at the same time)
-    const failed = this.numSkips > maxSkips || (this.interrupted && this.interruptedAsFailure);
+    const considerInterruptedAsFailure = this.interruptedAsFailure || this.numSuccesses === 0;
+    const failed = this.numSkips > maxSkips || (this.interrupted && considerInterruptedAsFailure);
 
     // -- Let's suppose: this.numSkips > maxSkips
     // In the context of RunnerIterator we pull values from the stream


### PR DESCRIPTION
In the context of #3084, we want to have a way built-in in fast-check to make sure that tests do not run for too long and can abide by certain timeouts constraints requested by the users.

While today we do have a timeout, it only scopes the interruption to one run of the predicate but does not consider "the runs" as a whole contrary to `interruptAfterTimeLimit`.

On the other hand, `interruptAfterTimeLimit` does have a timeout like behaviour but once started the predicate is never interrupted. Now it could be interrupted in-between, if running it until the end would cause a timeout given the time constraint passed to `interruptAfterTimeLimit`.

With such new feature in place, we will probably have to consider properties not having run at least once as failure, otherwise a buggy async algorithm would be marked as failure if it led to timeout at first run with `interruptAfterTimeLimit`.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
