### PR TITLE
✨(jest) Let fast-check guide timeouts

### DIFF
--- a/.yarn/versions/450c22cf.yml
+++ b/.yarn/versions/450c22cf.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": minor

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -71,7 +71,9 @@ function extractJestGLobalTimeout(): number | undefined {
   for (const key of Object.getOwnPropertySymbols(globalThis)) {
     if (String(key) === stateSymbolStringValue) {
       const jestState = (globalThis as any)[key];
-      return jestState.testTimeout;
+      if (jestState !== null && typeof jestState === 'object' && typeof jestState.testTimeout === 'number') {
+        return jestState.testTimeout;
+      }
     }
   }
   return undefined; // no such case expected

--- a/packages/jest/src/internals/types.ts
+++ b/packages/jest/src/internals/types.ts
@@ -1,9 +1,10 @@
 import type { it as itJest } from '@jest/globals';
-import type { Arbitrary, asyncProperty, assert } from 'fast-check';
+import type { Arbitrary, asyncProperty, assert, readConfigureGlobal } from 'fast-check';
 
 export type FcExtra = {
   asyncProperty: typeof asyncProperty;
   assert: typeof assert;
+  readConfigureGlobal: typeof readConfigureGlobal;
 };
 
 export type JestExtra = {

--- a/packages/jest/src/jest-fast-check-worker.ts
+++ b/packages/jest/src/jest-fast-check-worker.ts
@@ -52,13 +52,17 @@ function dummyTest(): It {
 type InitOutput = { test: FastCheckItBuilder<It>; it: FastCheckItBuilder<It>; expect: typeof jestExpect };
 
 export const init = (url: URL): InitOutput => {
-  const fc: FcExtra = { asyncProperty: propertyFor(url), assert: assert as FcExtra['assert'] };
+  const fcExtra: FcExtra = {
+    asyncProperty: propertyFor(url),
+    assert: assert as FcExtra['assert'],
+    readConfigureGlobal: fc.readConfigureGlobal,
+  };
   if (typeof it !== 'undefined') {
     if (typeof jest !== 'undefined') {
       // Jest is always properly defined when in CommonJS bundles
       return {
-        test: buildTest(test as It, jest, fc),
-        it: buildTest(it as It, jest, fc),
+        test: buildTest(test as It, jest, fcExtra),
+        it: buildTest(it as It, jest, fcExtra),
         expect: jestExpect,
       };
     } else {
@@ -68,8 +72,8 @@ export const init = (url: URL): InitOutput => {
       // @ts-ignore
       return import('@jest/globals').then(
         ({ jest }): InitOutput => ({
-          test: buildTest(test as It, jest, fc),
-          it: buildTest(it as It, jest, fc),
+          test: buildTest(test as It, jest, fcExtra),
+          it: buildTest(it as It, jest, fcExtra),
           expect: jestExpect,
         })
       ) as any;
@@ -77,8 +81,8 @@ export const init = (url: URL): InitOutput => {
   }
   const dummyJest: JestExtra = {};
   return {
-    test: buildTest(dummyTest(), dummyJest, fc),
-    it: buildTest(dummyTest(), dummyJest, fc),
+    test: buildTest(dummyTest(), dummyJest, fcExtra),
+    it: buildTest(dummyTest(), dummyJest, fcExtra),
     expect: jestExpect,
   };
 };

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -462,7 +462,9 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
       it.concurrent('should fail as test takes longer than Jest setTimeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-          jest.setTimeout(1000);
+          if (typeof jest !== 'undefined') {
+            jest.setTimeout(1000);
+          }
           runner.prop([fc.nat()])('property takes longer than Jest setTimeout', async () => {
             await new Promise(() => {}); // never resolving
           });
@@ -498,7 +500,9 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
         it.concurrent('should fail but favor local Jest timeout over Jest setTimeout', async () => {
           // Arrange
           const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-            jest.setTimeout(2000);
+            if (typeof jest !== 'undefined') {
+              jest.setTimeout(2000);
+            }
             runner.prop([fc.nat()])(
               'property favor local Jest timeout over Jest setTimeout',
               async () => {
@@ -521,7 +525,9 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
       it.concurrent('should fail but favor Jest setTimeout over Jest CLI timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-          jest.setTimeout(1000);
+          if (typeof jest !== 'undefined') {
+            jest.setTimeout(1000);
+          }
           runner.prop([fc.nat()])('property favor Jest setTimeout over Jest CLI timeout', async () => {
             await new Promise(() => {}); // never resolving
           });

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -507,17 +507,17 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
               1000
             );
           });
-  
+
           // Act
           const out = await runSpec(jestConfigRelativePath);
-  
+
           // Assert
           expectFail(out, specFileName);
           expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
           expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
         });
       }
-  
+
       it.concurrent('should fail but favor Jest setTimeout over Jest CLI timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
@@ -526,10 +526,10 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
             await new Promise(() => {}); // never resolving
           });
         });
-  
+
         // Act
         const out = await runSpec(jestConfigRelativePath, { testTimeoutCLI: 2000 });
-  
+
         // Assert
         expectFail(out, specFileName);
         expectTimeout(out, 1000); // neither 2000 (cli), nor 5000 (default)

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -396,6 +396,104 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
         expect(out).toMatch(/[×✕] property fail because passing \(with seed=-?\d+\)/);
       });
     });
