### PR TITLE
👷 Always build against latest node

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -183,7 +183,7 @@ jobs:
           - '@fast-check/vitest'
           - '@fast-check/worker'
         script-name: ['test']
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, latest]
         os: ['ubuntu-latest']
         include:
           # More platforms and scripts...

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -690,9 +690,7 @@ function expectTimeout(
   isGlobalInterrupt: boolean,
   testRunner: DescribeOptions['testRunner']
 ): void {
-  // Related to ticket https://github.com/facebook/jest/issues/13338
-  const supportForGlobalLevel = supportForGlobalLevel();
-  if (supportForGlobalLevel || !isGlobalInterrupt || testRunner === 'jasmine') {
+  if (supportForGlobalLevel() || !isGlobalInterrupt || testRunner === 'jasmine') {
     expect(out).toContain('Property interrupted after 0 tests');
   } else {
     // In such context, interrupt from fast-check will occur after the one caused by Jest.

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -434,7 +434,7 @@ describe.each<DescribeOptions>([
   });
 
   describe('timeout', () => {
-    if (!useWorkers || !process.version.startsWith('v18.')) {
+    if (!useWorkers || supportForGlobalLevel()) {
       it.concurrent('should fail as test takes longer than global Jest timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
@@ -476,7 +476,7 @@ describe.each<DescribeOptions>([
       });
     }
 
-    if (!useWorkers || !process.version.startsWith('v18.')) {
+    if (!useWorkers || supportForGlobalLevel()) {
       it.concurrent('should fail as test takes longer than Jest config timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(
@@ -519,7 +519,7 @@ describe.each<DescribeOptions>([
       expect(out).toMatch(/[×✕] property takes longer than Jest setTimeout/);
     });
 
-    if (!useWorkers || !process.version.startsWith('v18.')) {
+    if (!useWorkers || supportForGlobalLevel()) {
       it.concurrent('should fail as test takes longer than Jest CLI timeout', async () => {
         // Arrange
         const { specFileName, jestConfigRelativePath } = await writeToFile(runnerName, options, () => {
@@ -679,6 +679,11 @@ function expectFail(out: string, specFileName: string): void {
   expect(out).toMatch(new RegExp('FAIL .*/' + specFileName));
 }
 
+function supportForGlobalLevel() {
+  // Related to ticket https://github.com/facebook/jest/issues/13338
+  return !(process.version.startsWith('v18.') || process.version.startsWith('v19.'));
+}
+
 function expectTimeout(
   out: string,
   timeout: number,
@@ -686,7 +691,7 @@ function expectTimeout(
   testRunner: DescribeOptions['testRunner']
 ): void {
   // Related to ticket https://github.com/facebook/jest/issues/13338
-  const supportForGlobalLevel = !process.version.startsWith('v18.');
+  const supportForGlobalLevel = supportForGlobalLevel();
   if (supportForGlobalLevel || !isGlobalInterrupt || testRunner === 'jasmine') {
     expect(out).toContain('Property interrupted after 0 tests');
   } else {


### PR DESCRIPTION
It would prevent regressions linked to latest releases of node from surfacing only when the version starts to be an LTS.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
