### PR TITLE
🔥 Remove `withDeletedKeys` from `record`

### DIFF
--- a/.yarn/versions/784a780f.yml
+++ b/.yarn/versions/784a780f.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: major
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/record.ts
+++ b/packages/fast-check/src/arbitrary/record.ts
@@ -7,35 +7,18 @@ import type { EnumerableKeyOf } from './_internals/helpers/EnumerableKeysExtract
  * @remarks Since 0.0.12
  * @public
  */
-export type RecordConstraints<T = unknown> = (
-  | {
-      /**
-       * List keys that should never be deleted.
-       *
-       * Remark:
-       * You might need to use an explicit typing in case you need to declare symbols as required (not needed when required keys are simple strings).
-       * With something like `{ requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] }` when both `mySymbol1` and `a` are required.
-       *
-       * Warning: Cannot be used in conjunction with withDeletedKeys.
-       *
-       * @defaultValue Array containing all keys of recordModel
-       * @remarks Since 2.11.0
-       */
-      requiredKeys?: T[];
-    }
-  | {
-      /**
-       * Allow to remove keys from the generated record.
-       * Warning: Cannot be used in conjunction with requiredKeys.
-       * Prefer: `requiredKeys: []` over `withDeletedKeys: true`
-       *
-       * @defaultValue false
-       * @remarks Since 1.0.0
-       * @deprecated Prefer using `requiredKeys: []` instead of `withDeletedKeys: true` as the flag will be removed in the next major
-       */
-      withDeletedKeys?: boolean;
-    }
-) & {
+export type RecordConstraints<T = unknown> = {
+  /**
+   * List keys that should never be deleted.
+   *
+   * Remark:
+   * You might need to use an explicit typing in case you need to declare symbols as required (not needed when required keys are simple strings).
+   * With something like `{ requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] }` when both `mySymbol1` and `a` are required.
+   *
+   * @defaultValue Array containing all keys of recordModel
+   * @remarks Since 2.11.0
+   */
+  requiredKeys?: T[];
   /**
    * Do not generate records with null prototype
    * @defaultValue true
@@ -52,13 +35,11 @@ export type RecordConstraints<T = unknown> = (
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type RecordValue<T, TConstraints = {}> = TConstraints extends { withDeletedKeys: boolean; requiredKeys: any[] }
+export type RecordValue<T, TConstraints = {}> = TConstraints extends { requiredKeys: any[] }
   ? never
-  : TConstraints extends { withDeletedKeys: true }
-    ? Partial<T>
-    : TConstraints extends { requiredKeys: (infer TKeys)[] }
-      ? Partial<T> & Pick<T, TKeys & keyof T>
-      : T;
+  : TConstraints extends { requiredKeys: (infer TKeys)[] }
+    ? Partial<T> & Pick<T, TKeys & keyof T>
+    : T;
 
 /**
  * For records following the `recordModel` schema
@@ -80,7 +61,7 @@ function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<
  *
  * @example
  * ```typescript
- * record({ x: someArbitraryInt, y: someArbitraryInt }, {withDeletedKeys: true}): Arbitrary<{x?:number,y?:number}>
+ * record({ x: someArbitraryInt, y: someArbitraryInt }, {requiredKeys: []}): Arbitrary<{x?:number,y?:number}>
  * // merge two integer arbitraries to produce a {x, y}, {x}, {y} or {} record
  * ```
  *
@@ -104,13 +85,7 @@ function record<T>(
     return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }
 
-  if ('withDeletedKeys' in constraints && 'requiredKeys' in constraints) {
-    throw new Error(`requiredKeys and withDeletedKeys cannot be used together in fc.record`);
-  }
-
-  const requireDeletedKeys =
-    ('requiredKeys' in constraints && constraints.requiredKeys !== undefined) ||
-    ('withDeletedKeys' in constraints && !!constraints.withDeletedKeys);
+  const requireDeletedKeys = 'requiredKeys' in constraints && constraints.requiredKeys !== undefined;
   if (!requireDeletedKeys) {
     return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }

--- a/packages/fast-check/src/arbitrary/record.ts
+++ b/packages/fast-check/src/arbitrary/record.ts
@@ -35,11 +35,9 @@ export type RecordConstraints<T = unknown> = {
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type RecordValue<T, TConstraints = {}> = TConstraints extends { requiredKeys: any[] }
-  ? never
-  : TConstraints extends { requiredKeys: (infer TKeys)[] }
-    ? Partial<T> & Pick<T, TKeys & keyof T>
-    : T;
+export type RecordValue<T, TConstraints = {}> = TConstraints extends { requiredKeys: (infer TKeys)[] }
+  ? Partial<T> & Pick<T, TKeys & keyof T>
+  : T;
 
 /**
  * For records following the `recordModel` schema

--- a/packages/fast-check/test-types/main.ts
+++ b/packages/fast-check/test-types/main.ts
@@ -201,14 +201,6 @@ expectType<fc.Arbitrary<{ a: number; b: string }>>()(
   fc.record({ a: fc.nat(), b: fc.string() }, {}),
   '"record" accepts empty constraints',
 );
-expectType<fc.Arbitrary<{ a: number; b: string }>>()(
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: false }),
-  '"record" understands withDeletedKeys=false',
-);
-expectType<fc.Arbitrary<{ a?: number; b?: string }>>()(
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: true }),
-  '"record" understands withDeletedKeys=true',
-);
 expectType<fc.Arbitrary<{ a?: number; b?: string }>>()(
   fc.record({ a: fc.nat(), b: fc.string() }, { requiredKeys: [] }),
   '"record" only applies optional on keys declared within requiredKeys even when empty',
@@ -244,12 +236,6 @@ expectType<fc.Arbitrary<{ [mySymbol1]: number; [mySymbol2]?: string; a: number; 
     { requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] },
   ),
   '"record" only applies optional on keys declared within requiredKeys even if it contains symbols and normal keys',
-);
-expectType<fc.Arbitrary<never>>()(
-  // requiredKeys and withDeletedKeys cannot be used together
-  // typings are not perfect but at least they build a value that cannot be used
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: true, requiredKeys: [] }),
-  '"record" receiving both withDeletedKeys and requiredKeys is invalid',
 );
 type Query = { data: { field: 'X' } };
 expectType<fc.Arbitrary<Query>>()(

--- a/packages/fast-check/test/e2e/NoRegression.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegression.spec.ts
@@ -409,7 +409,7 @@ describe(`NoRegression`, () => {
   it('record', () => {
     expect(() =>
       fc.assert(
-        fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { withDeletedKeys: true }), (v) => testFunc(v)),
+        fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { requiredKeys: [] }), (v) => testFunc(v)),
         settings,
       ),
     ).toThrowErrorMatchingSnapshot();

--- a/packages/fast-check/test/e2e/arbitraries/RecordArbitrary.spec.ts
+++ b/packages/fast-check/test/e2e/arbitraries/RecordArbitrary.spec.ts
@@ -23,7 +23,7 @@ describe(`RecordArbitrary (seed: ${seed})`, () => {
         cc: fc.string(),
       };
       const out = fc.check(
-        fc.property(fc.record(recordModel, { withDeletedKeys: true }), (obj) => obj.bb == null),
+        fc.property(fc.record(recordModel, { requiredKeys: [] }), (obj) => obj.bb == null),
         {
           seed: seed,
         },
@@ -41,7 +41,7 @@ describe(`RecordArbitrary (seed: ${seed})`, () => {
         forceNegativeOutput: fc.boolean(),
       };
       const out = fc.check(
-        fc.property(fc.record(recordModel, { withDeletedKeys: true }), (obj) => {
+        fc.property(fc.record(recordModel, { requiredKeys: [] }), (obj) => {
           if (obj.forcePositiveOutput === true && obj.forceNegativeOutput === true) return false;
           return true;
         }),

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/FloatingPointHelpers.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/FloatingPointHelpers.ts
@@ -42,7 +42,7 @@ function constraintsInternal(
   is32Bits: boolean,
 ): fc.Arbitrary<ConstraintsInternalOut> {
   return fc
-    .record(recordConstraints, { withDeletedKeys: true })
+    .record(recordConstraints, { requiredKeys: [] })
     .filter((ct) => {
       // Forbid min and max to be NaN
       return (ct.min === undefined || !Number.isNaN(ct.min)) && (ct.max === undefined || !Number.isNaN(ct.max));

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
@@ -196,7 +196,7 @@ function defaultsMinMaxTypedInt8Arb() {
 }
 
 function validArrayConstraintsArb() {
-  return fc.record({ minLength: fc.nat(), maxLength: fc.nat() }, { withDeletedKeys: true }).map((ct) => {
+  return fc.record({ minLength: fc.nat(), maxLength: fc.nat() }, { requiredKeys: [] }).map((ct) => {
     if (ct.minLength !== undefined && ct.maxLength !== undefined && ct.minLength > ct.maxLength) {
       return { minLength: ct.maxLength, maxLength: ct.minLength };
     }
@@ -205,14 +205,12 @@ function validArrayConstraintsArb() {
 }
 
 function validIntegerConstraintsArb(min: number, max: number) {
-  return fc
-    .record({ min: fc.integer({ min, max }), max: fc.integer({ min, max }) }, { withDeletedKeys: true })
-    .map((ct) => {
-      if (ct.min !== undefined && ct.max !== undefined && ct.min > ct.max) {
-        return { min: ct.max, max: ct.min };
-      }
-      return ct;
-    });
+  return fc.record({ min: fc.integer({ min, max }), max: fc.integer({ min, max }) }, { requiredKeys: [] }).map((ct) => {
+    if (ct.min !== undefined && ct.max !== undefined && ct.min > ct.max) {
+      return { min: ct.max, max: ct.min };
+    }
+    return ct;
+  });
 }
 
 function invalidIntegerConstraintsArb(min: number, max: number) {

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -55,7 +55,7 @@ describe('double', () => {
     fc.assert(
       fc.property(
         float64raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         (f, otherCt) => {
           // Arrange
           fc.pre(!Number.isNaN(f));
@@ -75,7 +75,7 @@ describe('double', () => {
     fc.assert(
       fc.property(
         float64raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         fc.constantFrom('min', 'max', 'both'),
         (f, otherCt, exclusiveMode) => {
           // Arrange

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -70,7 +70,7 @@ describe('float', () => {
     fc.assert(
       fc.property(
         float32raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         (f, otherCt) => {
           // Arrange
           fc.pre(isNotNaN32bits(f));
@@ -90,7 +90,7 @@ describe('float', () => {
     fc.assert(
       fc.property(
         float32raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         fc.constantFrom('min', 'max', 'both'),
         (f, otherCt, exclusiveMode) => {
           // Arrange

--- a/packages/fast-check/test/unit/arbitrary/record.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/record.spec.ts
@@ -55,36 +55,6 @@ describe('record', () => {
       ),
     ));
 
-  it('should call buildPartialRecordArbitrary with keys=[] when constraints defines withDeletedKeys=true', () =>
-    fc.assert(
-      fc.property(
-        fc.uniqueArray(keyArb, { minLength: 1 }),
-        fc.option(fc.boolean(), { nil: undefined }),
-        (keys, noNullPrototype) => {
-          // Arrange
-          const recordModel: Record<string | symbol, Arbitrary<any>> = {};
-          for (const k of keys) {
-            const { instance } = fakeArbitrary();
-            recordModel[k] = instance;
-          }
-          const { instance } = fakeArbitrary<any>();
-          const buildPartialRecordArbitrary = jest.spyOn(
-            PartialRecordArbitraryBuilderMock,
-            'buildPartialRecordArbitrary',
-          );
-          buildPartialRecordArbitrary.mockReturnValue(instance);
-
-          // Act
-          const arb = record(recordModel, { withDeletedKeys: true, noNullPrototype });
-
-          // Assert
-          expect(arb).toBe(instance);
-          expect(buildPartialRecordArbitrary).toHaveBeenCalledTimes(1);
-          expect(buildPartialRecordArbitrary).toHaveBeenCalledWith(recordModel, [], noNullPrototype !== false);
-        },
-      ),
-    ));
-
   it('should call buildPartialRecordArbitrary with keys=requiredKeys when constraints defines valid requiredKeys', () =>
     fc.assert(
       fc.property(
@@ -149,34 +119,6 @@ describe('record', () => {
       }),
     ));
 
-  it('should reject configurations specifying both requiredKeys and withDeletedKeys (even undefined)', () =>
-    fc.assert(
-      fc.property(
-        fc.uniqueArray(fc.record({ name: keyArb, required: fc.boolean() }), {
-          minLength: 1,
-          selector: (entry) => entry.name,
-        }),
-        fc.option(fc.constant(true), { nil: undefined }),
-        fc.option(fc.boolean(), { nil: undefined }),
-        (keys, withRequiredKeys, withDeletedKeys) => {
-          // Arrange
-          const recordModel: Record<string | symbol, Arbitrary<any>> = {};
-          for (const k of keys) {
-            const { instance } = fakeArbitrary();
-            recordModel[k.name] = instance;
-          }
-
-          // Act / Assert
-          expect(() =>
-            record(recordModel, {
-              requiredKeys: withRequiredKeys ? keys.filter((k) => k.required).map((k) => k.name) : undefined,
-              withDeletedKeys: withDeletedKeys,
-            }),
-          ).toThrowError();
-        },
-      ),
-    ));
-
   it('should accept empty keys configurations with empty requiredKeys', () => {
     // Arrange
     const recordModel: Record<string | symbol, Arbitrary<any>> = {};
@@ -224,13 +166,13 @@ describe('record (integration)', () => {
     }),
     { selector: (entry) => entry.key },
   );
-  const constraintsArbitrary = fc.oneof(
-    fc.record({ withDeletedKeys: fc.boolean(), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
-    fc.record({ withRequiredKeys: fc.constant<true>(true), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
+  const constraintsArbitrary = fc.record(
+    { withRequiredKeys: fc.constant<true>(true), noNullPrototype: fc.boolean() },
+    { requiredKeys: [] },
   );
   const extraParameters: fc.Arbitrary<Extra> = fc
     .tuple(metaArbitrary, constraintsArbitrary)
-    .map(([metas, constraintsMeta]: [Meta[], { withDeletedKeys?: boolean; withRequiredKeys?: true }]) => {
+    .map(([metas, constraintsMeta]: [Meta[], { withRequiredKeys?: true }]) => {
       if ('withRequiredKeys' in constraintsMeta) {
         return [
           metas,
@@ -252,13 +194,6 @@ describe('record (integration)', () => {
     }
     for (const m of metas) {
       // optional keys can be missing in the generated instance
-      if (
-        'withDeletedKeys' in constraints &&
-        constraints.withDeletedKeys === true &&
-        !Object.prototype.hasOwnProperty.call(value, m.key)
-      ) {
-        continue;
-      }
       if (
         'requiredKeys' in constraints &&
         constraints.requiredKeys !== undefined &&

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -79,13 +79,11 @@ It comes very useful when dealing with settings.
 
 - `fc.record(recordModel)`
 - `fc.record(recordModel, {requiredKeys?, noNullPrototype?})`
-- `fc.record(recordModel, {withDeletedKeys?, noNullPrototype?})`
 
 **with:**
 
 - `recordModel` — _structure of the resulting instance_
-- `requiredKeys?` — default: `[all keys of recordModel]` — _list of keys that should never be deleted, remark: cannot be used with `withDeletedKeys`_
-- `withDeletedKeys?` — default: `false` — _when enabled, record might not generate all keys. `withDeletedKeys: true` is equivalent to `requiredKeys: []`, thus the two options cannot be used at the same time_
+- `requiredKeys?` — default: `[all keys of recordModel]` — _list of keys that should never be deleted_
 - `noNullPrototype?` — default: `true` — _only generate records based on the Object-prototype, do not generate any record with null-prototype_
 
 **Usages:**
@@ -142,7 +140,7 @@ fc.record(
     id: fc.uuidV(4),
     age: fc.nat(99),
   },
-  { withDeletedKeys: true },
+  { requiredKeys: [] },
 );
 // Note: Both id and age will be optional values
 // Examples of generated values:

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -144,11 +144,11 @@ fc.record(
 );
 // Note: Both id and age will be optional values
 // Examples of generated values:
-// • {"id":"ffffffe1-582d-457d-899e-8084fffffff7","age":97}
-// • {"age":96}
-// • {"id":"00000012-bdc2-4b1c-8a2a-245900000006","age":6}
-// • {"id":"8785297a-e305-43bc-bfff-fff1927a3512","age":30}
-// • {"age":17}
+// • {"id":"00000004-27f6-48bb-8000-000a69064200","age":3}
+// • {"id":"ffffffee-ffef-4fff-8000-0015f69788ee","age":21}
+// • {"age":34}
+// • {"id":"2db92e09-3fdc-49e6-8000-001b00000007","age":5}
+// • {"id":"00000006-0007-4000-8397-86ea00000004"}
 // • …
 ```
 


### PR DESCRIPTION
**:boom: Breaking change**

Initially `record` came with `withDeletedKeys`, but quickly we received the need to have a better granularity level to deal with keys to keep or not and so `requiredKeys` came.

Now, that we have it for some time, we want to drop `withDeletedKeys` as it tends to add complexity to the code and the API.

A migration path and possibly some scripts to help users to run the change might be provided in the future. For now the recommendation would be to replace: `withDeletedKeys: true` by `requiredKeys: []` and `withDeletedKeys: false` by nothing or `requiredKeys: [...here all the keys...]`.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [x] _Other(s):_ Drop deprecated feature
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ ...