+
+    describe('timeout', () => {
+      it.concurrent('should fail as test takes longer than global Jest timeout', async () => {
+        // Arrange
+        const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+          runner.prop([fc.nat()])('property takes longer than global Jest timeout', async () => {
+            await new Promise(() => {}); // never resolving
+          });
+        });
+
+        // Act
+        const out = await runSpec(jestConfigRelativePath);
+
+        // Assert
+        expectFail(out, specFileName);
+        expectTimeout(out, 5000);
+        expect(out).toMatch(/[×✕] property takes longer than global Jest timeout/);
+      });
+
+      if (!useLegacySignatures) {
+        it.concurrent('should fail as test takes longer than Jest local timeout', async () => {
+          // Arrange
+          const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+            runner.prop([fc.nat()])(
+              'property takes longer than Jest local timeout',
+              async () => {
+                await new Promise(() => {}); // never resolving
+              },
+              1000
+            );
+          });
+
+          // Act
+          const out = await runSpec(jestConfigRelativePath);
+
+          // Assert
+          expectFail(out, specFileName);
+          expectTimeout(out, 1000);
+          expect(out).toMatch(/[×✕] property takes longer than Jest local timeout/);
+        });
+      }
+
+      it.concurrent('should fail as test takes longer than Jest config timeout', async () => {
+        // Arrange
+        const { specFileName, jestConfigRelativePath } = await writeToFile(
+          runnerName,
+          { ...options, testTimeoutConfig: 1000 },
+          () => {
+            runner.prop([fc.nat()])('property takes longer than Jest config timeout', async () => {
+              await new Promise(() => {}); // never resolving
+            });
+          }
+        );
+
+        // Act
+        const out = await runSpec(jestConfigRelativePath);
+
+        // Assert
+        expectFail(out, specFileName);
+        expectTimeout(out, 1000);
+        expect(out).toMatch(/[×✕] property takes longer than Jest config timeout/);
+      });
+
+      it.concurrent('should fail as test takes longer than Jest setTimeout', async () => {
+        // Arrange
+        const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+          jest.setTimeout(1000);
+          runner.prop([fc.nat()])('property takes longer than Jest setTimeout', async () => {
+            await new Promise(() => {}); // never resolving
+          });
+        });
+
+        // Act
+        const out = await runSpec(jestConfigRelativePath);
+
+        // Assert
+        expectFail(out, specFileName);
+        expectTimeout(out, 1000);
+        expect(out).toMatch(/[×✕] property takes longer than Jest setTimeout/);
+      });
+
+      it.concurrent('should fail as test takes longer than Jest CLI timeout', async () => {
+        // Arrange
+        const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+          runner.prop([fc.nat()])('property takes longer than Jest CLI timeout', async () => {
+            await new Promise(() => {}); // never resolving
+          });
+        });
+
+        // Act
+        const out = await runSpec(jestConfigRelativePath, { testTimeoutCLI: 1000 });
+
+        // Assert
+        expectFail(out, specFileName);
+        expectTimeout(out, 1000);
+        expect(out).toMatch(/[×✕] property takes longer than Jest CLI timeout/);
+      });
+    });
   });
 });
 
