### PR TITLE
✨ Support excluded min/max in `float`

### DIFF
--- a/.yarn/versions/9cf55ded.yml
+++ b/.yarn/versions/9cf55ded.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/float.ts
+++ b/packages/fast-check/src/arbitrary/float.ts
@@ -22,11 +22,25 @@ export interface FloatConstraints {
    */
   min?: number;
   /**
+   * Should the lower bound (aka min) be excluded?
+   * Note: Excluding min=Number.NEGATIVE_INFINITY would result into having min set to -3.4028234663852886e+38.
+   * @defaultValue false
+   * @remarks Since 3.12.0
+   */
+  minExcluded?: boolean;
+  /**
    * Upper bound for the generated 32-bit floats (included)
    * @defaultValue Number.POSITIVE_INFINITY, 3.4028234663852886e+38 when noDefaultInfinity is true
    * @remarks Since 2.8.0
    */
   max?: number;
+  /**
+   * Should the upper bound (aka max) be excluded?
+   * Note: Excluding max=Number.POSITIVE_INFINITY would result into having max set to 3.4028234663852886e+38.
+   * @defaultValue false
+   * @remarks Since 3.12.0
+   */
+  maxExcluded?: boolean;
   /**
    * By default, lower and upper bounds are -infinity and +infinity.
    * By setting noDefaultInfinity to true, you move those defaults to minimal and maximal finite values.
@@ -82,11 +96,15 @@ export function float(constraints: FloatConstraints = {}): Arbitrary<number> {
   const {
     noDefaultInfinity = false,
     noNaN = false,
+    minExcluded = false,
+    maxExcluded = false,
     min = noDefaultInfinity ? -MAX_VALUE_32 : safeNegativeInfinity,
     max = noDefaultInfinity ? MAX_VALUE_32 : safePositiveInfinity,
   } = constraints;
-  const minIndex = safeFloatToIndex(min, 'min');
-  const maxIndex = safeFloatToIndex(max, 'max');
+  const minIndexRaw = safeFloatToIndex(min, 'min');
+  const minIndex = minExcluded ? minIndexRaw + 1 : minIndexRaw;
+  const maxIndexRaw = safeFloatToIndex(max, 'max');
+  const maxIndex = maxExcluded ? maxIndexRaw - 1 : maxIndexRaw;
   if (minIndex > maxIndex) {
     // Comparing min and max might be problematic in case min=+0 and max=-0
     // For that reason, we prefer to compare computed index to be safer

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -162,10 +162,16 @@ describe('float', () => {
     expect(integer).not.toHaveBeenCalled();
   });
 
-  it('should properly convert integer value for index between min and max into its associated float value', () =>
+  it('should properly convert integer value for index between min and max into its associated float value', () => {
+    const withoutExcludedConstraints = {
+      ...defaultFloatRecordConstraints,
+      minExcluded: fc.constant(false),
+      maxExcluded: fc.constant(false),
+    };
+
     fc.assert(
       fc.property(
-        fc.option(floatConstraints(), { nil: undefined }),
+        fc.option(floatConstraints(withoutExcludedConstraints), { nil: undefined }),
         fc.maxSafeNat(),
         fc.option(fc.integer({ min: 2 }), { nil: undefined }),
         (ct, mod, biasFactor) => {
@@ -185,7 +191,8 @@ describe('float', () => {
           expect(f).toBe(indexToFloat(arbitraryGeneratedIndex));
         }
       )
-    ));
+    );
+  });
 
   describe('with NaN', () => {
     const withNaNRecordConstraints = { ...defaultFloatRecordConstraints, noNaN: fc.constant(false) };

--- a/website/docs/core-blocks/arbitraries/primitives/number.md
+++ b/website/docs/core-blocks/arbitraries/primitives/number.md
@@ -163,7 +163,7 @@ fc.float({ noDefaultInfinity: true, min: Number.NEGATIVE_INTEGER, max: Number.PO
 
 fc.float({ min: 0, max: 1, maxExcluded: true });
 // Note: All possible 32-bit floating point values between 0 (included) and 1 (excluded)
-// Examples of generated values: 4.8016271592767985e-73, 4.8825963576686075e-55, 0.9999999999999967, 0.9999999999999959, 2.5e-322…
+// Examples of generated values: 3.2229864679470793e-44, 2.4012229232976108e-20, 1.1826533935374394e-27, 0.9999997615814209, 3.783505853677006e-44…
 
 fc.integer({ min: 0, max: (1 << 24) - 1 })
   .map((v) => v / (1 << 24))

--- a/website/docs/core-blocks/arbitraries/primitives/number.md
+++ b/website/docs/core-blocks/arbitraries/primitives/number.md
@@ -136,6 +136,8 @@ It always generates valid 32-bit floating point values.
 
 - `min?` — default: `-∞` and `-3.4028234663852886e+38` when `noDefaultInfinity:true` — _lower bound for the generated 32-bit floats (included)_
 - `max?` — default: `+∞` and `+3.4028234663852886e+38` when `noDefaultInfinity:true` — _upper bound for the generated 32-bit floats (included)_
+- `minExcluded?` — default: `false` — _do not include `min` in the set of possible values_
+- `maxExcluded?` — default: `false` — _do not include `max` in the set of possible values_
 - `noDefaultInfinity?` — default: `false` — _use finite values for `min` and `max` by default_
 - `noNaN?` — default: `false` — _do not generate `Number.NaN`_
 
@@ -158,6 +160,10 @@ fc.float({ noDefaultInfinity: true, min: Number.NEGATIVE_INTEGER, max: Number.PO
 // Note: Same as fc.float(), noDefaultInfinity just tells that defaults for min and max
 // should not be set to -∞ and +∞. It does not forbid the user to explicitely set them to -∞ and +∞.
 // Examples of generated values: -5.435122013092041, 1981086548623360, -2.2481372319305137e-9, -2.5223372357846707e-44, 5.606418179297701e-30…
+
+fc.float({ min: 0, max: 1, maxExcluded: true });
+// Note: All possible 32-bit floating point values between 0 (included) and 1 (excluded)
+// Examples of generated values: 4.8016271592767985e-73, 4.8825963576686075e-55, 0.9999999999999967, 0.9999999999999959, 2.5e-322…
 
 fc.integer({ min: 0, max: (1 << 24) - 1 })
   .map((v) => v / (1 << 24))


### PR DESCRIPTION
Up-to-now, it was not possible to ask for float  between min and max with either min or max or both not in the range.

Following the request #4046, we thought about it and started to offer ways to do so.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
