### PR TITLE
🐛(jest) Support failure to get timeout out of Jest

### DIFF
--- a/.yarn/versions/0eda474b.yml
+++ b/.yarn/versions/0eda474b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": patch

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -46,6 +46,11 @@ export function buildTestWithPropRunner<Ts extends [any] | any[], TsParameters e
       // Mix both jest and fc's timeouts
       customParams.interruptAfterTimeLimit = Math.min(customParams.interruptAfterTimeLimit, jestTimeout);
     }
+  } else {
+    // Related to ticket https://github.com/facebook/jest/issues/13338
+    // May occur whenever test runner is not one of the uspported ones (see extractJestGLobalTimeout)
+    // or if node version is 18.2.0 or above until the issue gets fixed on node side if confirmed
+    console.warn('Unable to get back timeout of Jest, falling back onto Jest for global timeout handling');
   }
 
   const promiseProp = wrapProp(prop);
@@ -57,7 +62,9 @@ export function buildTestWithPropRunner<Ts extends [any] | any[], TsParameters e
     async () => {
       await fc.assert(propertyInstance, customParams);
     },
-    0x7fffffff // must be 32-bit signed integer
+    jestTimeout !== undefined
+      ? 0x7fffffff // must be 32-bit signed integer
+      : undefined
   );
 }
 

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -635,12 +635,17 @@ function expectFail(out: string, specFileName: string): void {
 }
 
 function expectTimeout(out: string, timeout: number): void {
-  expect(out).toContain('Property interrupted after 0 tests');
+  // Related to ticket https://github.com/facebook/jest/issues/13338
+  const supportForGlobalLevel = !process.version.startsWith('v18.');
+  if (supportForGlobalLevel) {
+    expect(out).toContain('Property interrupted after 0 tests');
+  }
+  const consideredTimeout = supportForGlobalLevel ? timeout : 5000;
   const timeRegex = /[×✕] .* \(with seed=-?\d+\) \((\d+) ms\)/;
   expect(out).toMatch(timeRegex);
   const time = timeRegex.exec(out)!;
-  expect(Number(time[1])).toBeGreaterThanOrEqual(timeout);
-  expect(Number(time[1])).toBeLessThan(timeout * 1.5);
+  expect(Number(time[1])).toBeGreaterThanOrEqual(consideredTimeout);
+  expect(Number(time[1])).toBeLessThan(consideredTimeout * 1.5);
 }
 
 function expectAlignedSeeds(out: string, opts: { noAlignWithJest?: boolean } = {}): void {


### PR DESCRIPTION
The current code performs a work-around required as soon as the the user runs Jest with node 18.2.0 or above (whatever the version of Jest). As the bug does not seem to be inherent to the way fast-check plugs itself into Jest configuration (while it's hacky), we for the moment deactivate the new "timeout handled by fast-check itsefl" in these cases.

By the way, it's important to note that bug can also exist if the user does not use default runners, so until we find a more reliable way to access the timeout, we will have kill-switch caces like this one. Hopefully less frequent than the node 18.2.0 one that I hope will be fixed.

Related to ticket https://github.com/facebook/jest/issues/13338

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
