### PR TITLE
🔒️ Drop raw install of npm

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -486,13 +486,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -526,13 +524,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -566,13 +562,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -606,13 +600,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -646,13 +638,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -686,13 +676,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -726,13 +714,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -766,13 +752,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Using Node v18.x
+      - name: Using Node v20.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install latest npm version
-        run: npm install -g npm@9.7.1
       - name: Download production packages
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:


### PR DESCRIPTION
In order to publish our package we need a version of npm supporting the `--provenance` flag. Unfortunately version 9.5 coming with node 18 does not, so we moved to node 20 as it comes with 9.6 and supports it without the manual global install of npm (it was a security isue for scorecard).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
