### PR TITLE
🐛(jest) Safer global timeout retrieval

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -53,7 +53,8 @@
   "peerDependencies": {
     "@fast-check/worker": "~0.0.1",
     "@jest/expect": ">=28.0.0",
-    "@jest/globals": ">=25.5.2"
+    "@jest/globals": ">=25.5.2",
+    "jest-circus": ">=25.0.0"
   },
   "peerDependenciesMeta": {
     "@fast-check/worker": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -71,6 +71,7 @@
     "@types/node": "^18.11.17",
     "fast-check": "workspace:*",
     "jest": "^29.3.1",
+    "jest-jasmine2": "^29.3.1",
     "ts-jest": "^29.0.3",
     "typescript": "^4.9.4"
   },

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -72,7 +72,7 @@ function extractJestGlobalTimeout(): number | undefined {
   // Timeout defined via global configuration or CLI options (jest-circus runner)
   const jestCircusState = getState();
   if (jestCircusState !== undefined) {
-    return getState().testTimeout;
+    return jestCircusState.testTimeout;
   }
   // Tiemout defined via global configuraton or CLI option (jest-jasmine2 runner)
   if (typeof jasmine !== 'undefined') {

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -74,5 +74,9 @@ function extractJestGlobalTimeout(): number | undefined {
   if (jestCircusState !== undefined) {
     return getState().testTimeout;
   }
+  // Tiemout defined via global configuraton or CLI option (jest-jasmine2 runner)
+  if (typeof jasmine !== 'undefined') {
+    return jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  }
   return undefined;
 }

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -63,9 +63,15 @@ export function buildTestWithPropRunner<Ts extends [any] | any[], TsParameters e
 }
 
 function extractJestGlobalTimeout(): number | undefined {
-  // for jest-circus runner
+  // Timeout defined via explicit calls to jest.setTimeout
+  // See https://github.com/facebook/jest/blob/fb2de8a10f8e808b080af67aa771f67b5ea537ce/packages/jest-runtime/src/index.ts#L2174
+  const jestTimeout = (globalThis as any)[Symbol.for('TEST_TIMEOUT_SYMBOL')];
+  if (typeof jestTimeout === 'number') {
+    return jestTimeout;
+  }
+  // Timeout defined via global configuration or CLI options (jest-circus runner)
   const jestCircusState = getState();
-  if (state !== undefined) {
+  if (jestCircusState !== undefined) {
     return getState().testTimeout;
   }
   return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,7 @@ __metadata:
     "@types/node": ^18.11.17
     fast-check: "workspace:*"
     jest: ^29.3.1
+    jest-jasmine2: ^29.3.1
     ts-jest: ^29.0.3
     typescript: ^4.9.4
   peerDependencies:
@@ -6209,6 +6210,31 @@ __metadata:
     fsevents:
       optional: true
   checksum: 97ea26af0c28a2ba568c9c65d06211487bbcd501cb4944f9d55e07fd2b00ad96653ea2cc9033f3d5b7dc1feda33e47ae9cc56b400191ea4533be213c9f82e67c
+  languageName: node
+  linkType: hard
+
+"jest-jasmine2@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-jasmine2@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/expect": ^29.3.1
+    "@jest/source-map": ^29.2.0
+    "@jest/test-result": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.3.1
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-runtime: ^29.3.1
+    jest-snapshot: ^29.3.1
+    jest-util: ^29.3.1
+    p-limit: ^3.1.0
+    pretty-format: ^29.3.1
+  checksum: e8a3fabed31322ee2f9b687e5f0955bb0114634007aa0edc43742babb43b84f243a81e00fe97daa5bfe51def4ebe4b8f9fdf6561858d6eb1c5d2473de15aca59
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,7 @@ __metadata:
     "@fast-check/worker": ~0.0.1
     "@jest/expect": ">=28.0.0"
     "@jest/globals": ">=25.5.2"
+    jest-circus: ">=25.0.0"
   peerDependenciesMeta:
     "@fast-check/worker":
       optional: true


### PR DESCRIPTION
In node 18, accessing the symbol for the jest-circus state doew not work at all. The current PR attempts to find an alternative way to it.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
