### PR TITLE
✨ Support regex flags: d, m and s

### DIFF
--- a/.yarn/versions/35c176bc.yml
+++ b/.yarn/versions/35c176bc.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -57,6 +57,14 @@ function hardcodedRegex(): fc.Arbitrary<Extra> {
 }
 
 function regexBasedOnChunks(): fc.Arbitrary<Extra> {
+  const supportFlagD = (() => {
+    try {
+      new RegExp('.', 'd'); // Not supported in Node 14
+      return true;
+    } catch (err) {
+      return false;
+    }
+  })();
   const regexQuantifiableChunks = [
     '[s-z]', // any character in range s to z
     '[ace]', // any character from ace
@@ -103,7 +111,10 @@ function regexBasedOnChunks(): fc.Arbitrary<Extra> {
           // u: fc.boolean(), // unicode
           // y: fc.boolean(), // sticky
         })
-        .map((flags) => `${flags.d ? 'd' : ''}${flags.g ? 'g' : ''}${flags.m ? 'm' : ''}${flags.s ? 's' : ''}`),
+        .map(
+          (flags) =>
+            `${flags.d && supportFlagD ? 'd' : ''}${flags.g ? 'g' : ''}${flags.m ? 'm' : ''}${flags.s ? 's' : ''}`
+        ),
     })
     .map(({ disjunctions, flags }) => {
       return {


### PR DESCRIPTION
The flags i, u and y are still not supported yet.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
