### PR TITLE
⚡ Faster `decomposeFloat/Double`

### DIFF
--- a/.yarn/versions/e40445ea.yml
+++ b/.yarn/versions/e40445ea.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ You should also check for linting by running `yarn lint:check` and fix lint prob
 
 #### GitHub Actions integration
 
-All pull requests will trigger GitHub Actions chekcs.
+All pull requests will trigger GitHub Actions checks.
 It ensures that the pull request follow the code style of the project and do not break existing tests.
 
 #### Notify how impactful your change will be

--- a/packages/fast-check/src/arbitrary/double.ts
+++ b/packages/fast-check/src/arbitrary/double.ts
@@ -52,14 +52,14 @@ export interface DoubleConstraints {
 }
 
 /**
- * Same as {@link doubleToIndex} except it throws in case of invalid double
+ * Same as {@link doubleToIndex} except it throws in case of invalid double (NaN)
  *
  * @internal
  */
 function safeDoubleToIndex(d: number, constraintsLabel: keyof DoubleConstraints) {
   if (safeNumberIsNaN(d)) {
     // Number.NaN does not have any associated index in the current implementation
-    throw new Error('fc.double constraints.' + constraintsLabel + ' must be a 32-bit float');
+    throw new Error('fc.double constraints.' + constraintsLabel + ' must be a 64-bit float');
   }
   return doubleToIndex(d);
 }


### PR DESCRIPTION
This replaces the (creative) loop-based implementation with a constant-time one. The number 1.234 is about 1100x faster and 1e30 is about 2300x faster.

If you're okay with this change I can do the same thing for double.

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [x] Performance - faster
- [ ] Typings
- [ ] _Other(s):_ ...
