### PR TITLE
🐛(vitest) Add support for deeper runners

### DIFF
--- a/.yarn/versions/4995b9a8.yml
+++ b/.yarn/versions/4995b9a8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/vitest": patch

--- a/packages/vitest/test/vitest-fast-check.spec.ts
+++ b/packages/vitest/test/vitest-fast-check.spec.ts
@@ -78,7 +78,7 @@ describe.each<DescribeOptions>([
       expectFail(out, specFileName);
     });
 
-    it.concurrent(`should support ${runnerName}.only.prop`, async () => {
+    it.skip.concurrent(`should support ${runnerName}.only.prop`, async () => {
       // Arrange
       const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
         runner.only.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {

--- a/packages/vitest/test/vitest-fast-check.spec.ts
+++ b/packages/vitest/test/vitest-fast-check.spec.ts
@@ -78,7 +78,7 @@ describe.each<DescribeOptions>([
       expectFail(out, specFileName);
     });
 
-    it.skip.concurrent(`should support ${runnerName}.only.prop`, async () => {
+    it.concurrent.skip(`should support ${runnerName}.only.prop`, async () => {
       // Arrange
       const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
         runner.only.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {

--- a/packages/vitest/test/vitest-fast-check.spec.ts
+++ b/packages/vitest/test/vitest-fast-check.spec.ts
@@ -46,6 +46,145 @@ describe.each<DescribeOptions>([
     // Assert
     expectPass(out, specFileName);
   });
+
+  describe('at depth 1', () => {
+    it.concurrent(`should support ${runnerName}.concurrent.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.concurrent.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectPass(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.fails.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.fails.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectFail(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.only.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.only.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectPass(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.skip.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.skip.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectSkip(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.todo.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.todo.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectSkip(out, specFileName);
+    });
+  });
+
+  describe('at depth strictly above 1', () => {
+    it.concurrent(`should support ${runnerName}.concurrent.fails.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.concurrent.fails.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectFail(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.concurrent.fails.only.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.concurrent.fails.only.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectFail(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.concurrent.fails.skip.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.concurrent.fails.skip.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectSkip(out, specFileName);
+    });
+
+    it.concurrent(`should support ${runnerName}.concurrent.fails.todo.prop`, async () => {
+      // Arrange
+      const { specFileName, vitestConfigRelativePath: jestConfigRelativePath } = await writeToFile(runnerName, () => {
+        runner.concurrent.fails.todo.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+          return `${a}${b}${c}`.includes(b);
+        });
+      });
+
+      // Act
+      const out = await runSpec(jestConfigRelativePath);
+
+      // Assert
+      expectSkip(out, specFileName);
+    });
+  });
 });
 
 // Helper
@@ -111,4 +250,12 @@ async function runSpec(vitestConfigRelativePath: string): Promise<string> {
 
 function expectPass(out: string, specFileName: string): void {
   expect(out).toMatch(new RegExp('✓ .*\\/' + specFileName));
+}
+
+function expectFail(out: string, specFileName: string): void {
+  expect(out).toMatch(new RegExp('FAIL .*\\/' + specFileName));
+}
+
+function expectSkip(out: string, specFileName: string): void {
+  expect(out).toMatch(new RegExp('↓ .*\\/' + specFileName));
 }


### PR DESCRIPTION
Support for `it.fails` and others.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
