### PR TITLE
✨ Add support for disjunctions in regexes

### DIFF
--- a/.yarn/versions/bad5dc1c.yml
+++ b/.yarn/versions/bad5dc1c.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -130,6 +130,9 @@ function toMatchingArbitrary(astNode: RegexToken, constraints: StringMatchingCon
     case 'Group': {
       return toMatchingArbitrary(astNode.expression, constraints);
     }
+    case 'Disjunction': {
+      return oneof(toMatchingArbitrary(astNode.left, constraints), toMatchingArbitrary(astNode.right, constraints));
+    }
     default: {
       throw raiseUnsupportedASTNode(astNode);
     }

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
@@ -56,6 +56,14 @@ describe('tokenizeRegex', () => {
     { regex: /([)])/ },
     { regex: /([)\]])/ },
     { regex: /(function\s+)(?<name>[$_A-Z][$_A-Za-z0-9]*)/ },
+    { regex: /a|b/ }, // 'or' with only two operands containing a single token each
+    { regex: /a|b|c/ }, // 'or' with strictly more than two operands containing a single token each
+    { regex: /abc|def/ }, // 'or' with only two operands containing a multiple tokens each
+    { regex: /abc|def|h|jkl/ }, // 'or' with strictly more than two operands
+    { regex: /abc|[|]/ }, // 'or' with operands having pipe in it
+    { regex: /abc|\|/ }, // 'or' with operands having escaped pipe in it
+    { regex: /a\w+c|d.*|e[f-k]l/ }, // 'or' with complex operands
+    { regex: /(abc|def)/ },
   ];
 
   describe('non-unicode regex', () => {


### PR DESCRIPTION
Supporting regex patterns such as `a|b|c` is key if we want to release `stringMatching` at some point. Adding such support is the aim of this PR.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
