### PR TITLE
🐛 Declare types field first in exports

### DIFF
--- a/.yarn/versions/5db59271.yml
+++ b/.yarn/versions/5db59271.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/package.json
+++ b/packages/fast-check/package.json
@@ -7,8 +7,8 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "require": "./lib/fast-check.js",
       "types": "./lib/types/fast-check.d.ts",
+      "require": "./lib/fast-check.js",
       "default": "./lib/esm/fast-check.js"
     }
   },


### PR DESCRIPTION
It seems to work with it not being first but as linters explicitely tells it's a bad practice let's avoid any problem with it and move it as first field in exports so that we reduce the risks of issues related to bad definition of the package.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
