### PR TITLE
✨(jest) Add support for jasmine runner

### DIFF
--- a/.yarn/versions/6c0852d7.yml
+++ b/.yarn/versions/6c0852d7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": minor

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -70,6 +70,7 @@
     "@types/node": "^18.11.17",
     "fast-check": "workspace:*",
     "jest": "^29.3.1",
+    "jest-jasmine2": "^29.3.1",
     "ts-jest": "^29.0.3",
     "typescript": "^4.9.4"
   },

--- a/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/jest/src/internals/TestWithPropRunnerBuilder.ts
@@ -62,11 +62,13 @@ export function buildTestWithPropRunner<Ts extends [any] | any[], TsParameters e
 }
 
 function extractJestGLobalTimeout(): number | undefined {
-  // Initialized via setTimeout, see https://github.com/facebook/jest/blob/fb2de8a10f8e808b080af67aa771f67b5ea537ce/packages/jest-runtime/src/index.ts#L2174
+  // Timeout defined via explicit calls to jest.setTimeout
+  // See https://github.com/facebook/jest/blob/fb2de8a10f8e808b080af67aa771f67b5ea537ce/packages/jest-runtime/src/index.ts#L2174
   const jestTimeout = (globalThis as any)[Symbol.for('TEST_TIMEOUT_SYMBOL')];
   if (typeof jestTimeout === 'number') {
     return jestTimeout;
   }
+  // Timeout defined via global configuration or CLI options (jest-circus runner, the default starting since Jest 27)
   const stateSymbolStringValue = String(Symbol('JEST_STATE_SYMBOL'));
   for (const key of Object.getOwnPropertySymbols(globalThis)) {
     if (String(key) === stateSymbolStringValue) {
@@ -75,6 +77,10 @@ function extractJestGLobalTimeout(): number | undefined {
         return jestState.testTimeout;
       }
     }
+  }
+  // Timeout defined via global configuraton or CLI option (jest-jasmine2 runner, the default until Jest 26 included)
+  if (typeof jasmine !== 'undefined') {
+    return jasmine.DEFAULT_TIMEOUT_INTERVAL;
   }
   return undefined; // no such case expected
 }

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -447,7 +447,7 @@ describe.each<DescribeOptions>([
 
           // Assert
           expectFail(out, specFileName);
-          expectTimeout(out, 5000, true);
+          expectTimeout(out, 5000, true, testRunner);
           expect(out).toMatch(/[×✕] property takes longer than global Jest timeout/);
         });
       }
@@ -470,7 +470,7 @@ describe.each<DescribeOptions>([
 
           // Assert
           expectFail(out, specFileName);
-          expectTimeout(out, 1000, false);
+          expectTimeout(out, 1000, false, testRunner);
           expect(out).toMatch(/[×✕] property takes longer than Jest local timeout/);
         });
       }
@@ -493,7 +493,7 @@ describe.each<DescribeOptions>([
 
           // Assert
           expectFail(out, specFileName);
-          expectTimeout(out, 1000, true);
+          expectTimeout(out, 1000, true, testRunner);
           expect(out).toMatch(/[×✕] property takes longer than Jest config timeout/);
         });
       }
@@ -514,7 +514,7 @@ describe.each<DescribeOptions>([
 
         // Assert
         expectFail(out, specFileName);
-        expectTimeout(out, 1000, false);
+        expectTimeout(out, 1000, false, testRunner);
         expect(out).toMatch(/[×✕] property takes longer than Jest setTimeout/);
       });
 
@@ -532,7 +532,7 @@ describe.each<DescribeOptions>([
 
           // Assert
           expectFail(out, specFileName);
-          expectTimeout(out, 1000, true);
+          expectTimeout(out, 1000, true, testRunner);
           expect(out).toMatch(/[×✕] property takes longer than Jest CLI timeout/);
         });
       }
@@ -558,7 +558,7 @@ describe.each<DescribeOptions>([
 
           // Assert
           expectFail(out, specFileName);
-          expectTimeout(out, 1000, false); // neither 2000 (setTimeout), nor 5000 (default)
+          expectTimeout(out, 1000, false, testRunner); // neither 2000 (setTimeout), nor 5000 (default)
           expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
         });
       }
@@ -579,7 +579,7 @@ describe.each<DescribeOptions>([
 
         // Assert
         expectFail(out, specFileName);
-        expectTimeout(out, 1000, false); // neither 2000 (cli), nor 5000 (default)
+        expectTimeout(out, 1000, false, testRunner); // neither 2000 (cli), nor 5000 (default)
         expect(out).toMatch(/[×✕] property favor Jest setTimeout over Jest CLI timeout/);
       });
     });
@@ -679,10 +679,15 @@ function expectFail(out: string, specFileName: string): void {
   expect(out).toMatch(new RegExp('FAIL .*/' + specFileName));
 }
 
-function expectTimeout(out: string, timeout: number, isGlobalInterrupt: boolean): void {
+function expectTimeout(
+  out: string,
+  timeout: number,
+  isGlobalInterrupt: boolean,
+  testRunner: DescribeOptions['testRunner']
+): void {
   // Related to ticket https://github.com/facebook/jest/issues/13338
   const supportForGlobalLevel = !process.version.startsWith('v18.');
-  if (supportForGlobalLevel || !isGlobalInterrupt) {
+  if (supportForGlobalLevel || !isGlobalInterrupt || testRunner === 'jasmine') {
     expect(out).toContain('Property interrupted after 0 tests');
   } else {
     // In such context, interrupt from fast-check will occur after the one caused by Jest.

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,7 @@ __metadata:
     "@types/node": ^18.11.17
     fast-check: "workspace:*"
     jest: ^29.3.1
+    jest-jasmine2: ^29.3.1
     ts-jest: ^29.0.3
     typescript: ^4.9.4
   peerDependencies:
@@ -6208,6 +6209,31 @@ __metadata:
     fsevents:
       optional: true
   checksum: 97ea26af0c28a2ba568c9c65d06211487bbcd501cb4944f9d55e07fd2b00ad96653ea2cc9033f3d5b7dc1feda33e47ae9cc56b400191ea4533be213c9f82e67c
+  languageName: node
+  linkType: hard
+
+"jest-jasmine2@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-jasmine2@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/expect": ^29.3.1
+    "@jest/source-map": ^29.2.0
+    "@jest/test-result": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.3.1
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-runtime: ^29.3.1
+    jest-snapshot: ^29.3.1
+    jest-util: ^29.3.1
+    p-limit: ^3.1.0
+    pretty-format: ^29.3.1
+  checksum: e8a3fabed31322ee2f9b687e5f0955bb0114634007aa0edc43742babb43b84f243a81e00fe97daa5bfe51def4ebe4b8f9fdf6561858d6eb1c5d2473de15aca59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While jasmine runner is not anymore the default runner, it used to be the default one for a while (and for version we officially support). As a consequence not supporting it today is not possible, so this PR fixes this issue.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
