### PR TITLE
⚡️ Do not wrap stream when dropping 0 items

### DIFF
--- a/.yarn/versions/aecf7c7e.yml
+++ b/.yarn/versions/aecf7c7e.yml
@@ -1,0 +1,7 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/stream/Stream.ts
+++ b/packages/fast-check/src/stream/Stream.ts
@@ -112,6 +112,9 @@ export class Stream<T> implements IterableIterator<T> {
    * @remarks Since 0.0.1
    */
   drop(n: number): Stream<T> {
+    if (n <= 0) {
+      return this;
+    }
     let idx = 0;
     function helper(): boolean {
       return idx++ < n;


### PR DESCRIPTION
The previous implementation of `Stream::drop` was causing adding an unneeded wrapping level when asking to drop 0 items, while it could just have returned itself.

This PR attempts to drop this extra wrapping in order to check how impactful such removal could be.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
