### PR TITLE
✨ Support unicode regexes

### DIFF
--- a/.yarn/versions/be583bed.yml
+++ b/.yarn/versions/be583bed.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/helpers/ReadRegex.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/ReadRegex.ts
@@ -1,4 +1,13 @@
 /**
+ * Internal helper used to compute the size in bytes of one character
+ */
+function charSizeAt(text: string, pos: number) {
+  return text[pos] >= '\uD800' && text[pos] <= '\uDBFF' && text[pos + 1] >= '\uDC00' && text[pos + 1] <= '\uDFFF'
+    ? 2
+    : 1;
+}
+
+/**
  * Internal helper checking if a character is an hexadecimal one, ie: a-fA-F0-9
  */
 function isHexaDigit(char: string): boolean {
@@ -37,7 +46,7 @@ function parenthesisBlockContentEndFrom(text: string, from: number): number {
   for (let index = from; index !== text.length; ++index) {
     const char = text[index];
     if (char === '\\') {
-      index += 1;
+      index += 1; // in theory we should offset by charSizeAt, but same behaviour here
     } else if (char === ')') {
       if (numExtraOpened === 0) {
         return index;
@@ -213,12 +222,15 @@ function blockEndFrom(text: string, from: number, unicodeMode: boolean, mode: To
             }
             return subIndex;
           }
-          return from + 2;
+          const charSize = unicodeMode ? charSizeAt(text, from + 1) : 1;
+          return from + charSize + 1;
         }
       }
     }
-    default:
-      return from + 1;
+    default: {
+      const charSize = unicodeMode ? charSizeAt(text, from) : 1;
+      return from + charSize;
+    }
   }
 }
 

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -215,7 +215,7 @@ export function stringMatching(regex: RegExp, constraints: StringMatchingConstra
     //   i - case-insensitive
     //   u - unicode support
     //   y - search at the exact position in the text or sticky mode
-    if (flag !== 'd' && flag !== 'g' && flag !== 'm' && flag !== 's') {
+    if (flag !== 'd' && flag !== 'g' && flag !== 'm' && flag !== 's' && flag !== 'u') {
       throw new Error(`Unable to use "stringMatching" against a regex using the flag ${flag}`);
     }
   }

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/ReadRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/ReadRegex.spec.ts
@@ -49,6 +49,8 @@ describe('readFrom', () => {
     ${'\\k<group_name>'}         | ${'\\k<group_name>'}
     ${'\\k<group_name'}          | ${['\\k', null]}
     ${'(?<la>a(?<lb>b)c)'}       | ${'(?<la>a(?<lb>b)c)'}
+    ${'🐱'}                      | ${['\ud83d', '🐱']}
+    ${'\\🐱'}                    | ${['\\\ud83d', '\\🐱']}
   `('should properly extract first block of "$source"', ({ source, expected }) => {
     const expectedNonUnicode = typeof expected === 'string' ? expected : expected[0];
     const expectedUnicode = typeof expected === 'string' ? expected : expected[1];

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
@@ -16,7 +16,7 @@ describe('tokenizeRegex', () => {
     { regex: /.??/ },
     { regex: /.{1,4}?/ },
     { regex: /a/ },
-    { regex: /🐱/ },
+    { regex: /🐱/, invalidWithUnicode: true }, // handled separately
     { regex: /\125/, invalidWithUnicode: true },
     { regex: /\x25/ },
     { regex: /\u0025/ },
@@ -44,7 +44,6 @@ describe('tokenizeRegex', () => {
     { regex: /[abc^def]/ },
     { regex: /[a-z^A-Z]/ },
     { regex: /\u{1[81]}/, invalidWithUnicode: true },
-    { regex: /[\u{1f431}-\u{1f434}]/u },
     { regex: /[\u{1f431}-\u{1f434}]/u },
     { regex: /(foo)/ }, // capturing group
     { regex: /(foo) (bar) (baz)/ }, // multiple capturing groups
@@ -116,5 +115,40 @@ describe('tokenizeRegex', () => {
         }
       }
     );
+
+    it.each`
+      regex
+      ${/🐱/u}
+      ${/[🐱🐴]/u}
+      ${/[🐱-🐴]/u}
+      ${/[a-🐱b-🐴]/u}
+    `('should consider code-point as any other character when parsing $regex', ({ regex }) => {
+      const catReplacement = '\ufff0';
+      const horseReplacement = '\ufff4';
+      const revampedRegex = new RegExp(
+        regex.source.replace(/🐱/g, catReplacement).replace(/🐴/g, horseReplacement),
+        regex.flag
+      );
+      const tokenized = tokenizeRegex(regex);
+      const tokenizedRevamped = tokenizeRegex(revampedRegex);
+      const tokenizedRevampedUpdated = JSON.parse(
+        JSON.stringify(tokenizedRevamped, (key, value) => {
+          if (value === catReplacement) {
+            return '🐱';
+          }
+          if (value === catReplacement.codePointAt(0)) {
+            return '🐱'.codePointAt(0);
+          }
+          if (value === horseReplacement) {
+            return '🐴';
+          }
+          if (value === horseReplacement.codePointAt(0)) {
+            return '🐴'.codePointAt(0);
+          }
+          return value;
+        })
+      );
+      expect(tokenizedRevampedUpdated).toEqual(tokenized);
+    });
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/helpers/TokenizeRegex.spec.ts
@@ -119,6 +119,7 @@ describe('tokenizeRegex', () => {
     it.each`
       regex
       ${/🐱/u}
+      ${/🐱+/u}
       ${/[🐱🐴]/u}
       ${/[🐱-🐴]/u}
       ${/[a-🐱b-🐴]/u}

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -108,12 +108,14 @@ function regexBasedOnChunks(): fc.Arbitrary<Extra> {
           // i: fc.boolean(), // case-insensitive
           m: fc.boolean(), // multiline for ^ and $
           s: fc.boolean(), // multiline for .
-          // u: fc.boolean(), // unicode
+          u: fc.boolean(), // unicode
           // y: fc.boolean(), // sticky
         })
         .map(
           (flags) =>
-            `${flags.d && supportFlagD ? 'd' : ''}${flags.g ? 'g' : ''}${flags.m ? 'm' : ''}${flags.s ? 's' : ''}`
+            `${flags.d && supportFlagD ? 'd' : ''}${flags.g ? 'g' : ''}${flags.m ? 'm' : ''}${flags.s ? 's' : ''}${
+              flags.u ? 'u' : ''
+            }`
         ),
     })
     .map(({ disjunctions, flags }) => {


### PR DESCRIPTION
Regexes could be flagged as unicode ones by adding a small 'u' on them. When defined that way their behaviour defer a bit on some behaviours.

The most important change being that regexes start reading not byte by byte but code point by code point.

We just add support for them.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
