### PR TITLE
Lock pure-rand dependency to 6.0.0 instead of range

### DIFF
--- a/packages/fast-check/package.json
+++ b/packages/fast-check/package.json
@@ -53,7 +53,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "pure-rand": "^6.0.0"
+    "pure-rand": "6.0.0"
   },
   "devDependencies": {
     "@fast-check/poisoning": "workspace:*",


### PR DESCRIPTION
This will protect against potential supply chain attacks.

Your library is used in security-critical apps. Even though lockfiles are utilized, i'd prefer a simple deterministic solution.
