### PR TITLE
🐛 Stop unwrapping `ulid` we cannot build

### DIFF
--- a/.yarn/versions/c8458015.yml
+++ b/.yarn/versions/c8458015.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
@@ -114,7 +114,7 @@ export function uintToBase32StringUnmapper(value: unknown): number {
   let accumulated = 0;
   let power = 1;
   for (let index = value.length - 1; index >= 0; --index) {
-    const char = value[index].toUpperCase();
+    const char = value[index];
     const numericForChar = decodeSymbolLookupTable[char];
     if (numericForChar === undefined) {
       throw new Error('Unsupported type');


### PR DESCRIPTION
Being able to unwrap and deconstruct data that could never be created by one arbitrary can lead to wrong shrinker from being selected and thus strange issues (edge cases but let's avoid them).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