@@ -404,7 +502,7 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
 let num = -1;
 async function writeToFile(
   runner: 'test' | 'it',
-  options: { useLegacySignatures: boolean; useWorkers: boolean },
+  options: { useLegacySignatures: boolean; useWorkers: boolean; testTimeoutConfig?: number },
   fileContent: () => void
 ): Promise<{ specFileName: string; jestConfigRelativePath: string }> {
   const { useLegacySignatures, useWorkers } = options;
@@ -448,13 +546,21 @@ async function writeToFile(
   // Write the files
   await Promise.all([
     fs.writeFile(specFilePath, specContent),
-    fs.writeFile(jestConfigPath, `module.exports = { testMatch: ['<rootDir>/${specFileName}'], transform: {} };`),
+    fs.writeFile(
+      jestConfigPath,
+      `module.exports = { testMatch: ['<rootDir>/${specFileName}'], transform: {}, ${
+        options.testTimeoutConfig !== undefined ? `testTimeout: ${options.testTimeoutConfig},` : ''
+      } };`
+    ),
   ]);
 
   return { specFileName, jestConfigRelativePath };
 }
 
-async function runSpec(jestConfigRelativePath: string, opts: { jestSeed?: number } = {}): Promise<string> {
+async function runSpec(
+  jestConfigRelativePath: string,
+  opts: { jestSeed?: number; testTimeoutCLI?: number } = {}
+): Promise<string> {
   const { stdout: jestBinaryPathCommand } = await execFile('yarn', ['bin', 'jest'], { shell: true });
   const jestBinaryPath = jestBinaryPathCommand.split('\n')[0];
   try {
@@ -464,6 +570,7 @@ async function runSpec(jestConfigRelativePath: string, opts: { jestSeed?: number
       jestConfigRelativePath,
       '--show-seed',
       ...(opts.jestSeed !== undefined ? ['--seed', String(opts.jestSeed)] : []),
+      ...(opts.testTimeoutCLI !== undefined ? [`--testTimeout=${opts.testTimeoutCLI}`] : []),
     ]);
     return specOutput;
   } catch (err) {
@@ -477,6 +584,15 @@ function expectPass(out: string, specFileName: string): void {
 
 function expectFail(out: string, specFileName: string): void {
   expect(out).toMatch(new RegExp('FAIL .*/' + specFileName));
+}
+
+function expectTimeout(out: string, timeout: number): void {
+  expect(out).toContain('Property interrupted after 0 tests');
+  const timeRegex = /[×✕] .* \(with seed=-?\d+\) \((\d+) ms\)/;
+  expect(out).toMatch(timeRegex);
+  const time = timeRegex.exec(out)!;
+  expect(Number(time[1])).toBeGreaterThanOrEqual(timeout);
+  expect(Number(time[1])).toBeLessThan(timeout * 1.5);
 }
 
 function expectAlignedSeeds(out: string, opts: { noAlignWithJest?: boolean } = {}): void {

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -495,27 +495,29 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
       });
     });
 
-    it.concurrent('should fail but favor local Jest timeout over Jest setTimeout', async () => {
-      // Arrange
-      const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-        jest.setTimeout(2000);
-        runner.prop([fc.nat()])(
-          'property favor local Jest timeout over Jest setTimeout',
-          async () => {
-            await new Promise(() => {}); // never resolving
-          },
-          1000
-        );
+    if (!useLegacySignatures) {
+      it.concurrent('should fail but favor local Jest timeout over Jest setTimeout', async () => {
+        // Arrange
+        const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+          jest.setTimeout(2000);
+          runner.prop([fc.nat()])(
+            'property favor local Jest timeout over Jest setTimeout',
+            async () => {
+              await new Promise(() => {}); // never resolving
+            },
+            1000
+          );
+        });
+
+        // Act
+        const out = await runSpec(jestConfigRelativePath);
+
+        // Assert
+        expectFail(out, specFileName);
+        expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
+        expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
       });
-
-      // Act
-      const out = await runSpec(jestConfigRelativePath, { testTimeoutCLI: 2000 });
-
-      // Assert
-      expectFail(out, specFileName);
-      expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
-      expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
-    });
+    }
 
     it.concurrent('should fail but favor Jest setTimeout over Jest CLI timeout', async () => {
       // Arrange

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -493,48 +493,48 @@ describe.each<{ specName: string; runnerName: RunnerType; useLegacySignatures: b
         expectTimeout(out, 1000);
         expect(out).toMatch(/[×✕] property takes longer than Jest CLI timeout/);
       });
-    });
 
