### PR TITLE
✨ Support null-proto in `dictionary`

### DIFF
--- a/.yarn/versions/967d1489.yml
+++ b/.yarn/versions/967d1489.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
@@ -25,6 +25,7 @@ import { letrec } from '../../letrec';
 import { SizeForArbitrary } from '../helpers/MaxLengthFromMinLength';
 import { uniqueArray } from '../../uniqueArray';
 import { createDepthIdentifier, DepthIdentifier } from '../helpers/DepthContext';
+import { constant } from '../../constant';
 
 /** @internal */
 function mapOf<T, U>(
@@ -51,12 +52,15 @@ function dictOf<U>(
   size: SizeForArbitrary | undefined,
   depthIdentifier: DepthIdentifier,
 ) {
-  return uniqueArray(tuple(ka, va), {
-    maxLength: maxKeys,
-    size,
-    selector: (t) => t[0],
-    depthIdentifier,
-  }).map(keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper);
+  return tuple(
+    uniqueArray(tuple(ka, va), {
+      maxLength: maxKeys,
+      size,
+      selector: (t) => t[0],
+      depthIdentifier,
+    }),
+    constant(false),
+  ).map(keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper);
 }
 
 /** @internal */

--- a/packages/fast-check/src/arbitrary/dictionary.ts
+++ b/packages/fast-check/src/arbitrary/dictionary.ts
@@ -3,6 +3,8 @@ import { tuple } from './tuple';
 import { uniqueArray } from './uniqueArray';
 import { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength';
 import { keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper } from './_internals/mappers/KeyValuePairsToObject';
+import { constant } from './constant';
+import { boolean } from './boolean';
 
 /** @internal */
 function dictionaryKeyExtractor(entry: [string, unknown]): string {
@@ -28,10 +30,16 @@ export interface DictionaryConstraints {
    */
   maxKeys?: number;
   /**
-   * Define how large the generated values should be (at max)   *
+   * Define how large the generated values should be (at max)
    * @remarks Since 2.22.0
    */
   size?: SizeForArbitrary;
+  /**
+   * Do not generate objects with null prototype
+   * @defaultValue true
+   * @remarks Since 3.13.0
+   */
+  noNullPrototype?: boolean;
 }
 
 /**
@@ -48,10 +56,14 @@ export function dictionary<T>(
   valueArb: Arbitrary<T>,
   constraints: DictionaryConstraints = {},
 ): Arbitrary<Record<string, T>> {
-  return uniqueArray(tuple(keyArb, valueArb), {
-    minLength: constraints.minKeys,
-    maxLength: constraints.maxKeys,
-    size: constraints.size,
-    selector: dictionaryKeyExtractor,
-  }).map(keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper);
+  const noNullPrototype = constraints.noNullPrototype !== false;
+  return tuple(
+    uniqueArray(tuple(keyArb, valueArb), {
+      minLength: constraints.minKeys,
+      maxLength: constraints.maxKeys,
+      size: constraints.size,
+      selector: dictionaryKeyExtractor,
+    }),
+    noNullPrototype ? constant(false) : boolean(),
+  ).map(keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper);
 }

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
@@ -154,10 +154,22 @@ describe('keyValuePairsToObjectUnmapper', () => {
     expect(withNullPrototype).toBe(false);
   });
 
+  it('should properly unmap a fake null-prototype instance', () => {
+    // Arrange
+    const obj = { ['__proto__']: null };
+
+    // Act
+    const [keyValues, withNullPrototype] = keyValuePairsToObjectUnmapper(obj);
+
+    // Assert
+    expect(keyValues).toHaveLength(1);
+    expect(keyValues).toContainEqual(['__proto__', null]);
+    expect(withNullPrototype).toBe(false);
+  });
+
   it.each`
     value                                                                | condition
     ${new (class A {})()}                                                | ${'it is not just a simple object but a more complex type'}
-    ${{ ['__proto__']: null }}                                           | ${'it is a fake null-prototype'}
     ${[]}                                                                | ${'it is an Array'}
     ${new Number(0)}                                                     | ${'it is a boxed-Number'}
     ${0}                                                                 | ${'it is a number'}

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/KeyValuePairsToObject.spec.ts
@@ -5,11 +5,11 @@ import {
 import fc from '../../../../../src/fast-check';
 
 describe('keyValuePairsToObjectMapper', () => {
-  it('should create instances with Object prototype', () => {
+  it('should create instances with Object prototype when requested to', () => {
     fc.assert(
       fc.property(fc.uniqueArray(fc.tuple(fc.string(), fc.anything()), { selector: (kv) => kv[0] }), (keyValues) => {
         // Arrange / Act
-        const obj = keyValuePairsToObjectMapper(keyValues);
+        const obj = keyValuePairsToObjectMapper([keyValues, false]);
 
         // Assert
         expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
@@ -23,23 +23,45 @@ describe('keyValuePairsToObjectMapper', () => {
     );
   });
 
-  it('should create instances with all requested keys', () => {
+  it('should create instances with null prototype when requested to', () => {
     fc.assert(
       fc.property(fc.uniqueArray(fc.tuple(fc.string(), fc.anything()), { selector: (kv) => kv[0] }), (keyValues) => {
         // Arrange / Act
-        const obj = keyValuePairsToObjectMapper(keyValues);
+        const obj = keyValuePairsToObjectMapper([keyValues, true]);
 
         // Assert
-        expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
-        for (const [key, value] of keyValues) {
-          expect(key in obj).toBe(true);
-          expect(obj[key]).toBe(value);
+        expect(Object.getPrototypeOf(obj)).toBe(null);
+        if (!keyValues.some(([k]) => k === 'constructor')) {
+          expect('constructor' in obj).toBe(false);
+        }
+        if (!keyValues.some(([k]) => k === '__proto__')) {
+          expect('__proto__' in obj).toBe(false);
         }
       }),
     );
   });
 
-  it('should create the same instances as-if we used bracket-based assignment', () => {
+  it('should create instances with all requested keys', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.tuple(fc.string(), fc.anything()), { selector: (kv) => kv[0] }),
+        fc.boolean(),
+        (keyValues, withNullPrototype) => {
+          // Arrange / Act
+          const obj = keyValuePairsToObjectMapper([keyValues, withNullPrototype]);
+
+          // Assert
+          expect(Object.getPrototypeOf(obj)).toBe(withNullPrototype ? null : Object.prototype);
+          for (const [key, value] of keyValues) {
+            expect(key in obj).toBe(true);
+            expect(obj[key]).toBe(value);
+          }
+        },
+      ),
+    );
+  });
+
+  it('should create the same instances as-if we used bracket-based assignment (except proto for null case)', () => {
     fc.assert(
       fc.property(
         fc.uniqueArray(
@@ -49,9 +71,10 @@ describe('keyValuePairsToObjectMapper', () => {
           ),
           { selector: (kv) => kv[0] },
         ),
-        (keyValues) => {
+        fc.boolean(),
+        (keyValues, withNullPrototype) => {
           // Arrange / Act
-          const obj = keyValuePairsToObjectMapper(keyValues);
+          const obj = keyValuePairsToObjectMapper([keyValues, withNullPrototype]);
           const refObj = Object.fromEntries(keyValues); // will miss __proto__ if passed as keys
 
           // Assert
@@ -64,16 +87,23 @@ describe('keyValuePairsToObjectMapper', () => {
     );
   });
 
-  it('should be able to build instances with dangerous keys', () => {
+  it.each`
+    name        | withNullPrototype
+    ${'Object'} | ${false}
+    ${'null'}   | ${true}
+  `('should be able to build instances with dangerous keys in $name-proto case', ({ withNullPrototype }) => {
     // Arrange / Act
     const obj = keyValuePairsToObjectMapper([
-      ['__proto__', '1'],
-      ['constructor', '2'],
-      ['toString', '3'],
+      [
+        ['__proto__', '1'],
+        ['constructor', '2'],
+        ['toString', '3'],
+      ],
+      withNullPrototype,
     ]);
 
     // Assert
-    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(obj)).toBe(withNullPrototype ? null : Object.prototype);
     // Valid values
     expect(obj.__proto__).toBe('1');
     expect(obj.constructor).toBe('2');
@@ -90,10 +120,23 @@ describe('keyValuePairsToObjectUnmapper', () => {
     const obj = {};
 
     // Act
-    const keyValues = keyValuePairsToObjectUnmapper(obj);
+    const [keyValues, withNullPrototype] = keyValuePairsToObjectUnmapper(obj);
 
     // Assert
     expect(keyValues).toEqual([]);
+    expect(withNullPrototype).toBe(false);
+  });
+
+  it('should properly unmap basic instances of null-proto Object without keys', () => {
+    // Arrange
+    const obj = Object.create(null);
+
+    // Act
+    const [keyValues, withNullPrototype] = keyValuePairsToObjectUnmapper(obj);
+
+    // Assert
+    expect(keyValues).toEqual([]);
+    expect(withNullPrototype).toBe(true);
   });
 
   it('should properly unmap basic instances of Object with multiple keys', () => {
@@ -101,19 +144,20 @@ describe('keyValuePairsToObjectUnmapper', () => {
     const obj = { a: 'e', 1: 'hello', b: undefined };
 
     // Act
-    const keyValues = keyValuePairsToObjectUnmapper(obj);
+    const [keyValues, withNullPrototype] = keyValuePairsToObjectUnmapper(obj);
 
     // Assert
     expect(keyValues).toHaveLength(3);
     expect(keyValues).toContainEqual(['a', 'e']);
     expect(keyValues).toContainEqual(['1', 'hello']);
     expect(keyValues).toContainEqual(['b', undefined]);
+    expect(withNullPrototype).toBe(false);
   });
 
   it.each`
     value                                                                | condition
-    ${Object.create(null)}                                               | ${'it has no prototype'}
     ${new (class A {})()}                                                | ${'it is not just a simple object but a more complex type'}
+    ${{ ['__proto__']: null }}                                           | ${'it is a fake null-prototype'}
     ${[]}                                                                | ${'it is an Array'}
     ${new Number(0)}                                                     | ${'it is a boxed-Number'}
     ${0}                                                                 | ${'it is a number'}

--- a/packages/fast-check/test/unit/arbitrary/dictionary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/dictionary.spec.ts
@@ -18,17 +18,30 @@ describe('dictionary (integration)', () => {
       keys: fc.uniqueArray(fc.string(), { minLength: 35 }), // enough keys to respect constraints
       values: fc.uniqueArray(fc.anything(), { minLength: 1 }),
       constraints: fc
-        .tuple(fc.nat({ max: 5 }), fc.nat({ max: 30 }), fc.boolean(), fc.boolean())
-        .map(([min, gap, withMin, withMax]) => ({
+        .tuple(
+          fc.nat({ max: 5 }),
+          fc.nat({ max: 30 }),
+          fc.boolean(),
+          fc.boolean(),
+          fc.option(fc.boolean(), { nil: undefined }),
+        )
+        .map(([min, gap, withMin, withMax, noNullPrototype]) => ({
           minKeys: withMin ? min : undefined,
           maxKeys: withMax ? min + gap : undefined,
+          noNullPrototype,
         })),
     },
     { requiredKeys: ['keys', 'values'] },
   );
 
   const isCorrect = (value: Record<string, unknown>, extra: Extra) => {
-    expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+    if (
+      extra.constraints === undefined ||
+      extra.constraints.noNullPrototype ||
+      extra.constraints.noNullPrototype === undefined
+    ) {
+      expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+    }
     for (const k of Object.keys(value)) {
       expect(extra.keys).toContain(k);
     }

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -54,6 +54,16 @@ fc.dictionary(fc.string(), fc.nat(), { minKeys: 2 });
 // • {" R~Own":2147483645,"~":16,"i$#D":1037390287}
 // • {">YTN<Tt":1950414260,"I6":1505301756,"2;]'dH.i!":815067799,":kmC'":1948205418,"g|GTLPe-":2101264769}
 // • …
+
+fc.dictionary(fc.string(), fc.string(), { noNullPrototype: false });
+// Note: Allow generated values to be objects with null prototype
+// Examples of generated values:
+// • {"|^!!\"+.\"%":"LB","]CQxQ":"0/uv","(JH(35e8":":"}
+// • {",>a[":"f&EYz","VR 9JX":"/|hRyU","Nm20AgHq":"b","A1Gb{5nXM":"?B","W;>__":"","G5":"IS"}
+// • {"3{59v":"Tf]hDL2","tj:,Kq9'2":"#o:WpR","":"[4h","e{":"j","!Ws@hZV_":"p1*44.<"}
+// • Object.assign(Object.create(null),{"/\\v":"1ki#1'|#","L":"2o","chGEb'qmi":"hXXU"})
+// • {"Q]8":"JQ=b<ea","@zz\\]oW(*":"uv","w":"\\","X*X":"/2{*wi=d","\"+;P\"tp3n":"LLZ-%}w"}
+// • …
 ```
 
 Resources: [API reference](https://fast-check.dev/api-reference/functions/dictionary.html).  

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -13,7 +13,7 @@ Generate dictionaries containing keys generated using `keyArb` and values genera
 **Signatures:**
 
 - `fc.dictionary(keyArb, valueArb)`
-- `fc.dictionary(keyArb, valueArb, {minKeys?, maxKeys?, size?})`
+- `fc.dictionary(keyArb, valueArb, {minKeys?, maxKeys?, size?, noNullPrototype?})`
 
 **with:**
 
@@ -22,6 +22,7 @@ Generate dictionaries containing keys generated using `keyArb` and values genera
 - `minKeys?` — default: `0` — _minimal number of keys in the generated instances (included)_
 - `maxKeys?` — default: `0x7fffffff` [more](/docs/configuration/larger-entries-by-default/#size-explained) — _maximal number of keys in the generated instances (included)_
 - `size?` — default: `undefined` [more](/docs/configuration/larger-entries-by-default/#size-explained) — _how large should the generated values be?_
+- `noNullPrototype?` — default: `true` — _only generate objects based on the Object-prototype, do not generate any object with null-prototype_
 
 **Usages:**
 


### PR DESCRIPTION
For now, users will have to explicitly ask for it. But in the next major, the null-prototype will be the default.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
