### PR TITLE
✨(worker) Add "file" isolation level

### DIFF
--- a/.yarn/versions/69718570.yml
+++ b/.yarn/versions/69718570.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/worker": patch
+
+declined:
+  - "@fast-check/jest"

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -51,11 +51,14 @@ Refer to the tests defined `test/main.spec.ts` for a living example of how you c
 
 ## Extra options
 
-The builder of properties `propertyFor` accepts a second parameter to customize how the workers will behave. By default, workers will be shared across runs of predicates linked to the same instance of property. In case you want a full isolation between your runs, you can use:
+The builder of properties `propertyFor` accepts a second parameter to customize how the workers will behave. By default, workers will be shared across properties. In case you want a more isolation between your runs, you can use:
 
 ```js
 const property = propertyFor(new URL(import.meta.url), { isolationLevel: 'predicate' });
-// Other values: 'property' (the default)
+// Other values:
+// - "file": Re-use workers cross properties (default)
+// - "property": Re-use workers for each run of the predicate. Not shared across properties!
+// - "predicate": One worker per run of the predicate
 ```
 
 ## Minimal requirements

--- a/packages/worker/src/internals/worker-pool/GlobalPool.ts
+++ b/packages/worker/src/internals/worker-pool/GlobalPool.ts
@@ -1,0 +1,59 @@
+import { BasicPool } from './BasicPool.js';
+import { IWorkerPool, PooledWorker } from './IWorkerPool.js';
+
+const poolPerFile = new Map<string, BasicPool<unknown, unknown>>();
+const pendingTerminationPerFile = new Map<string, ReturnType<typeof setTimeout>>();
+
+function cancelPendingTerminationIfAny(workerFileUrl: URL) {
+  const key = workerFileUrl.toString();
+  const pendingTermination = pendingTerminationPerFile.get(key);
+  if (pendingTermination === undefined) {
+    return;
+  }
+  clearTimeout(pendingTermination);
+}
+
+/**
+ * Cross-properties pool able to re-use the workers for many properties
+ */
+export class GlobalPool<TSuccess, TPayload> implements IWorkerPool<TSuccess, TPayload> {
+  private readonly internalPool: BasicPool<TSuccess, TPayload>;
+
+  /**
+   * Instantiate a new pool of workers
+   * @param workerFileUrl - URL of the script for workers
+   */
+  constructor(private readonly workerFileUrl: URL) {
+    const key = workerFileUrl.toString();
+    const existingPool = poolPerFile.get(key);
+    if (existingPool !== undefined) {
+      this.internalPool = existingPool as BasicPool<TSuccess, TPayload>;
+    } else {
+      const freshPool = new BasicPool<TSuccess, TPayload>(workerFileUrl);
+      this.internalPool = freshPool;
+      poolPerFile.set(key, freshPool as BasicPool<unknown, unknown>);
+    }
+    cancelPendingTerminationIfAny(workerFileUrl);
+  }
+
+  spawnNewWorker(): Promise<PooledWorker<TSuccess, TPayload>> {
+    cancelPendingTerminationIfAny(this.workerFileUrl);
+    return this.internalPool.spawnNewWorker();
+  }
+
+  getFirstAvailableWorker(): PooledWorker<TSuccess, TPayload> | undefined {
+    cancelPendingTerminationIfAny(this.workerFileUrl);
+    return this.internalPool.getFirstAvailableWorker();
+  }
+
+  terminateAllWorkers(): Promise<void> {
+    cancelPendingTerminationIfAny(this.workerFileUrl);
+    pendingTerminationPerFile.set(
+      this.workerFileUrl.toString(),
+      setTimeout(() => {
+        this.internalPool.terminateAllWorkers();
+      }, 0)
+    );
+    return Promise.resolve();
+  }
+}

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -57,12 +57,13 @@ export type PropertyForOptions = {
    * How to isolate executions of the predicates from each others?
    * The more isolated they are the less risk if one execution alter shared globals, but the more time it takes.
    *
-   * - `property`: Re-use workers for each run of the predicate, except in case of faulty worker (not to mix with failing run). Not shared across properties!
+   * - `file`: Re-use workers cross properties
+   * - `property`: Re-use workers for each run of the predicate. Not shared across properties!
    * - `predicate`: One worker per run of the predicate
    *
-   * @default "property"
+   * @default "file"
    */
-  isolationLevel?: 'property' | 'predicate';
+  isolationLevel?: 'file' | 'property' | 'predicate';
 };
 
 const registeredPredicates = new Set<number>();
