### PR TITLE
✨ Support generation of strings not constrained by ^ or $

### DIFF
--- a/.yarn/versions/6bfcbed8.yml
+++ b/.yarn/versions/6bfcbed8.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/helpers/SanitizeRegexAst.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/SanitizeRegexAst.ts
@@ -1,0 +1,113 @@
+import { stringify } from '../../../utils/stringify';
+import { RegexToken } from './TokenizeRegex';
+
+function raiseUnsupportedASTNode(astNode: never): Error {
+  return new Error(`Unsupported AST node! Received: ${stringify(astNode)}`);
+}
+
+type TraversalResults = { hasStart: boolean; hasEnd: boolean };
+
+function addMissingDotStarTraversalAddMissing(astNode: RegexToken, isFirst: boolean, isLast: boolean): RegexToken {
+  const traversalResults = { hasStart: false, hasEnd: false };
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  const revampedNode = addMissingDotStarTraversal(astNode, isFirst, isLast, traversalResults);
+  const missingStart = isFirst && !traversalResults.hasStart;
+  const missingEnd = isLast && !traversalResults.hasEnd;
+  if (!missingStart && !missingEnd) {
+    return revampedNode;
+  }
+  const expressions: RegexToken[] = [];
+  if (missingStart) {
+    expressions.push({ type: 'Assertion', kind: '^' });
+    expressions.push({
+      type: 'Repetition',
+      quantifier: { type: 'Quantifier', kind: '*', greedy: true },
+      expression: { type: 'Char', kind: 'meta', symbol: '.', value: '.', codePoint: Number.NaN },
+    });
+  }
+  expressions.push(revampedNode);
+  if (missingEnd) {
+    expressions.push({
+      type: 'Repetition',
+      quantifier: { type: 'Quantifier', kind: '*', greedy: true },
+      expression: { type: 'Char', kind: 'meta', symbol: '.', value: '.', codePoint: Number.NaN },
+    });
+    expressions.push({ type: 'Assertion', kind: '$' });
+  }
+  return { type: 'Group', capturing: false, expression: { type: 'Alternative', expressions } };
+}
+
+function addMissingDotStarTraversal(
+  astNode: RegexToken,
+  isFirst: boolean,
+  isLast: boolean,
+  traversalResults: TraversalResults
+): RegexToken {
+  switch (astNode.type) {
+    case 'Char':
+      return astNode;
+    case 'Repetition':
+      return astNode;
+    case 'Quantifier':
+      throw new Error(`Wrongly defined AST tree, Quantifier nodes not supposed to be scanned!`);
+    case 'Alternative':
+      traversalResults.hasStart = true; // disjunction always adds missing start and end if any
+      traversalResults.hasEnd = true;
+      return {
+        ...astNode,
+        expressions: astNode.expressions.map((node, index) =>
+          addMissingDotStarTraversalAddMissing(
+            node,
+            isFirst && index === 0,
+            isLast && index === astNode.expressions.length - 1
+          )
+        ),
+      };
+    case 'CharacterClass':
+      return astNode;
+    case 'ClassRange':
+      return astNode;
+    case 'Group': {
+      return {
+        ...astNode,
+        expression: addMissingDotStarTraversal(astNode.expression, isFirst, isLast, traversalResults),
+      };
+    }
+    case 'Disjunction': {
+      traversalResults.hasStart = true; // disjunction always adds missing start and end if any
+      traversalResults.hasEnd = true;
+      return {
+        ...astNode,
+        left: astNode.left !== null ? addMissingDotStarTraversalAddMissing(astNode.left, isFirst, isLast) : null,
+        right: astNode.right !== null ? addMissingDotStarTraversalAddMissing(astNode.right, isFirst, isLast) : null,
+      };
+    }
+    case 'Assertion': {
+      if (astNode.kind === '^' || astNode.kind === 'Lookahead') {
+        traversalResults.hasStart = true;
+        return astNode;
+      } else if (astNode.kind === '$' || astNode.kind === 'Lookbehind') {
+        traversalResults.hasEnd = true;
+        return astNode;
+      } else {
+        throw new Error(`Assertions of kind ${astNode.kind} not implemented yet!`);
+      }
+    }
+    case 'Backreference':
+      return astNode;
+    default:
+      throw raiseUnsupportedASTNode(astNode);
+  }
+}
+
+/**
+ * Revamp a regex token tree into one featuring missing ^ and $ assertions.
+ *
+ * WARNING: The produced tree may not define the same groups.
+ * Refer to the unit tests for more details on this limitation.
+ *
+ * @internal
+ */
+export function addMissingDotStar(astNode: RegexToken): RegexToken {
+  return addMissingDotStarTraversalAddMissing(astNode, true, true);
+}

