### PR TITLE
🔧 Drop website build on `build:all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   ],
   "scripts": {
     "contributor:add": "all-contributors add",
-    "build:all": "yarn workspaces foreach -pvi --topological-dev run build",
-    "build-ci:all": "yarn workspaces foreach -pvi --topological-dev run build-ci",
+    "build:all": "yarn workspaces foreach -pvi --topological-dev --exclude website run build",
+    "build-ci:all": "yarn workspaces foreach -pvi --topological-dev --exclude website run build-ci",
     "test:all": "yarn workspaces foreach -pvi run test && yarn workspaces foreach -pvi run e2e",
     "typecheck:all": "yarn workspaces foreach -pvi run typecheck",
     "format": "prettier --cache --write .",


### PR DESCRIPTION
Building the website for the documentation has already a dedicated step in the workflow. No need to build it twice. Additionally it's one of the most costly package to build so worth dropping it from fast paths.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
