### PR TITLE
✨ Explicit ban of unsupported regex flags in `stringMatching`

### DIFF
--- a/.yarn/versions/8ce44fac.yml
+++ b/.yarn/versions/8ce44fac.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -133,11 +133,18 @@ function toMatchingArbitrary(astNode: RegexToken, constraints: StringMatchingCon
  * @public
  */
 export function stringMatching(regex: RegExp, constraints: StringMatchingConstraints = {}): Arbitrary<string> {
-  if (regex.flags.includes('i')) {
-    throw new Error('Unable to produce string matching case insensitive regexes');
-  }
-  if (regex.flags.includes('u')) {
-    throw new Error('Unable to produce string matching unicode regexes');
+  for (const flag of regex.flags) {
+    // Supported:
+    //   g - all matches, not limited to first match
+    // Not supported:
+    //   i - case-insensitive
+    //   m - multiline
+    //   s - dot matches newline character
+    //   u - unicode support
+    //   y - search at the exact position in the text or sticky mode
+    if (flag !== 'g') {
+      throw new Error(`Unable to use "stringMatching" against a regex using the flag ${flag}`);
+    }
   }
   const sanitizedConstraints: StringMatchingConstraints = { size: constraints.size };
   const regexRootToken = tokenizeRegex(regex);


### PR DESCRIPTION
Many flags on regexes are not supported by `stringMatching` at the moment. Instead of letting users detect the issues, we reject before generating anything to make it clear. Support for some of them will come as we enrich this feature.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