--- a/packages/fast-check/src/arbitrary/_internals/helpers/SanitizeRegexAst.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/SanitizeRegexAst.ts
@@ -8,6 +8,9 @@ function raiseUnsupportedASTNode(astNode: never): Error {
 type TraversalResults = { hasStart: boolean; hasEnd: boolean };
 
 function addMissingDotStarTraversalAddMissing(astNode: RegexToken, isFirst: boolean, isLast: boolean): RegexToken {
+  if (!isFirst && !isLast) {
+    return astNode;
+  }
   const traversalResults = { hasStart: false, hasEnd: false };
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const revampedNode = addMissingDotStarTraversal(astNode, isFirst, isLast, traversalResults);

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -3,6 +3,7 @@ import { safeEvery, safeJoin } from '../utils/globals';
 import { Error, safeIndexOf, safeMap } from '../utils/globals';
 import { stringify } from '../utils/stringify';
 import { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength';
+import { addMissingDotStar } from './_internals/helpers/SanitizeRegexAst';
 import { tokenizeRegex, RegexToken } from './_internals/helpers/TokenizeRegex';
 import { char } from './char';
 import { constant } from './constant';
@@ -181,6 +182,6 @@ export function stringMatching(regex: RegExp, constraints: StringMatchingConstra
     }
   }
   const sanitizedConstraints: StringMatchingConstraints = { size: constraints.size };
-  const regexRootToken = tokenizeRegex(regex);
+  const regexRootToken = addMissingDotStar(tokenizeRegex(regex));
   return toMatchingArbitrary(regexRootToken, sanitizedConstraints);
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/SanitizeRegexAst.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/SanitizeRegexAst.spec.ts
@@ -1,0 +1,27 @@
+import { addMissingDotStar } from '../../../../../src/arbitrary/_internals/helpers/SanitizeRegexAst';
+import { tokenizeRegex } from '../../../../../src/arbitrary/_internals/helpers/TokenizeRegex';
+
+describe('addMissingDotStar', () => {
+  it.each`
+    source              | target
+    ${/a/}              | ${/(?:^.*a.*$)/}
+    ${/abc/}            | ${/(?:^.*a)b(?:c.*$)/}
+    ${/[a-z]/}          | ${/(?:^.*[a-z].*$)/}
+    ${/a|b/}            | ${/(?:^.*a.*$)|(?:^.*b.*$)/}
+    ${/(a)/}            | ${/(?:^.*(a).*$)/}
+    ${/(a|b)/}          | ${/((?:^.*a.*$)|(?:^.*b.*$))/ /* original group altered */}
+    ${/(a|^b$)/}        | ${/((?:^.*a.*$)|^b$)/ /* original group altered */}
+    ${/(^|b)a($|c)/}    | ${/(^|(?:^.*b))a($|(?:c.*$))/ /* original group altered */}
+    ${/(?<toto>a)/}     | ${/(?:^.*(?<toto>a).*$)/}
+    ${/(^|\s)a+(\s|$)/} | ${/(^|(?:^.*\s))a+((?:\s.*$)|$)/}
+  `('should transform $source into $target', ({ source, target }) => {
+    const sourceAst = tokenizeRegex(source);
+    const targetAst = tokenizeRegex(target);
+
+    const transformedSourceAst = addMissingDotStar(sourceAst);
+    expect(transformedSourceAst).toEqual(targetAst);
+
+    const twiceTransformedSourceAst = addMissingDotStar(transformedSourceAst);
+    expect(twiceTransformedSourceAst).toEqual(transformedSourceAst);
+  });
+});

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -65,9 +65,9 @@ String matching the passed regex.
 **Usages:**
 
 ```js
-fc.stringMatching(/html|php|css|java(script)?/);
+fc.stringMatching(/\s(html|php|css|java(script)?)\s/);
 // Note: The regex does not contain ^ or $ assertions, so extra text could be added before and after the match
-// Examples of generated values: "css", "html", "java", "php", "javascript"…
+// Examples of generated values: "ca\rjava U4", "'Kn7&cP<5:\tjava\n", "<NfX\rcss\r*.", "%\u000bjavascript\fname", "#\u000bcss\u000b`&HpS"…
 
 fc.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[12345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 // Note: Regex matching UUID


### PR DESCRIPTION
Up-to-now generating strings out of regexes not defining ^ and $ was equivalent to having them. It now differs!

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
