### PR TITLE
✅ Test against more regexes in `stringMatching`

### DIFF
--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -7,6 +7,55 @@ import {
 } from './__test-helpers__/ArbitraryAssertions';
 
 describe('stringMatching (integration)', () => {
+  const extraParameters: fc.Arbitrary<Extra> = fc.oneof(hardcodedRegex(), regexBasedOnChunks());
+
+  const stringMatchingBuilder = (extra: Extra) => stringMatching(extra.regex);
+
+  const isCorrect = (value: string, extra: Extra) => extra.regex.test(value);
+
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(stringMatchingBuilder, { extraParameters });
+  });
+
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(stringMatchingBuilder, isCorrect, { extraParameters });
+  });
+});
+
+// Helpers
+
+type Extra = { regex: RegExp };
+
+function hardcodedRegex(): fc.Arbitrary<Extra> {
+  return fc.constantFrom(
+    // IPv4
+    { regex: /^\d+\.\d+\.\d+\.\d+$/ },
+    // IPv4
+    { regex: /^([0-9]{1,3}\.){3}\.([0-9]{1,3})$/ },
+    // IPv4
+    {
+      regex:
+        /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/,
+    },
+    // IPv6
+    {
+      regex:
+        /^((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b).){3}(b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b))|(([0-9A-Fa-f]{1,4}:){0,5}:((b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b).){3}(b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b))|(::([0-9A-Fa-f]{1,4}:){0,5}((b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b).){3}(b((25[0-5])|(1d{2})|(2[0-4]d)|(d{1,2}))b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))$/,
+    },
+    // E-mail address based on RFC-1123
+    {
+      regex:
+        /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+    },
+    // E-mail address based on RFC-5322
+    {
+      regex:
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+    }
+  );
+}
+
+function regexBasedOnChunks(): fc.Arbitrary<Extra> {
   const regexQuantifiableChunks = [
     '[s-z]', // any character in range s to z
     '[ace]', // any character from ace
@@ -19,8 +68,7 @@ describe('stringMatching (integration)', () => {
     ...'\r\n\x1E\x15', // new lines and terminators
     ...'0123456789ABCDEFabcdef-', // some letters, digits... (just some hardcoded characters)
   ];
-  type Extra = { regex: RegExp };
-  const extraParameters: fc.Arbitrary<Extra> = fc
+  return fc
     .array(
       fc.record({
         startAssertion: fc.boolean(),
@@ -73,16 +121,4 @@ describe('stringMatching (integration)', () => {
         ),
       };
     });
-
-  const stringMatchingBuilder = (extra: Extra) => stringMatching(extra.regex);
-
-  const isCorrect = (value: string, extra: Extra) => extra.regex.test(value);
-
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(stringMatchingBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(stringMatchingBuilder, isCorrect, { extraParameters });
-  });
-});
+}


### PR DESCRIPTION
The set of regexes we run `stringMatching` against was too restricted. In order to cover even more cases, we added some examples extracted from real world.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
