### PR TITLE
🐛(vitest) Fix vitest import failing due to TestBuilder

### DIFF
--- a/.yarn/versions/66290b37.yml
+++ b/.yarn/versions/66290b37.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/vitest": patch

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -24,7 +24,7 @@
     "build:publish-cjs": "tsc -p tsconfig.publish.json",
     "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm && cp package.esm-template.json lib/esm/package.json",
     "test": "jest",
-    "test-bundle": "vitest --config test-bundle/vitest.config.mjs",
+    "test-bundle": "node test-bundle/basic.mjs && vitest --config test-bundle/vitest.config.mjs",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/packages/vitest/src/vitest-fast-check.ts
+++ b/packages/vitest/src/vitest-fast-check.ts
@@ -1,6 +1,6 @@
 import { it as itVitest, test as testVitest } from 'vitest';
 import * as fc from 'fast-check';
-import { buildTest } from './internals/TestBuilder';
+import { buildTest } from './internals/TestBuilder.js';
 
 import type { FastCheckItBuilder } from './internals/TestBuilder';
 import type { It } from './internals/types';

--- a/packages/vitest/test-bundle/basic.mjs
+++ b/packages/vitest/test-bundle/basic.mjs
@@ -1,0 +1,25 @@
+// Checking that our package can be properly imported by ES Module imports.
+// It seems that in some cases, Vitest allow imports of invalid packages, with that dedicated
+// test case, we make sure that the package is correct from a Node point of view.
+
+import('@fast-check/vitest').then(
+  () => {
+    // In theory, Vitest is supposed to throw when imported outside of its own execution context
+    // but we prefer not failing if it starts not to be the case anymore as it sounds rather like
+    // testing an implementation detail of Vitest.
+  },
+  (err) => {
+    if (
+      err.message.includes('Vitest was initialized with native Node instead of Vite Node') &&
+      err.stack.includes('at new VitestUtils')
+    ) {
+      // When Vitest throws because it was not executed in the right context we receive: raw Error thrown by VitestUtils.
+      // We ignore errors linked to Vitest not being executed into the right context as this file is supposed not to be executed
+      // with the right context so it's fully expected to throw at this point.
+      return;
+    }
+    // When our modules are not properly defined, we receive: err.code === "ERR_MODULE_NOT_FOUND".
+    // Or at least, it's one of the possible errors we could receive.
+    throw err;
+  }
+);


### PR DESCRIPTION
In other words: Import TestBuilder.js with extension.

Not importing it via an explicit extension caused #3657. Indeed in modern js imports, any import have to specify an extension or more precisely to refer to the file with its full path (relative or absolute).

In theory, we have a dedicated test suite to cover this case, but it seems it was not able to fall into it. I'll probably check back later where it failed and why it did so.

Fixes #3657

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
