### PR TITLE
✨ Add support for "Invalid Date" in `date`

### DIFF
--- a/.yarn/versions/a60cfd09.yml
+++ b/.yarn/versions/a60cfd09.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/mappers/TimeToDate.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/TimeToDate.ts
@@ -1,5 +1,8 @@
 import { Date, Error, safeGetTime } from '../../../utils/globals';
 
+const safeNaN = Number.NaN;
+const safeNumberIsNaN = Number.isNaN;
+
 /** @internal */
 export function timeToDateMapper(time: number): Date {
   return new Date(time);
@@ -11,4 +14,19 @@ export function timeToDateUnmapper(value: unknown): number {
     throw new Error('Not a valid value for date unmapper');
   }
   return safeGetTime(value);
+}
+
+/** @internal */
+export function timeToDateMapperWithNaN(valueForNaN: number): (time: number) => Date {
+  return (time) => {
+    return time === valueForNaN ? new Date(safeNaN) : timeToDateMapper(time);
+  };
+}
+
+/** @internal */
+export function timeToDateUnmapperWithNaN(valueForNaN: number): (value: unknown) => number {
+  return (value) => {
+    const time = timeToDateUnmapper(value);
+    return safeNumberIsNaN(time) ? valueForNaN : time;
+  };
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/TimeToDate.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/TimeToDate.spec.ts
@@ -7,33 +7,40 @@ import {
 } from '../../../../../src/arbitrary/_internals/mappers/TimeToDate';
 
 describe('timeToDateUnmapper', () => {
-  it('should be able to revert any mapped date correctly', () =>
+  it('should be able to revert any mapped date correctly', () => {
     fc.assert(
       fc.property(fc.date({ noInvalidDate: true }), (d) => {
-        // Act
+        // Arrange / Act
         const rev = timeToDateUnmapper(d);
         const revRev = timeToDateMapper(rev);
 
         // Assert
         expect(revRev).toEqual(d);
       }),
-    ));
+    );
+  });
 });
 
 describe('timeToDateUnmapperWithNane', () => {
-  it('should be able to revert any mapped date correctly', () =>
+  it('should be able to revert any mapped date correctly', () => {
     fc.assert(
       fc.property(
         fc.date({ noInvalidDate: false }),
         fc.integer({ min: -8640000000000000, max: 8640000000000000 }),
         (d, nanValue) => {
-          // Act
+          // Arrange / Act
           const rev = timeToDateUnmapperWithNaN(nanValue)(d);
           const revRev = timeToDateMapperWithNaN(nanValue)(rev);
 
           // Assert
-          expect(revRev).toEqual(d);
+          if (d.getTime() === nanValue) {
+            expect(rev).toBe(nanValue);
+            expect(revRev).toEqual(new Date(Number.NaN));
+          } else {
+            expect(revRev.getTime()).toEqual(d.getTime());
+          }
         },
       ),
-    ));
+    );
+  });
 });

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/TimeToDate.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/TimeToDate.spec.ts
@@ -1,10 +1,15 @@
 import fc from 'fast-check';