@@ -78,7 +79,7 @@ function workerProperty<Ts extends [unknown, ...unknown[]]>(
   const currentPredicateId = ++lastPredicateId;
   if (isMainThread) {
     // Main thread code
-    const isolationLevel = options.isolationLevel || 'property';
+    const isolationLevel = options.isolationLevel || 'file';
     const arbitraries = args.slice(0, -1) as PropertyArbitraries<Ts>;
     const { property, terminateAllWorkers } = runMainThread<Ts>(url, currentPredicateId, isolationLevel, arbitraries);
     allKnownTerminateAllWorkersPerProperty.set(property, terminateAllWorkers);

--- a/packages/worker/test/main.properties.cjs
+++ b/packages/worker/test/main.properties.cjs
@@ -40,6 +40,7 @@ exports.buildUnregisteredProperty = () =>
 let counterIsolatedAtPredicate = 0;
 exports.passingPropertyAsIsolatedAtPredicate = propertyFor(pathToFileURL(__filename), { isolationLevel: 'predicate' })(
   fc.integer({ min: -1000, max: 1000 }),
+  fc.integer({ min: -1000, max: 1000 }),
   (_from, _to) => {
     if (counterIsolatedAtPredicate !== 0) {
       throw new Error(`Encounter counter different from 0, got: ${counterIsolatedAtPredicate}`);
@@ -51,10 +52,48 @@ exports.passingPropertyAsIsolatedAtPredicate = propertyFor(pathToFileURL(__filen
 let counterIsolatedAtProperty = 0;
 exports.failingPropertyAsNotEnoughIsolated = propertyFor(pathToFileURL(__filename), { isolationLevel: 'property' })(
   fc.integer({ min: -1000, max: 1000 }),
+  fc.integer({ min: -1000, max: 1000 }),
   (_from, _to) => {
     if (counterIsolatedAtProperty !== 0) {
       throw new Error(`Encounter counter different from 0, got: ${counterIsolatedAtProperty}`);
     }
     counterIsolatedAtProperty += 1;
+  }
+);
+
+let isolatedCrossProperties = null;
+exports.passingPropertyAsIsolatedWarmUp = propertyFor(pathToFileURL(__filename), { isolationLevel: 'property' })(
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.integer({ min: -1000, max: 1000 }),
+  (_from, _to) => {
+    isolatedCrossProperties = 'warm-up';
+  }
+);
+exports.passingPropertyAsIsolatedRun = propertyFor(pathToFileURL(__filename), { isolationLevel: 'property' })(
+  fc.integer({ min: -1000, max: 1000 }),
+  (_from, _to) => {
+    if (isolatedCrossProperties !== null && isolatedCrossProperties !== 'run') {
+      throw new Error(`Broken isolation, got: ${isolatedCrossProperties}`);
+    }
+    isolatedCrossProperties = 'run';
+  }
+);
+
+let notIsolatedCrossProperties = null;
+exports.passingPropertyButBadlyIsolatedWarmUp = propertyFor(pathToFileURL(__filename), { isolationLevel: 'file' })(
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.integer({ min: -1000, max: 1000 }),
+  (_from, _to) => {
+    notIsolatedCrossProperties = 'warm-up';
+  }
+);
+exports.failingPropertyAsBadlyIsolatedRun = propertyFor(pathToFileURL(__filename), { isolationLevel: 'file' })(
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.integer({ min: -1000, max: 1000 }),
+  (_from, _to) => {
+    if (notIsolatedCrossProperties !== null && notIsolatedCrossProperties !== 'run') {
+      throw new Error(`Broken isolation, got: ${notIsolatedCrossProperties}`);
+    }
+    notIsolatedCrossProperties = 'run';
   }
 );

--- a/packages/worker/test/main.spec.ts
+++ b/packages/worker/test/main.spec.ts
@@ -9,6 +9,10 @@ import {
   buildUnregisteredProperty,
   passingPropertyAsIsolatedAtPredicate,
   failingPropertyAsNotEnoughIsolated,
+  passingPropertyAsIsolatedWarmUp,
+  passingPropertyAsIsolatedRun,
+  passingPropertyButBadlyIsolatedWarmUp,
+  failingPropertyAsBadlyIsolatedRun,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 } from './main.properties.cjs';
@@ -154,6 +158,31 @@ if (isMainThread) {
           }
           expect(foundOne).toBe(true);
         }
+      },
+      jestTimeout
+    );
+
+    it(
+      'should be able to isolate at property level',
+      async () => {
+        // Arrange
+        await expect(assert(passingPropertyAsIsolatedWarmUp, defaultOptions)).resolves.not.toThrow();
+
+        // Act / Assert
+        await expect(assert(passingPropertyAsIsolatedRun, defaultOptions)).resolves.not.toThrow();
+      },
+      jestTimeout
+    );
+
+    it(
+      'should be re-use the same worker across several properties when isolated at file level',
+      async () => {
+        // Arrange
+        const expectedError = /Broken isolation, got: warm-up/;
+        await expect(assert(passingPropertyButBadlyIsolatedWarmUp, defaultOptions)).resolves.not.toThrow();
+
+        // Act / Assert
+        await expect(assert(failingPropertyAsBadlyIsolatedRun, defaultOptions)).rejects.toThrowError(expectedError);
       },
       jestTimeout
     );


### PR DESCRIPTION
"file" isolation level will make `@fast-check/worker` able to re-use the same worker cross-properties. By doing so, we reduce the cost of running properties through workers as instead of requesting to spawn dedicated workers for the property we just use the ones already there is any.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
