### PR TITLE
💚 Stabilize tests on `jsonValue`

### DIFF
--- a/packages/fast-check/test/unit/arbitrary/jsonValue.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/jsonValue.spec.ts
@@ -27,7 +27,13 @@ describe('jsonValue (integration)', () => {
   );
 
   const isCorrect = (v: unknown, extra: Extra) => {
-    expect(JSON.parse(fc.stringify(v))).toEqual(v); // JSON.stringify does not handle the -0 properly
+    // JSON.stringify does not handle the -0 properly
+    // And fc.stringify produces '["__proto__"]:' whenever it encounters __proto__ as a key
+    // Our 'safeStringified' should hanlde both of the problems!
+    const intermediateStringified = fc.stringify(v);
+    const safeStringified = intermediateStringified.replace(/\["__proto__"\]:/g, '"__proto__":');
+    expect(JSON.parse(safeStringified)).toEqual(v);
+
     if (extra !== undefined && extra.maxDepth !== undefined) {
       expect(computeObjectDepth(v)).toBeLessThanOrEqual(extra.maxDepth);
     }

--- a/packages/fast-check/test/unit/arbitrary/unicodeJsonValue.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/unicodeJsonValue.spec.ts
@@ -27,7 +27,13 @@ describe('unicodeJsonValue (integration)', () => {
   );
 
   const isCorrect = (v: unknown, extra: Extra) => {
-    expect(JSON.parse(fc.stringify(v))).toEqual(v); // JSON.stringify does not handle the -0 properly
+    // JSON.stringify does not handle the -0 properly
+    // And fc.stringify produces '["__proto__"]:' whenever it encounters __proto__ as a key
+    // Our 'safeStringified' should hanlde both of the problems!
+    const intermediateStringified = fc.stringify(v);
+    const safeStringified = intermediateStringified.replace(/\["__proto__"\]:/g, '"__proto__":');
+    expect(JSON.parse(safeStringified)).toEqual(v);
+
     if (extra !== undefined && extra.maxDepth !== undefined) {
       expect(computeObjectDepth(v)).toBeLessThanOrEqual(extra.maxDepth);
     }


### PR DESCRIPTION
THe current implementation of the test suffered from the fact that `fc.stringify` was producing valid JS values while `JSON.parse` was expecting valid JSON values. As the two specs are not fully aligned being a valid JS value does not imply being a valid JSON one.

Fixes #3478

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