-import { timeToDateMapper, timeToDateUnmapper } from '../../../../../src/arbitrary/_internals/mappers/TimeToDate';
+import {
+  timeToDateMapper,
+  timeToDateMapperWithNaN,
+  timeToDateUnmapper,
+  timeToDateUnmapperWithNaN,
+} from '../../../../../src/arbitrary/_internals/mappers/TimeToDate';
 
 describe('timeToDateUnmapper', () => {
   it('should be able to revert any mapped date correctly', () =>
     fc.assert(
-      fc.property(fc.date(), (d) => {
+      fc.property(fc.date({ noInvalidDate: true }), (d) => {
         // Act
         const rev = timeToDateUnmapper(d);
         const revRev = timeToDateMapper(rev);
@@ -12,5 +17,23 @@ describe('timeToDateUnmapper', () => {
         // Assert
         expect(revRev).toEqual(d);
       }),
+    ));
+});
+
+describe('timeToDateUnmapperWithNane', () => {
+  it('should be able to revert any mapped date correctly', () =>
+    fc.assert(
+      fc.property(
+        fc.date({ noInvalidDate: false }),
+        fc.integer({ min: -8640000000000000, max: 8640000000000000 }),
+        (d, nanValue) => {
+          // Act
+          const rev = timeToDateUnmapperWithNaN(nanValue)(d);
+          const revRev = timeToDateMapperWithNaN(nanValue)(rev);
+
+          // Assert
+          expect(revRev).toEqual(d);
+        },
+      ),
     ));
 });

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -70,10 +70,11 @@ describe('date', () => {
       }),
     ));
 
-  it('should always map the maximal value of the internal integer to the requested maximal date', () =>
+  it('should always map the maximal value (minus one if NaN accepted) of the internal integer to the requested maximal date', () =>
     fc.assert(
       fc.property(constraintsArb(), (constraints) => {
         // Arrange
+        const withInvalidDates = constraints.noInvalidDate === false;
         const { instance, map } = fakeArbitrary<number>();
         const { instance: mappedInstance } = fakeArbitrary<Date>();
         const integer = jest.spyOn(IntegerMock, 'integer');
@@ -84,7 +85,7 @@ describe('date', () => {
         date(constraints);
         const { max: rangeMax } = integer.mock.calls[0][0]!;
         const [mapper] = map.mock.calls[0];
-        const maxDate = mapper(rangeMax!) as Date;
+        const maxDate = mapper(withInvalidDates ? rangeMax! - 1 : rangeMax!) as Date;
 
         // Assert
         if (constraints.max !== undefined) {

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -149,7 +149,7 @@ describe('date', () => {
 });
 
 describe('date (integration)', () => {
-  type Extra = { min?: Date; max?: Date };
+  type Extra = { min?: Date; max?: Date; noInvalidDate?: boolean };
   const extraParameters: fc.Arbitrary<Extra> = constraintsArb();
 
   const isCorrect = (d: Date, extra: Extra) => {

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -160,6 +160,10 @@ describe('date (integration)', () => {
     if (extra.max) expect(d.getTime()).toBeLessThanOrEqual(extra.max.getTime());
   };
 
+  const isEqual = (d1: Date, d2: Date) => {
+    expect(d1.getTime()).toEqual(d2.getTime());
+  };
+
   const isStrictlySmaller = (d1: Date, d2: Date) => {
     if (Number.isNaN(d1.getTime())) {
       expect(d2.getTime()).not.toBe(Number.NaN);
@@ -173,7 +177,7 @@ describe('date (integration)', () => {
   const dateBuilder = (extra: Extra) => date(extra);
 
   it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(dateBuilder, { extraParameters });
+    assertProduceSameValueGivenSameSeed(dateBuilder, { extraParameters, isEqual });
   });
 
   it('should only produce correct values', () => {
@@ -185,7 +189,7 @@ describe('date (integration)', () => {
   });
 
   it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(dateBuilder, { extraParameters });
+    assertShrinkProducesSameValueWithoutInitialContext(dateBuilder, { extraParameters, isEqual });
   });
 
   it('should preserve strictly smaller ordering in shrink', () => {

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -153,7 +153,7 @@ describe('date (integration)', () => {
   const extraParameters: fc.Arbitrary<Extra> = constraintsArb();
 
   const isCorrect = (d: Date, extra: Extra) => {
-    if (extra.noInvalidDate || noInvalidDate === undefined) {
+    if (extra.noInvalidDate || extra.noInvalidDate === undefined) {
       expect(d.getTime()).not.toBe(Number.NaN);
     }
     if (extra.min) expect(d.getTime()).toBeGreaterThanOrEqual(extra.min.getTime());

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -155,6 +155,8 @@ describe('date (integration)', () => {
   const isCorrect = (d: Date, extra: Extra) => {
     if (extra.noInvalidDate || extra.noInvalidDate === undefined) {
       expect(d.getTime()).not.toBe(Number.NaN);
+    } else if (Number.isNaN(d.getTime())) {
+      return;
     }
     if (extra.min) expect(d.getTime()).toBeGreaterThanOrEqual(extra.min.getTime());
     if (extra.max) expect(d.getTime()).toBeLessThanOrEqual(extra.max.getTime());

--- a/website/docs/core-blocks/arbitraries/primitives/date.md
+++ b/website/docs/core-blocks/arbitraries/primitives/date.md
@@ -15,12 +15,13 @@ Generate any possible dates in the specified range. Both the lower bound and upp
 **Signatures:**
 
 - `fc.date()`
-- `fc.date({ min?, max? })`
+- `fc.date({ min?, max?, noInvalidDate? })`
 
 **with:**
 
 - `min?` — default: `new Date(-8640000000000000)` — _lower bound of the range (included)_
 - `max?` — default: `new Date(8640000000000000)` — _upper bound of the range (included)_
+- `noInvalidDate?` — default: `true` — _when `true` the Date "Invalid Date" will never be defined_
 
 **Usages:**
 


### PR DESCRIPTION
Up-to-now, the arbitrary called `date()` was unable to generate "Invalid Date". Following this PR, it will be able to do so, if you provide it with the flag `noInvalidDate: false`.

In the next major version of fast-check, this flag will default to false (while today it defaults to true not to break existing clients).

Fixes #1064

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
