### PR TITLE
✨ Add support for negate regex

### DIFF
--- a/.yarn/versions/9fbd0c94.yml
+++ b/.yarn/versions/9fbd0c94.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
@@ -35,6 +35,13 @@ describe('tokenizeRegex', () => {
     { regex: /[ac-ez]/ },
     { regex: /[A-Z][a-z]*/ },
     { regex: /[a\-z]/ },
+    { regex: /[\wz]/ },
+    { regex: /[.-f]/ },
+    { regex: /[\w-z]/, invalidWithUnicode: true }, // equivalent to [w-z]
+    { regex: /[^abc]/ },
+    { regex: /[^a-z]/ },
+    { regex: /[abc^def]/ },
+    { regex: /[a-z^A-Z]/ },
     { regex: /\u{1[81]}/, invalidWithUnicode: true },
     { regex: /[\u{1f431}-\u{1f434}]/u },
   ];

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -10,6 +10,8 @@ describe('stringMatching (integration)', () => {
   const regexQuantifiableChunks = [
     '[s-z]', // any character in range s to z
     '[ace]', // any character from ace
+    '[^s-z]', // any character not in range s to z
+    '[^ace]', // any character not from ace
     '.', // 'any' character
     ...['w', 'd', 's' /*'b'*/].map((v) => `\\${v}`), // lower case meta characters
     ...['w', 'd', 's' /*'b'*/].map((v) => `\\${v.toUpperCase()}`), // upper case meta characters


### PR DESCRIPTION
Up-to-now our `stringMatching` arbitrary was unable to deal properly with `[^a-z]` or `[^abc]`. With that PR, it will be able to deal with them.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
