### PR TITLE
✨(jest) Support passing options to worker

### DIFF
--- a/.yarn/versions/d43d3539.yml
+++ b/.yarn/versions/d43d3539.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": minor

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -90,6 +90,7 @@ const { init, fc } = require('@fast-check/jest/worker');
 const { pathToFileURL } = require('node:url');
 
 const { test, expect } = init(pathToFileURL(__filename));
+// can also be passed options such as isolationLevel: init(pathToFileURL(__filename), {})
 
 test.prop([fc.constant(null)])('should pass', (value) => {
   expect(value).toBe(null);
@@ -102,6 +103,7 @@ The ES Modules approach would be:
 import { init, fc } from '@fast-check/jest/worker';
 
 const { test, expect } = await init(new URL(import.meta.url));
+// can also be passed options such as isolationLevel: init(new URL(import.meta.url), {})
 
 test.prop([fc.constant(null)])('should pass', (value) => {
   expect(value).toBe(null);

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -51,7 +51,7 @@
     "fast-check": "^3.0.0"
   },
   "peerDependencies": {
-    "@fast-check/worker": "~0.0.1",
+    "@fast-check/worker": "~0.0.7",
     "@jest/expect": ">=28.0.0",
     "@jest/globals": ">=25.5.2"
   },

--- a/packages/jest/src/jest-fast-check-worker.ts
+++ b/packages/jest/src/jest-fast-check-worker.ts
@@ -1,5 +1,5 @@
 import * as fc from 'fast-check';
-import { assert, propertyFor } from '@fast-check/worker';
+import { assert, propertyFor, PropertyForOptions } from '@fast-check/worker';
 import { jestExpect } from '@jest/expect';
 import { buildTest } from './internals/TestBuilder.js';
 
@@ -51,9 +51,9 @@ function dummyTest(): It {
 
 type InitOutput = { test: FastCheckItBuilder<It>; it: FastCheckItBuilder<It>; expect: typeof jestExpect };
 
-export const init = (url: URL): InitOutput => {
+export const init = (url: URL, options?: PropertyForOptions): InitOutput => {
   const fcExtra: FcExtra = {
-    asyncProperty: propertyFor(url),
+    asyncProperty: propertyFor(url, options),
     assert: assert as FcExtra['assert'],
     readConfigureGlobal: fc.readConfigureGlobal,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2683,7 +2683,7 @@ __metadata:
     ts-jest: ^29.1.0
     typescript: ^5.0.4
   peerDependencies:
-    "@fast-check/worker": ~0.0.1
+    "@fast-check/worker": ~0.0.7
     "@jest/expect": ">=28.0.0"
     "@jest/globals": ">=25.5.2"
   peerDependenciesMeta:


### PR DESCRIPTION
The package `@fast-check/jest` propose an experimental support for `@fast-check/worker`. We enriched this support to add the ability for the users to pass extra configuration options to `@fast-check/worker` at initialization time such as the isolationLevel and possibly others that might come in next iterations.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
