### PR TITLE
⚡️ Drop some unneeded allocs in `ulid`

### DIFF
--- a/.yarn/versions/54a4cdd6.yml
+++ b/.yarn/versions/54a4cdd6.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
@@ -72,20 +72,22 @@ function encodeSymbol(symbol: number) {
 }
 
 /** @internal */
-function pad(value: string, constLength: number) {
-  return (
-    Array(constLength - value.length)
-      .fill('0')
-      .join('') + value
-  );
+function pad(value: string, paddingLength: number) {
+  let extraPadding = '';
+  while (value.length + extraPadding.length < paddingLength) {
+    extraPadding += '0';
+  }
+  return extraPadding + value;
 }
 
 /** @internal */
-export function uintToBase32StringMapper(num: number, constLength: number | undefined = undefined): string {
-  if (num === 0) return pad('0', constLength ?? 1);
+export function uintToBase32StringMapper(num: number, paddingLength: number): string {
+  if (num === 0) {
+    return pad('0', paddingLength);
+  }
 
-  let base32Str = '',
-    remaining = num;
+  let base32Str = '';
+  let remaining = num;
   for (let symbolsLeft = Math.floor(getBaseLog(32, num)) + 1; symbolsLeft > 0; symbolsLeft--) {
     const val = Math.pow(32, symbolsLeft - 1);
     const symbol = Math.floor(remaining / val);
@@ -94,12 +96,14 @@ export function uintToBase32StringMapper(num: number, constLength: number | unde
     remaining -= symbol * val;
   }
 
-  return pad(base32Str, constLength ?? base32Str.length);
+  return pad(base32Str, paddingLength);
 }
 
 /** @internal */
-export function paddedUintToBase32StringMapper(constLength: number) {
-  return (num: number): string => uintToBase32StringMapper(num, constLength);
+export function paddedUintToBase32StringMapper(paddingLength: number) {
+  return function padded(num: number): string {
+    return uintToBase32StringMapper(num, paddingLength);
+  };
 }
 
 /** @internal */

--- a/packages/fast-check/src/arbitrary/ulid.ts
+++ b/packages/fast-check/src/arbitrary/ulid.ts
@@ -3,6 +3,9 @@ import { tuple } from './tuple';
 import { integer } from './integer';
 import { paddedUintToBase32StringMapper, uintToBase32StringUnmapper } from './_internals/mappers/UintToBase32String';
 
+const padded10Mapper = paddedUintToBase32StringMapper(10);
+const padded8Mapper = paddedUintToBase32StringMapper(8);
+
 /**
  * For ulid
  *
@@ -21,22 +24,21 @@ export function ulid(): Arbitrary<string> {
   const randomnessPartTwoArbitrary = integer({ min: 0, max: 0xffffffffff }); // 40 bits
 
   return tuple(timestampPartArbitrary, randomnessPartOneArbitrary, randomnessPartTwoArbitrary).map(
-    ([date, random1, random2]) => {
-      return [
-        paddedUintToBase32StringMapper(10)(date), // 10 chars of base32 -> 48 bits
-        paddedUintToBase32StringMapper(8)(random1), // 8 chars of base32 -> 40 bits
-        paddedUintToBase32StringMapper(8)(random2),
-      ].join('');
+    (parts) => {
+      return (
+        padded10Mapper(parts[0]) + // 10 chars of base32 -> 48 bits
+        padded8Mapper(parts[1]) + // 8 chars of base32 -> 40 bits
+        padded8Mapper(parts[2])
+      );
     },
     (value) => {
       if (typeof value !== 'string' || value.length !== 26) {
         throw new Error('Unsupported type');
       }
-
-      return [value.slice(0, 10), value.slice(10, 18), value.slice(18)].map(uintToBase32StringUnmapper) as [
-        number,
-        number,
-        number
+      return [
+        uintToBase32StringUnmapper(value.slice(0, 10)),
+        uintToBase32StringUnmapper(value.slice(10, 18)),
+        uintToBase32StringUnmapper(value.slice(18)),
       ];
     }
   );


### PR DESCRIPTION
The current implementation of `ulid` was relying on many unneeded intermediate arrays to construct and deconstruct ulids. We just make it faster by relying on less intermediate arrays.

The change should reduce the memory footprint of ulids.

More to come with a partial revamp of some parts of the logic.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
