### PR TITLE
♻️(worker) Allow support for multiple predicates per worker

### DIFF
--- a/.yarn/versions/ef87c51d.yml
+++ b/.yarn/versions/ef87c51d.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/worker": patch
+
+declined:
+  - "@fast-check/jest"

--- a/packages/worker/src/internals/SharedTypes.ts
+++ b/packages/worker/src/internals/SharedTypes.ts
@@ -1,5 +1,5 @@
 import type { Arbitrary, IAsyncPropertyWithHooks } from 'fast-check';
-import { type PoolToWorkerMessage, type WorkerToPoolMessage } from './worker-pool/BasicPool.js';
+import { type PoolToWorkerMessage, type WorkerToPoolMessage } from './worker-pool/IWorkerPool.js';
 
 export type PropertyArbitraries<Ts extends unknown[]> = {
   [K in keyof Ts]: Arbitrary<Ts[K]>;

--- a/packages/worker/src/internals/worker-pool/IWorkerPool.ts
+++ b/packages/worker/src/internals/worker-pool/IWorkerPool.ts
@@ -7,14 +7,19 @@ export type OnErrorCallback = (error: unknown) => void;
 export type PooledWorker<TSuccess, TPayload> = {
   isAvailable: () => boolean;
   isFaulty: () => boolean;
-  register: (payload: TPayload, onSuccess: OnSuccessCallback<TSuccess>, onFailure: OnErrorCallback) => void;
+  register: (
+    predicateId: number,
+    payload: TPayload,
+    onSuccess: OnSuccessCallback<TSuccess>,
+    onFailure: OnErrorCallback
+  ) => void;
   terminateIfStillRunning: () => Promise<void>;
 };
 
 /**
  * Message exchanged from the pool to the worker
  */
-export type PoolToWorkerMessage<TPayload> = { runId: number; payload: TPayload };
+export type PoolToWorkerMessage<TPayload> = { targetPredicateId: number; runId: number; payload: TPayload };
 
 /**
  * Message exchanged from the worker to the pool

--- a/packages/worker/src/internals/worker-pool/OneTimePool.ts
+++ b/packages/worker/src/internals/worker-pool/OneTimePool.ts
@@ -11,10 +11,9 @@ export class OneTimePool<TSuccess, TPayload> implements IWorkerPool<TSuccess, TP
   /**
    * Instantiate a new pool of workers
    * @param workerFileUrl - URL of the script for workers
-   * @param workerId - Id of the worker to be passed to the worker at launch time
    */
-  constructor(workerFileUrl: URL, workerId: number) {
-    this.internalPool = new BasicPool<TSuccess, TPayload>(workerFileUrl, workerId);
+  constructor(workerFileUrl: URL) {
+    this.internalPool = new BasicPool<TSuccess, TPayload>(workerFileUrl);
   }
 
   spawnNewWorker(): Promise<PooledWorker<TSuccess, TPayload>> {

--- a/packages/worker/src/internals/worker-runner/NoWorkerRunner.ts
+++ b/packages/worker/src/internals/worker-runner/NoWorkerRunner.ts
@@ -1,8 +1,5 @@
 import { type MessagePort } from 'node:worker_threads';
-import {
-  type MainThreadToWorkerMessage,
-  type WorkerToMainThreadMessage,
-} from '../SharedTypes.js';
+import { type MainThreadToWorkerMessage, type WorkerToMainThreadMessage } from '../SharedTypes.js';
 
 /**
  * Setup the fallback worker listening to all predicates and rejecting any that has never been registered

--- a/packages/worker/src/internals/worker-runner/NoWorkerRunner.ts
+++ b/packages/worker/src/internals/worker-runner/NoWorkerRunner.ts
@@ -1,0 +1,28 @@
+import { type MessagePort } from 'node:worker_threads';
+import {
+  type MainThreadToWorkerMessage,
+  type WorkerToMainThreadMessage,
+} from '../SharedTypes.js';
+
+/**
+ * Setup the fallback worker listening to all predicates and rejecting any that has never been registered
+ * @param parentPort - the parent to listen to and sending us queries to execute
+ * @param registeredPredicates - list of all the predicates currently registered, can be updated after the call to runNoWorker
+ */
+export function runNoWorker(parentPort: MessagePort, registeredPredicates: Set<number>): void {
+  parentPort.on('message', (message: MainThreadToWorkerMessage<unknown>) => {
+    const { targetPredicateId, runId } = message;
+    if (registeredPredicates.has(targetPredicateId)) {
+      return;
+    }
+    const errorMessage = `Unregistered predicate, got: ${targetPredicateId}, for registered: ${[
+      ...registeredPredicates,
+    ].join(', ')}`;
+    const sentMessage: WorkerToMainThreadMessage = {
+      success: false,
+      error: new Error(errorMessage),
+      runId,
+    };
+    parentPort.postMessage(sentMessage);
+  });
+}

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -1,12 +1,17 @@
 import { isMainThread, parentPort, workerData } from 'node:worker_threads';
 
 import { assert as fcAssert, type IAsyncProperty, type IProperty, type Parameters } from 'fast-check';
-import { runWorker } from './internals/WorkerRunner.js';
+import { runWorker } from './internals/worker-runner/WorkerRunner.js';
 import { runMainThread } from './internals/MainThreadRunner.js';
 import { NoopWorkerProperty } from './internals/NoopWorkerProperty.js';
-import { type PropertyArbitraries, type PropertyPredicate, type WorkerProperty } from './internals/SharedTypes.js';
+import {
+  type PropertyArbitraries,
+  type PropertyPredicate,
+  type WorkerProperty,
+} from './internals/SharedTypes.js';
+import { runNoWorker } from './internals/worker-runner/NoWorkerRunner.js';
 
-let lastWorkerId = 0;
+let lastPredicateId = 0;
 const allKnownTerminateAllWorkersPerProperty = new Map<
   IAsyncProperty<unknown> | IProperty<unknown>,
   () => Promise<void>
@@ -64,23 +69,29 @@ export type PropertyForOptions = {
   isolationLevel?: 'property' | 'predicate';
 };
 
+const registeredPredicates = new Set<number>();
+if (!isMainThread && parentPort !== null && workerData.fastcheckWorker === true) {
+  runNoWorker(parentPort, registeredPredicates)
+}
+
 function workerProperty<Ts extends [unknown, ...unknown[]]>(
   url: URL,
   options: PropertyForOptions,
   ...args: [...arbitraries: PropertyArbitraries<Ts>, predicate: PropertyPredicate<Ts>]
 ): WorkerProperty<Ts> {
-  const currentWorkerId = ++lastWorkerId;
+  const currentPredicateId = ++lastPredicateId;
   if (isMainThread) {
     // Main thread code
     const isolationLevel = options.isolationLevel || 'property';
     const arbitraries = args.slice(0, -1) as PropertyArbitraries<Ts>;
-    const { property, terminateAllWorkers } = runMainThread<Ts>(url, currentWorkerId, isolationLevel, arbitraries);
+    const { property, terminateAllWorkers } = runMainThread<Ts>(url, currentPredicateId, isolationLevel, arbitraries);
     allKnownTerminateAllWorkersPerProperty.set(property, terminateAllWorkers);
     return property;
-  } else if (parentPort !== null && currentWorkerId === workerData.currentWorkerId) {
+  } else if (parentPort !== null && workerData.fastcheckWorker === true) {
     // Worker code
     const predicate = args[args.length - 1] as PropertyPredicate<Ts>;
-    runWorker(parentPort, predicate);
+    runWorker(parentPort, currentPredicateId, predicate);
+    registeredPredicates.add(currentPredicateId);
   }
   // Cannot throw for invalid worker at this point as we may not be the only worker for this run
   // so we just return a dummy no-op property

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -4,11 +4,7 @@ import { assert as fcAssert, type IAsyncProperty, type IProperty, type Parameter
 import { runWorker } from './internals/worker-runner/WorkerRunner.js';
 import { runMainThread } from './internals/MainThreadRunner.js';
 import { NoopWorkerProperty } from './internals/NoopWorkerProperty.js';
-import {
-  type PropertyArbitraries,
-  type PropertyPredicate,
-  type WorkerProperty,
-} from './internals/SharedTypes.js';
+import { type PropertyArbitraries, type PropertyPredicate, type WorkerProperty } from './internals/SharedTypes.js';
 import { runNoWorker } from './internals/worker-runner/NoWorkerRunner.js';
 
 let lastPredicateId = 0;
@@ -71,7 +67,7 @@ export type PropertyForOptions = {
 
 const registeredPredicates = new Set<number>();
 if (!isMainThread && parentPort !== null && workerData.fastcheckWorker === true) {
-  runNoWorker(parentPort, registeredPredicates)
+  runNoWorker(parentPort, registeredPredicates);
 }
 
 function workerProperty<Ts extends [unknown, ...unknown[]]>(

--- a/packages/worker/test/internals/worker-pool/BasicPool.spec.ts
+++ b/packages/worker/test/internals/worker-pool/BasicPool.spec.ts
@@ -1,4 +1,5 @@
-import { BasicPool, PoolToWorkerMessage, WorkerToPoolMessage } from '../../../src/internals/worker-pool/BasicPool.js';
+import { PoolToWorkerMessage, WorkerToPoolMessage } from '../../../src/internals/worker-pool/IWorkerPool.js';
+import { BasicPool } from '../../../src/internals/worker-pool/BasicPool.js';
 import * as WorkerThreadsMock from 'node:worker_threads';
 
 describe('BasicPool', () => {
@@ -6,15 +7,14 @@ describe('BasicPool', () => {
     // Arrange
     const { Worker, on, postMessage } = mockWorker();
     const workerFileUrl = new URL('file:///worker.cjs');
-    const workerId = 0;
-    const pool = new BasicPool(workerFileUrl, workerId);
+    const pool = new BasicPool(workerFileUrl);
 
     // Act
     pool.spawnNewWorker();
 
     // Assert
     expect(Worker).toHaveBeenCalledTimes(1);
-    expect(Worker).toHaveBeenCalledWith(workerFileUrl, { workerData: { currentWorkerId: workerId } });
+    expect(Worker).toHaveBeenCalledWith(workerFileUrl, { workerData: { fastcheckWorker: true } });
     expect(on).toHaveBeenCalled();
     expect(postMessage).not.toHaveBeenCalled();
   });
@@ -24,8 +24,7 @@ describe('BasicPool', () => {
       // Arrange
       const { on } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
-      const pool = new BasicPool(workerFileUrl, workerId);
+      const pool = new BasicPool(workerFileUrl);
 
       // Act
       const workerPromise = pool.spawnNewWorker();
@@ -41,16 +40,16 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
 
       // Act
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Assert
       expect(worker.isAvailable()).toBe(false);
@@ -64,15 +63,15 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
       const successMessage = 'success!';
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
@@ -94,15 +93,15 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
       const errorMessage = 'oups there was an error!';
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
@@ -124,14 +123,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
@@ -156,14 +155,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const onErrorHandler = on.mock.calls.find(([eventName]) => eventName === 'messageerror')![1];
@@ -181,14 +180,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const onErrorHandler = on.mock.calls.find(([eventName]) => eventName === 'error')![1];
@@ -206,14 +205,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
 
       // Act
       const exitCode = 101;
@@ -234,8 +233,7 @@ describe('BasicPool', () => {
       // Arrange
       const { on } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
 
       // Act
@@ -250,8 +248,7 @@ describe('BasicPool', () => {
       // Arrange
       const { on } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
 
       // Act
@@ -266,8 +263,7 @@ describe('BasicPool', () => {
       // Arrange
       const { on } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
 
       // Act
@@ -285,8 +281,7 @@ describe('BasicPool', () => {
       // Arrange
       const { on, terminate } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
@@ -305,14 +300,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage, terminate } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
       const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
       const receivedRunId = receivedMessage.runId;
       const message: WorkerToPoolMessage<string> = { runId: receivedRunId, success: true, output: 'successMessage' };
@@ -335,14 +330,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, postMessage, terminate } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
       const receivedMessage: PoolToWorkerMessage<string> = postMessage.mock.calls[0][0];
       const receivedRunId = receivedMessage.runId;
       const message: WorkerToPoolMessage<string> = { runId: receivedRunId, success: false, error: 'errorMessage' };
@@ -365,14 +360,14 @@ describe('BasicPool', () => {
       // Arrange
       const { on, terminate } = mockWorker();
       const workerFileUrl = new URL('file:///worker.cjs');
-      const workerId = 0;
+      const predicateId = 0;
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
-      const pool = new BasicPool<string, string>(workerFileUrl, workerId);
+      const pool = new BasicPool<string, string>(workerFileUrl);
       const workerPromise = pool.spawnNewWorker();
       fireOnlineEvent(on);
       const worker = await workerPromise;
-      worker.register('to-worker', onSuccess, onFailure);
+      worker.register(predicateId, 'to-worker', onSuccess, onFailure);
       expect(terminate).not.toHaveBeenCalled();
 
       // Act

--- a/packages/worker/test/main.spec.ts
+++ b/packages/worker/test/main.spec.ts
@@ -58,7 +58,7 @@ if (isMainThread) {
       async () => {
         // Arrange
         const unregisteredProperty = buildUnregisteredProperty();
-        const expectedError = /Worker stopped with exit code 0/;
+        const expectedError = /Unregistered predicate/;
 
         // Act / Assert
         await expect(assert(unregisteredProperty, defaultOptions)).rejects.toThrowError(expectedError);
@@ -103,7 +103,7 @@ if (isMainThread) {
       'should be able to isolate at predicate level',
       async () => {
         // Arrange
-        const options = { numRuns: 3 }; // predicate level isolation is way longer to run
+        const options = { ...defaultOptions, numRuns: 3 }; // predicate level isolation is way longer to run
 
         // Act / Assert
         await expect(assert(passingPropertyAsIsolatedAtPredicate, options)).resolves.not.toThrow();
@@ -115,7 +115,7 @@ if (isMainThread) {
       'should be able to isolate at property level and thus share workers cross-predicate',
       async () => {
         // Arrange
-        const options = { numRuns: 3 }; // just to rely on same options as the ones of 'predicate level isolation'
+        const options = { ...defaultOptions, numRuns: 3 }; // just to rely on same options as the ones of 'predicate level isolation'
         const expectedError = /Encounter counter different from 0/;
 
         // Act / Assert
@@ -128,7 +128,7 @@ if (isMainThread) {
       'should respawn a new worker when the predicate execution fails',
       async () => {
         // Arrange
-        const options = { verbose: 2 };
+        const options = { ...defaultOptions, verbose: 2 };
 
         // Act / Assert
         try {


### PR DESCRIPTION
Up to now, one worker was always linked to a single predicate. With this PR it's now feasible to have the same worker able to run many predicates.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