-    if (!useLegacySignatures) {
-      it.concurrent('should fail but favor local Jest timeout over Jest setTimeout', async () => {
+      if (!useLegacySignatures) {
+        it.concurrent('should fail but favor local Jest timeout over Jest setTimeout', async () => {
+          // Arrange
+          const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
+            jest.setTimeout(2000);
+            runner.prop([fc.nat()])(
+              'property favor local Jest timeout over Jest setTimeout',
+              async () => {
+                await new Promise(() => {}); // never resolving
+              },
+              1000
+            );
+          });
+  
+          // Act
+          const out = await runSpec(jestConfigRelativePath);
+  
+          // Assert
+          expectFail(out, specFileName);
+          expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
+          expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
+        });
+      }
+  
+      it.concurrent('should fail but favor Jest setTimeout over Jest CLI timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-          jest.setTimeout(2000);
-          runner.prop([fc.nat()])(
-            'property favor local Jest timeout over Jest setTimeout',
-            async () => {
-              await new Promise(() => {}); // never resolving
-            },
-            1000
-          );
+          jest.setTimeout(1000);
+          runner.prop([fc.nat()])('property favor Jest setTimeout over Jest CLI timeout', async () => {
+            await new Promise(() => {}); // never resolving
+          });
         });
-
+  
         // Act
-        const out = await runSpec(jestConfigRelativePath);
-
+        const out = await runSpec(jestConfigRelativePath, { testTimeoutCLI: 2000 });
+  
         // Assert
         expectFail(out, specFileName);
-        expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
-        expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
+        expectTimeout(out, 1000); // neither 2000 (cli), nor 5000 (default)
+        expect(out).toMatch(/[×✕] property favor Jest setTimeout over Jest CLI timeout/);
       });
-    }
-
-    it.concurrent('should fail but favor Jest setTimeout over Jest CLI timeout', async () => {
-      // Arrange
-      const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
-        jest.setTimeout(1000);
-        runner.prop([fc.nat()])('property favor Jest setTimeout over Jest CLI timeout', async () => {
-          await new Promise(() => {}); // never resolving
-        });
-      });
-
-      // Act
-      const out = await runSpec(jestConfigRelativePath, { testTimeoutCLI: 2000 });
-
-      // Assert
-      expectFail(out, specFileName);
-      expectTimeout(out, 1000); // neither 2000 (cli), nor 5000 (default)
-      expect(out).toMatch(/[×✕] property favor Jest setTimeout over Jest CLI timeout/);
     });
   });
 });


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Up-to-now fast-check and jest had their own and separate mechanisms to handle timeouts of running tests.
On one side fast-check defined interruptAfterTimeLimit, on the other Jest defined timeout.

Trick has been to define interruptAfterTimeLimit = 0.9 * timeout, so that fast-check timeouts before jest does (0.ç just being one possible value among others, but it does not mean it will always be fast-check before jest).

This trick will not be needed anymore as when relying on `@fast-check/jest`, timeouts of jest will be redirected to fast-check so that fast-check will be responsible for any timeout related to pbt tests.

Fixes #3084

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
