### PR TITLE
✨ Support excluded min/max in `double`

### DIFF
--- a/.yarn/versions/de5677c4.yml
+++ b/.yarn/versions/de5677c4.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -149,9 +149,15 @@ describe('double', () => {
 
   if (typeof BigInt !== 'undefined') {
     it('should properly convert integer value for index between min and max into its associated float value', () => {
+      const withoutExcludedConstraints = {
+        ...defaultDoubleRecordConstraints,
+        minExcluded: fc.constant(false),
+        maxExcluded: fc.constant(false),
+      };
+
       fc.assert(
         fc.property(
-          fc.option(doubleConstraints(), { nil: undefined }),
+          fc.option(doubleConstraints(withoutExcludedConstraints), { nil: undefined }),
           fc.bigUintN(64),
           fc.option(fc.integer({ min: 2 }), { nil: undefined }),
           (ct, mod, biasFactor) => {

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -55,7 +55,7 @@ describe('double', () => {
     );
   });
 
-  it('should accept any constraits defining min (not-NaN) equal to max', () => {
+  it('should accept any constraints defining min (not-NaN) equal to max', () => {
     fc.assert(
       fc.property(
         float64raw(),
@@ -70,6 +70,32 @@ describe('double', () => {
 
           // Assert
           expect(arb).toBeDefined();
+        }
+      )
+    );
+  });
+
+  it('should reject any constraints defining min (not-NaN) equal to max if one is exclusive', () => {
+    fc.assert(
+      fc.property(
+        float64raw(),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.constantFrom('min', 'max', 'both'),
+        (f, otherCt, exclusiveMode) => {
+          // Arrange
+          fc.pre(!Number.isNaN(f));
+          spyArrayInt64();
+
+          // Act / Assert
+          expect(() =>
+            double({
+              ...otherCt,
+              min: f,
+              max: f,
+              minExcluded: exclusiveMode === 'min' || exclusiveMode === 'both',
+              maxExcluded: exclusiveMode === 'max' || exclusiveMode === 'both',
+            })
+          ).toThrowError();
         }
       )
     );
@@ -227,13 +253,15 @@ describe('double', () => {
           const { min, max } = minMaxForConstraints(ct);
           const minIndex = doubleToIndex(min);
           const maxIndex = doubleToIndex(max);
+          const expectedMinIndex = ct.minExcluded ? add64(minIndex, Unit64) : minIndex;
+          const expectedMaxIndex = ct.maxExcluded ? substract64(maxIndex, Unit64) : maxIndex;
 
           // Act
           double(ct);
 
           // Assert
           expect(arrayInt64).toHaveBeenCalledTimes(1);
-          expect(arrayInt64).toHaveBeenCalledWith(minIndex, maxIndex);
+          expect(arrayInt64).toHaveBeenCalledWith(expectedMinIndex, expectedMaxIndex);
         })
       );
     });
@@ -254,17 +282,31 @@ describe('double (integration)', () => {
       expect(v).not.toBe(Number.NaN); // should not produce NaN if explicitely asked not too
     }
     if (extra.min !== undefined && !Number.isNaN(v)) {
-      expect(v).toBeGreaterThanOrEqual(extra.min); // should always be greater than min when specified
+      if (extra.minExcluded) {
+        expect(v).toBeGreaterThan(extra.min); // should always be strictly greater than min when specified
+      } else {
+        expect(v).toBeGreaterThanOrEqual(extra.min); // should always be greater than min when specified
+      }
     }
     if (extra.max !== undefined && !Number.isNaN(v)) {
-      expect(v).toBeLessThanOrEqual(extra.max); // should always be smaller than max when specified
+      if (extra.maxExcluded) {
+        expect(v).toBeLessThan(extra.max); // should always be strictly smaller than max when specified
+      } else {
+        expect(v).toBeLessThanOrEqual(extra.max); // should always be smaller than max when specified
+      }
     }
     if (extra.noDefaultInfinity) {
       if (extra.min === undefined) {
         expect(v).not.toBe(Number.NEGATIVE_INFINITY); // should not produce -infinity when noInfinity and min unset
+        if (extra.minExcluded) {
+          expect(v).not.toBe(-Number.MAX_VALUE); // nor -max_value
+        }
       }
       if (extra.max === undefined) {
         expect(v).not.toBe(Number.POSITIVE_INFINITY); // should not produce +infinity when noInfinity and max unset
+        if (extra.minExcluded) {
+          expect(v).not.toBe(Number.MAX_VALUE); // nor max_value
+        }
       }
     }
   };

--- a/website/docs/core-blocks/arbitraries/primitives/number.md
+++ b/website/docs/core-blocks/arbitraries/primitives/number.md
@@ -187,6 +187,8 @@ The lower and upper bounds are included into the range of possible values.
 
 - `min?` — default: `-∞` and `-Number.MAX_VALUE` when `noDefaultInfinity:true` — _lower bound for the generated 32-bit floats (included)_
 - `max?` — default: `+∞` and `Number.MAX_VALUE` when `noDefaultInfinity:true` — _upper bound for the generated 32-bit floats (included)_
+- `minExcluded?` — default: `false` — _do not include `min` in the set of possible values_
+- `maxExcluded?` — default: `false` — _do not include `max` in the set of possible values_
 - `noDefaultInfinity?` — default: `false` — _use finite values for `min` and `max` by default_
 - `noNaN?` — default: `false` — _do not generate `Number.NaN`_
 
@@ -209,6 +211,10 @@ fc.double({ noDefaultInfinity: true, min: Number.NEGATIVE_INTEGER, max: Number.P
 // Note: Same as fc.double(), noDefaultInfinity just tells that defaults for min and max
 // should not be set to -∞ and +∞. It does not forbid the user to explicitely set them to -∞ and +∞.
 // Examples of generated values: 7.593633990222606e-236, -5.74664305820822e+216, -1.243100551492039e-161, 1.797693134862313e+308, -1.7976931348623077e+308…
+
+fc.double({ min: 0, max: 1, maxExcluded: true });
+// Note: All possible positive floating point values between 0 (included) and 1 (excluded)
+// Examples of generated values: 4.8016271592767985e-73, 4.8825963576686075e-55, 0.9999999999999967, 0.9999999999999959, 2.5e-322…
 
 fc.tuple(fc.integer({ min: 0, max: (1 << 26) - 1 }), fc.integer({ min: 0, max: (1 << 27) - 1 }))
   .map((v) => (v[0] * Math.pow(2, 27) + v[1]) * Math.pow(2, -53))


### PR DESCRIPTION
Up-to-now, it was not possible to ask for double between min and max with either min or max or both not in the range.

Following the request #4046, we thought about it and started to offer ways to do so.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
