### PR TITLE
✨ Correctly parse ^ and $ in regex

### DIFF
--- a/.yarn/versions/feb84070.yml
+++ b/.yarn/versions/feb84070.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/helpers/TokenizeRegex.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/TokenizeRegex.ts
@@ -84,6 +84,10 @@ type DisjunctionRegexToken = {
   left: RegexToken;
   right: RegexToken;
 };
+type AssertionRegexToken = {
+  type: 'Assertion';
+  kind: '^' | '$';
+};
 
 export type RegexToken =
   | CharRegexToken
@@ -93,7 +97,8 @@ export type RegexToken =
   | CharacterClassRegexToken
   | ClassRangeRegexToken
   | GroupRegexToken
-  | DisjunctionRegexToken;
+  | DisjunctionRegexToken
+  | AssertionRegexToken;
 
 /**
  * Create a simple char token
@@ -343,7 +348,13 @@ function pushTokens(tokens: RegexToken[], regexSource: string, unicodeMode: bool
         break;
       }
       default: {
-        tokens.push(blockToCharToken(block));
+        if (block === '^') {
+          tokens.push({ type: 'Assertion', kind: block });
+        } else if (block === '$') {
+          tokens.push({ type: 'Assertion', kind: block });
+        } else {
+          tokens.push(blockToCharToken(block));
+        }
         break;
       }
     }

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -133,6 +133,9 @@ function toMatchingArbitrary(astNode: RegexToken, constraints: StringMatchingCon
     case 'Disjunction': {
       return oneof(toMatchingArbitrary(astNode.left, constraints), toMatchingArbitrary(astNode.right, constraints));
     }
+    case 'Assertion': {
+      return constant('');
+    }
     default: {
       throw raiseUnsupportedASTNode(astNode);
     }

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
@@ -64,6 +64,14 @@ describe('tokenizeRegex', () => {
     { regex: /abc|\|/ }, // 'or' with operands having escaped pipe in it
     { regex: /a\w+c|d.*|e[f-k]l/ }, // 'or' with complex operands
     { regex: /(abc|def)/ },
+    { regex: /^ab$/ },
+    { regex: /[^a][b$]/ },
+    { regex: /[a^][$b]/ },
+    { regex: /(^|a)(b|$)/ },
+    { regex: /(a|^)($|b)/ },
+    { regex: /a^$b/ },
+    { regex: /a*^$b*/ }, // matches '', but not 'aa', seems equivalent to /^$/
+    { regex: /\^ab\$/ },
   ];
 
   describe('non-unicode regex', () => {


### PR DESCRIPTION
The current tokenizer parsing the regexes passed to `stringMatching` was unable to correctly parse ^ and $. It now correctly does.

We still not really interpret the non-existance of them as a possible escape to create more data before or after the pattern but we will attempt to do so in the upcoming PRs.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
