### PR TITLE
✨ Support null-proto in `record`

### DIFF
--- a/.yarn/versions/97d78019.yml
+++ b/.yarn/versions/97d78019.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder.ts
@@ -1,5 +1,7 @@
 import { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary';
 import { safeIndexOf, safePush } from '../../../utils/globals';
+import { boolean } from '../../boolean';
+import { constant } from '../../constant';
 import { option } from '../../option';
 import { tuple } from '../../tuple';
 import { EnumerableKeyOf, extractEnumerableKeys } from '../helpers/EnumerableKeysExtractor';
@@ -15,6 +17,7 @@ type NoKeyType = typeof noKeyValue;
 export function buildPartialRecordArbitrary<T, TKeys extends EnumerableKeyOf<T>>(
   recordModel: { [K in keyof T]: Arbitrary<T[K]> },
   requiredKeys: TKeys[] | undefined,
+  noNullPrototype: boolean,
 ): Arbitrary<Partial<T> & Pick<T, TKeys>> {
   const keys = extractEnumerableKeys(recordModel);
   const arbs: Arbitrary<T[keyof T] | NoKeyType>[] = [];
@@ -27,7 +30,7 @@ export function buildPartialRecordArbitrary<T, TKeys extends EnumerableKeyOf<T>>
       safePush(arbs, option(requiredArbitrary, { nil: noKeyValue as NoKeyType }));
     }
   }
-  return tuple(...arbs).map(
+  return tuple(tuple(...arbs), noNullPrototype ? constant(false) : boolean()).map(
     buildValuesAndSeparateKeysToObjectMapper<T, NoKeyType>(keys, noKeyValue),
     buildValuesAndSeparateKeysToObjectUnmapper<T, NoKeyType>(keys, noKeyValue),
   );

--- a/packages/fast-check/src/arbitrary/record.ts
+++ b/packages/fast-check/src/arbitrary/record.ts
@@ -7,7 +7,7 @@ import { EnumerableKeyOf } from './_internals/helpers/EnumerableKeysExtractor';
  * @remarks Since 0.0.12
  * @public
  */
-export type RecordConstraints<T = unknown> =
+export type RecordConstraints<T = unknown> = (
   | {
       /**
        * List keys that should never be deleted.
@@ -34,7 +34,15 @@ export type RecordConstraints<T = unknown> =
        * @deprecated Prefer using `requiredKeys: []` instead of `withDeletedKeys: true` as the flag will be removed in the next major
        */
       withDeletedKeys?: boolean;
-    };
+    }
+) & {
+  /**
+   * Do not generate objects with null prototype
+   * @defaultValue true
+   * @remarks Since 3.13.0
+   */
+  noNullPrototype?: boolean;
+};
 
 /**
  * Infer the type of the Arbitrary produced by record
@@ -90,8 +98,10 @@ function record<T>(
   recordModel: { [K in keyof T]: Arbitrary<T[K]> },
   constraints?: RecordConstraints<keyof T>,
 ): unknown {
+  const noNullPrototype =
+    constraints === undefined || constraints.noNullPrototype === undefined || constraints.noNullPrototype;
   if (constraints == null) {
-    return buildPartialRecordArbitrary(recordModel, undefined);
+    return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }
 
   if ('withDeletedKeys' in constraints && 'requiredKeys' in constraints) {
@@ -102,7 +112,7 @@ function record<T>(
     ('requiredKeys' in constraints && constraints.requiredKeys !== undefined) ||
     ('withDeletedKeys' in constraints && !!constraints.withDeletedKeys);
   if (!requireDeletedKeys) {
-    return buildPartialRecordArbitrary(recordModel, undefined);
+    return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }
 
   const requiredKeys = ('requiredKeys' in constraints ? constraints.requiredKeys : undefined) || [];
@@ -116,7 +126,7 @@ function record<T>(
     }
   }
 
-  return buildPartialRecordArbitrary(recordModel, requiredKeys as EnumerableKeyOf<T>[]);
+  return buildPartialRecordArbitrary(recordModel, requiredKeys as EnumerableKeyOf<T>[], noNullPrototype);
 }
 
 export { record };

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/PartialRecordArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/PartialRecordArbitraryBuilder.spec.ts
@@ -1,6 +1,8 @@
 import { fakeArbitrary } from '../../__test-helpers__/ArbitraryHelpers';
 import { buildPartialRecordArbitrary } from '../../../../../src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder';
 
+import * as BooleanMock from '../../../../../src/arbitrary/boolean';
+import * as ConstantMock from '../../../../../src/arbitrary/constant';
 import * as OptionMock from '../../../../../src/arbitrary/option';
 import * as TupleMock from '../../../../../src/arbitrary/tuple';
 import * as ValuesAndSeparateKeysToObjectMock from '../../../../../src/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject';
@@ -12,156 +14,210 @@ function beforeEachHook() {
 beforeEach(beforeEachHook);
 
 describe('buildPartialRecordArbitrary', () => {
-  it('should never wrap arbitraries linked to required keys and forward all keys to mappers', () => {
-    // Arrange
-    const { instance: mappedInstance } = fakeArbitrary<any>();
-    const { instance: tupleInstance, map } = fakeArbitrary<any[]>();
-    const option = jest.spyOn(OptionMock, 'option');
-    const tuple = jest.spyOn(TupleMock, 'tuple');
-    tuple.mockReturnValue(tupleInstance);
-    map.mockReturnValue(mappedInstance);
+  it.each([{ noNullPrototype: true }, { noNullPrototype: false }])(
+    'should never wrap arbitraries linked to required keys and forward all keys to mappers (noNullPrototype: $noNullPrototype)',
+    ({ noNullPrototype }) => {
+      // Arrange
+      const { instance: mappedInstance } = fakeArbitrary<any>();
+      const { instance: tupleInstance } = fakeArbitrary<any[]>();
+      const { instance: tupleInstance2, map } = fakeArbitrary<any[]>();
+      const { instance: booleanInstance } = fakeArbitrary<any>();
+      const boolean = jest.spyOn(BooleanMock, 'boolean');
+      const constant = jest.spyOn(ConstantMock, 'constant');
+      const option = jest.spyOn(OptionMock, 'option');
+      const tuple = jest.spyOn(TupleMock, 'tuple');
+      boolean.mockReturnValueOnce(booleanInstance);
+      constant.mockReturnValueOnce(booleanInstance);
+      tuple.mockReturnValueOnce(tupleInstance).mockReturnValueOnce(tupleInstance2);
+      map.mockReturnValueOnce(mappedInstance);
 
-    const mapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectMapper',
-    );
-    buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
+      const mapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectMapper',
+      );
+      buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
 
-    const unmapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectUnmapper',
-    );
-    buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
+      const unmapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectUnmapper',
+      );
+      buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
 
-    const arbKey1 = fakeArbitrary();
-    const arbKey2 = fakeArbitrary();
-    const recordModel = {
-      a: arbKey1,
-      b: arbKey2,
-    };
-    const requiredKeys: (keyof typeof recordModel)[] = ['a', 'b'];
-    const allKeys: (keyof typeof recordModel)[] = ['a', 'b'];
+      const arbKey1 = fakeArbitrary();
+      const arbKey2 = fakeArbitrary();
+      const recordModel = {
+        a: arbKey1,
+        b: arbKey2,
+      };
+      const requiredKeys: (keyof typeof recordModel)[] = ['a', 'b'];
+      const allKeys: (keyof typeof recordModel)[] = ['a', 'b'];
 
-    // Act
-    const arb = buildPartialRecordArbitrary(recordModel, requiredKeys);
+      // Act
+      const arb = buildPartialRecordArbitrary(recordModel, requiredKeys, noNullPrototype);
 
-    // Assert
-    expect(arb).toBe(mappedInstance);
-    expect(option).not.toHaveBeenCalled();
-    expect(tuple).toHaveBeenCalledTimes(1);
-    expect(tuple).toHaveBeenCalledWith(recordModel.a, recordModel.b);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(map).toHaveBeenCalledTimes(1);
-    expect(map).toHaveBeenCalledWith(mapper, unmapper);
-  });
+      // Assert
+      expect(arb).toBe(mappedInstance);
+      expect(option).not.toHaveBeenCalled();
+      expect(tuple).toHaveBeenCalledTimes(2);
+      expect(tuple).toHaveBeenCalledWith(recordModel.a, recordModel.b);
+      expect(tuple).toHaveBeenCalledWith(tupleInstance, booleanInstance);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(map).toHaveBeenCalledTimes(1);
+      expect(map).toHaveBeenCalledWith(mapper, unmapper);
+      if (noNullPrototype) {
+        expect(boolean).not.toHaveBeenCalled();
+        expect(constant).toHaveBeenCalledTimes(1);
+        expect(constant).toHaveBeenCalledWith(false); // ie withNullPrototype=false
+      } else {
+        expect(boolean).toHaveBeenCalledTimes(1);
+        expect(constant).not.toHaveBeenCalled();
+      }
+    },
+  );
 
-  it('should wrap arbitraries not linked to required keys into option and forward all keys to mappers', () => {
-    // Arrange
-    const { instance: mappedInstance } = fakeArbitrary<any>();
-    const { instance: tupleInstance, map } = fakeArbitrary<any[]>();
-    const { instance: optionInstance1 } = fakeArbitrary();
-    const { instance: optionInstance2 } = fakeArbitrary();
-    const option = jest.spyOn(OptionMock, 'option');
-    const tuple = jest.spyOn(TupleMock, 'tuple');
-    const optionInstance1Old = optionInstance1;
-    const optionInstance2Old = optionInstance2;
-    option.mockReturnValueOnce(optionInstance1Old).mockReturnValueOnce(optionInstance2Old);
-    tuple.mockReturnValue(tupleInstance);
-    map.mockReturnValue(mappedInstance);
+  it.each([{ noNullPrototype: true }, { noNullPrototype: false }])(
+    'should wrap arbitraries not linked to required keys into option and forward all keys to mappers (noNullPrototype: $noNullPrototype)',
+    ({ noNullPrototype }) => {
+      // Arrange
+      const { instance: mappedInstance } = fakeArbitrary<any>();
+      const { instance: tupleInstance } = fakeArbitrary<any[]>();
+      const { instance: tupleInstance2, map } = fakeArbitrary<any[]>();
+      const { instance: booleanInstance } = fakeArbitrary<any>();
+      const { instance: optionInstance1 } = fakeArbitrary();
+      const { instance: optionInstance2 } = fakeArbitrary();
+      const boolean = jest.spyOn(BooleanMock, 'boolean');
+      const constant = jest.spyOn(ConstantMock, 'constant');
+      const option = jest.spyOn(OptionMock, 'option');
+      const tuple = jest.spyOn(TupleMock, 'tuple');
+      const optionInstance1Old = optionInstance1;
+      const optionInstance2Old = optionInstance2;
+      boolean.mockReturnValueOnce(booleanInstance);
+      constant.mockReturnValueOnce(booleanInstance);
+      option.mockReturnValueOnce(optionInstance1Old).mockReturnValueOnce(optionInstance2Old);
+      tuple.mockReturnValueOnce(tupleInstance).mockReturnValueOnce(tupleInstance2);
+      map.mockReturnValueOnce(mappedInstance);
 
-    const mapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectMapper',
-    );
-    buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
+      const mapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectMapper',
+      );
+      buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
 
-    const unmapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectUnmapper',
-    );
-    buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
+      const unmapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectUnmapper',
+      );
+      buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
 
-    const arbKey1 = fakeArbitrary();
-    const arbKey2 = fakeArbitrary();
-    const arbKey3 = fakeArbitrary();
-    const recordModel = {
-      a: arbKey1,
-      b: arbKey2,
-      c: arbKey3,
-    };
-    const requiredKeys: (keyof typeof recordModel)[] = ['b'];
-    const allKeys: (keyof typeof recordModel)[] = ['a', 'b', 'c'];
+      const arbKey1 = fakeArbitrary();
+      const arbKey2 = fakeArbitrary();
+      const arbKey3 = fakeArbitrary();
+      const recordModel = {
+        a: arbKey1,
+        b: arbKey2,
+        c: arbKey3,
+      };
+      const requiredKeys: (keyof typeof recordModel)[] = ['b'];
+      const allKeys: (keyof typeof recordModel)[] = ['a', 'b', 'c'];
 
-    // Act
-    const arb = buildPartialRecordArbitrary(recordModel, requiredKeys);
+      // Act
+      const arb = buildPartialRecordArbitrary(recordModel, requiredKeys, noNullPrototype);
 
-    // Assert
-    expect(arb).toBe(mappedInstance);
-    expect(option).toHaveBeenCalledTimes(2);
-    expect(option).toHaveBeenCalledWith(recordModel.a, { nil: expect.any(Symbol) });
-    expect(option).toHaveBeenCalledWith(recordModel.c, { nil: expect.any(Symbol) });
-    expect(tuple).toHaveBeenCalledTimes(1);
-    expect(tuple).toHaveBeenCalledWith(optionInstance1Old, recordModel.b, optionInstance2Old);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(map).toHaveBeenCalledTimes(1);
-    expect(map).toHaveBeenCalledWith(mapper, unmapper);
-  });
+      // Assert
+      expect(arb).toBe(mappedInstance);
+      expect(option).toHaveBeenCalledTimes(2);
+      expect(option).toHaveBeenCalledWith(recordModel.a, { nil: expect.any(Symbol) });
+      expect(option).toHaveBeenCalledWith(recordModel.c, { nil: expect.any(Symbol) });
+      expect(tuple).toHaveBeenCalledTimes(2);
+      expect(tuple).toHaveBeenCalledWith(optionInstance1Old, recordModel.b, optionInstance2Old);
+      expect(tuple).toHaveBeenCalledWith(tupleInstance, booleanInstance);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(map).toHaveBeenCalledTimes(1);
+      expect(map).toHaveBeenCalledWith(mapper, unmapper);
+      if (noNullPrototype) {
+        expect(boolean).not.toHaveBeenCalled();
+        expect(constant).toHaveBeenCalledTimes(1);
+        expect(constant).toHaveBeenCalledWith(false); // ie withNullPrototype=false
+      } else {
+        expect(boolean).toHaveBeenCalledTimes(1);
+        expect(constant).not.toHaveBeenCalled();
+      }
+    },
+  );
 
-  it('should not wrap any arbitrary when required keys is not specified (all required) and forward all keys to mappers', () => {
-    // Arrange
-    const { instance: mappedInstance } = fakeArbitrary<any>();
-    const { instance: tupleInstance, map } = fakeArbitrary<any[]>();
-    const option = jest.spyOn(OptionMock, 'option');
-    const tuple = jest.spyOn(TupleMock, 'tuple');
-    tuple.mockReturnValue(tupleInstance);
-    map.mockReturnValue(mappedInstance);
+  it.each([{ noNullPrototype: true }, { noNullPrototype: false }])(
+    'should not wrap any arbitrary when required keys is not specified (all required) and forward all keys to mappers (noNullPrototype: $noNullPrototype)',
+    ({ noNullPrototype }) => {
+      // Arrange
+      const { instance: mappedInstance } = fakeArbitrary<any>();
+      const { instance: tupleInstance } = fakeArbitrary<any[]>();
+      const { instance: tupleInstance2, map } = fakeArbitrary<any[]>();
+      const { instance: booleanInstance } = fakeArbitrary<any>();
+      const boolean = jest.spyOn(BooleanMock, 'boolean');
+      const constant = jest.spyOn(ConstantMock, 'constant');
+      const option = jest.spyOn(OptionMock, 'option');
+      const tuple = jest.spyOn(TupleMock, 'tuple');
+      boolean.mockReturnValueOnce(booleanInstance);
+      constant.mockReturnValueOnce(booleanInstance);
+      tuple.mockReturnValueOnce(tupleInstance).mockReturnValueOnce(tupleInstance2);
+      map.mockReturnValueOnce(mappedInstance);
 
-    const mapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectMapper',
-    );
-    buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
+      const mapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectMapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectMapper',
+      );
+      buildValuesAndSeparateKeysToObjectMapper.mockReturnValue(mapper);
 
-    const unmapper = jest.fn();
-    const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
-      ValuesAndSeparateKeysToObjectMock,
-      'buildValuesAndSeparateKeysToObjectUnmapper',
-    );
-    buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
+      const unmapper = jest.fn();
+      const buildValuesAndSeparateKeysToObjectUnmapper = jest.spyOn(
+        ValuesAndSeparateKeysToObjectMock,
+        'buildValuesAndSeparateKeysToObjectUnmapper',
+      );
+      buildValuesAndSeparateKeysToObjectUnmapper.mockReturnValue(unmapper);
 
-    const arbKey1 = fakeArbitrary();
-    const arbKey2 = fakeArbitrary();
-    const recordModel = {
-      a: arbKey1,
-      b: arbKey2,
-    };
-    const requiredKeys = undefined;
-    const allKeys: (keyof typeof recordModel)[] = ['a', 'b'];
+      const arbKey1 = fakeArbitrary();
+      const arbKey2 = fakeArbitrary();
+      const recordModel = {
+        a: arbKey1,
+        b: arbKey2,
+      };
+      const requiredKeys = undefined;
+      const allKeys: (keyof typeof recordModel)[] = ['a', 'b'];
 
-    // Act
-    const arb = buildPartialRecordArbitrary(recordModel, requiredKeys);
+      // Act
+      const arb = buildPartialRecordArbitrary(recordModel, requiredKeys, noNullPrototype);
 
-    // Assert
-    expect(arb).toBe(mappedInstance);
-    expect(option).not.toHaveBeenCalled();
-    expect(tuple).toHaveBeenCalledTimes(1);
-    expect(tuple).toHaveBeenCalledWith(recordModel.a, recordModel.b);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
-    expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
-    expect(map).toHaveBeenCalledTimes(1);
-    expect(map).toHaveBeenCalledWith(mapper, unmapper);
-  });
+      // Assert
+      expect(arb).toBe(mappedInstance);
+      expect(option).not.toHaveBeenCalled();
+      expect(tuple).toHaveBeenCalledTimes(2);
+      expect(tuple).toHaveBeenCalledWith(recordModel.a, recordModel.b);
+      expect(tuple).toHaveBeenCalledWith(tupleInstance, booleanInstance);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectMapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledTimes(1);
+      expect(buildValuesAndSeparateKeysToObjectUnmapper).toHaveBeenCalledWith(allKeys, expect.any(Symbol));
+      expect(map).toHaveBeenCalledTimes(1);
+      expect(map).toHaveBeenCalledWith(mapper, unmapper);
+      if (noNullPrototype) {
+        expect(boolean).not.toHaveBeenCalled();
+        expect(constant).toHaveBeenCalledTimes(1);
+        expect(constant).toHaveBeenCalledWith(false); // ie withNullPrototype=false
+      } else {
+        expect(boolean).toHaveBeenCalledTimes(1);
+        expect(constant).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/packages/fast-check/test/unit/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject.spec.ts
@@ -4,54 +4,80 @@ import {
 } from '../../../../../src/arbitrary/_internals/mappers/ValuesAndSeparateKeysToObject';
 
 describe('buildValuesAndSeparateKeysToObjectMapper', () => {
-  it('should create instances with Object prototype', () => {
+  it('should create instances with Object prototype when passed withNullPrototype=false', () => {
     // Arrange
     const keys: (string | symbol)[] = [];
     const magicNoValue = Symbol('no-value');
     const values: any[] = [];
+    const withNullPrototype = false;
+    const definition: Parameters<typeof mapper>[0] = [values, withNullPrototype];
 
     // Act
     const mapper = buildValuesAndSeparateKeysToObjectMapper<any, typeof magicNoValue>(keys, magicNoValue);
-    const obj = mapper(values);
+    const obj = mapper(definition);
 
     // Assert
     expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
   });
 
-  it('should replace magic values by no key', () => {
+  it('should create instances with null prototype when passed withNullPrototype=true', () => {
     // Arrange
-    const keys: (string | symbol)[] = ['a', 'b', 'c', 'd'];
+    const keys: (string | symbol)[] = [];
     const magicNoValue = Symbol('no-value');
-    const values: any[] = [undefined, magicNoValue, null, 0];
+    const values: any[] = [];
+    const withNullPrototype = true;
+    const definition: Parameters<typeof mapper>[0] = [values, withNullPrototype];
 
     // Act
     const mapper = buildValuesAndSeparateKeysToObjectMapper<any, typeof magicNoValue>(keys, magicNoValue);
-    const obj = mapper(values);
+    const obj = mapper(definition);
 
     // Assert
-    expect(obj).toHaveProperty('a');
-    expect(obj).not.toHaveProperty('b');
-    expect(obj).toHaveProperty('c');
-    expect(obj).toHaveProperty('d');
-    expect(obj).toEqual({ a: undefined, c: null, d: 0 });
+    expect(Object.getPrototypeOf(obj)).toBe(null);
   });
 
-  it('should be able to produce instances with "__proto__" as key', () => {
-    // Arrange
-    const keys: (string | symbol)[] = ['__proto__'];
-    const magicNoValue = Symbol('no-value');
-    const values: any[] = [0];
+  it.each([{ withNullPrototype: true }, { withNullPrototype: false }])(
+    'should replace magic values by no key when withNullPrototype=$withNullPrototype',
+    ({ withNullPrototype }) => {
+      // Arrange
+      const keys: (string | symbol)[] = ['a', 'b', 'c', 'd'];
+      const magicNoValue = Symbol('no-value');
+      const values: any[] = [undefined, magicNoValue, null, 0];
+      const definition: Parameters<typeof mapper>[0] = [values, withNullPrototype];
 
-    // Act
-    const mapper = buildValuesAndSeparateKeysToObjectMapper<any, typeof magicNoValue>(keys, magicNoValue);
-    const obj = mapper(values);
+      // Act
+      const mapper = buildValuesAndSeparateKeysToObjectMapper<any, typeof magicNoValue>(keys, magicNoValue);
+      const obj = mapper(definition);
 
-    // Assert
-    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
-    expect(obj).toHaveProperty('__proto__');
-    expect(obj.__proto__).toBe(0);
-    expect(obj).toEqual({ ['__proto__']: 0 });
-  });
+      // Assert
+      expect(obj).toHaveProperty('a');
+      expect(obj).not.toHaveProperty('b');
+      expect(obj).toHaveProperty('c');
+      expect(obj).toHaveProperty('d');
+      expect(obj).toEqual({ a: undefined, c: null, d: 0 });
+    },
+  );
+
+  it.each([{ withNullPrototype: true }, { withNullPrototype: false }])(
+    'should be able to produce instances with "__proto__" as key when withNullPrototype=$withNullPrototype',
+    ({ withNullPrototype }) => {
+      // Arrange
+      const keys: (string | symbol)[] = ['__proto__'];
+      const magicNoValue = Symbol('no-value');
+      const values: any[] = [0];
+      const definition: Parameters<typeof mapper>[0] = [values, withNullPrototype];
+
+      // Act
+      const mapper = buildValuesAndSeparateKeysToObjectMapper<any, typeof magicNoValue>(keys, magicNoValue);
+      const obj = mapper(definition);
+
+      // Assert
+      expect(Object.getPrototypeOf(obj)).toBe(withNullPrototype ? null : Object.prototype);
+      expect(obj).toHaveProperty('__proto__');
+      expect(obj.__proto__).toBe(0);
+      expect(obj).toEqual({ ['__proto__']: 0 });
+    },
+  );
 });
 
 describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
@@ -66,7 +92,21 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual([]);
+    expect(values).toEqual([[], false]);
+  });
+
+  it('should properly unmap basic instances of Object without keys nor prototype', () => {
+    // Arrange
+    const obj = Object.create(null);
+    const keys: (string | symbol)[] = [];
+    const magicNoValue = Symbol('no-value');
+
+    // Act
+    const unmapper = buildValuesAndSeparateKeysToObjectUnmapper<any, typeof magicNoValue>(keys, magicNoValue);
+    const values = unmapper(obj);
+
+    // Assert
+    expect(values).toEqual([[], true]);
   });
 
   it('should properly unmap basic instances of Object with multiple keys and no missing', () => {
@@ -80,7 +120,7 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual([undefined, 'hello', 'e']);
+    expect(values).toEqual([[undefined, 'hello', 'e'], false]);
   });
 
   it('should properly unmap instances of Object with known symbols as keys', () => {
@@ -96,7 +136,7 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual(['hello', undefined, 'e']);
+    expect(values).toEqual([['hello', undefined, 'e'], false]);
   });
 
   it('should properly unmap instances of Object with missing keys', () => {
@@ -113,10 +153,10 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual(['hello', magicNoValue, undefined, 'e', magicNoValue, magicNoValue]);
+    expect(values).toEqual([['hello', magicNoValue, undefined, 'e', magicNoValue, magicNoValue], false]);
   });
 
-  it('should properly unmap instances of Object with "__proto__" as key when there', () => {
+  it('should properly unmap instances of Object with "__proto__" as key when set to a value', () => {
     // Arrange
     const obj = { ['__proto__']: 'e' };
     const keys: (string | symbol)[] = ['toString', '__proto__', 'a'];
@@ -127,10 +167,24 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual([magicNoValue, 'e', magicNoValue]);
+    expect(values).toEqual([[magicNoValue, 'e', magicNoValue], false]);
   });
 
-  it('should properly unmap instances of Object with "__proto__" as key when not there', () => {
+  it('should properly unmap instances of Object with "__proto__" as key when set to null', () => {
+    // Arrange
+    const obj = { ['__proto__']: null };
+    const keys: (string | symbol)[] = ['toString', '__proto__', 'a'];
+    const magicNoValue = Symbol('no-value');
+
+    // Act
+    const unmapper = buildValuesAndSeparateKeysToObjectUnmapper<any, typeof magicNoValue>(keys, magicNoValue);
+    const values = unmapper(obj);
+
+    // Assert
+    expect(values).toEqual([[magicNoValue, null, magicNoValue], false]);
+  });
+
+  it('should properly unmap instances of Object with "__proto__" as key when unset', () => {
     // Arrange
     const obj = {};
     const keys: (string | symbol)[] = ['toString', '__proto__', 'a'];
@@ -141,12 +195,11 @@ describe('buildValuesAndSeparateKeysToObjectUnmapper', () => {
     const values = unmapper(obj);
 
     // Assert
-    expect(values).toEqual([magicNoValue, magicNoValue, magicNoValue]);
+    expect(values).toEqual([[magicNoValue, magicNoValue, magicNoValue], false]);
   });
 
   it.each`
     value                                                                | condition
-    ${Object.create(null)}                                               | ${'it has no prototype'}
     ${new (class A {})()}                                                | ${'it is not just a simple object but a more complex type'}
     ${[]}                                                                | ${'it is an Array'}
     ${new Number(0)}                                                     | ${'it is a boxed-Number'}

--- a/packages/fast-check/test/unit/arbitrary/record.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/record.spec.ts
@@ -210,14 +210,20 @@ describe('record (integration)', () => {
     { selector: (entry) => entry.key },
   );
   const constraintsArbitrary = fc.oneof(
-    fc.record({ withDeletedKeys: fc.boolean() }, { requiredKeys: [] }),
-    fc.record({ withRequiredKeys: fc.constant<true>(true) }, { requiredKeys: [] }),
+    fc.record({ withDeletedKeys: fc.boolean(), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
+    fc.record({ withRequiredKeys: fc.constant<true>(true), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
   );
   const extraParameters: fc.Arbitrary<Extra> = fc
     .tuple(metaArbitrary, constraintsArbitrary)
     .map(([metas, constraintsMeta]: [Meta[], { withDeletedKeys?: boolean; withRequiredKeys?: true }]) => {
       if ('withRequiredKeys' in constraintsMeta) {
-        return [metas, { requiredKeys: metas.filter((m) => m.kept).map((m) => m.key) }] as [Meta[], RecordConstraints];
+        return [
+          metas,
+          {
+            requiredKeys: metas.filter((m) => m.kept).map((m) => m.key),
+            ...('noNullPrototype' in constraintsMeta ? { noNullPrototype: constraintsMeta.noNullPrototype } : {}),
+          },
+        ] as [Meta[], RecordConstraints];
       }
       return [metas, constraintsMeta] as [Meta[], RecordConstraints];
     });

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -67,14 +67,15 @@ It comes very useful when dealing with settings.
 **Signatures:**
 
 - `fc.record(recordModel)`
-- `fc.record(recordModel, {requiredKeys?})`
-- `fc.record(recordModel, {withDeletedKeys?})`
+- `fc.record(recordModel, {requiredKeys?, noNullPrototype?})`
+- `fc.record(recordModel, {withDeletedKeys?, noNullPrototype?})`
 
 **with:**
 
 - `recordModel` — _structure of the resulting instance_
 - `requiredKeys?` — default: `[all keys of recordModel]` — _list of keys that should never be deleted, remark: cannot be used with `withDeletedKeys`_
 - `withDeletedKeys?` — default: `false` — _when enabled, record might not generate all keys. `withDeletedKeys: true` is equivalent to `requiredKeys: []`, thus the two options cannot be used at the same time_
+- `noNullPrototype?` — default: `true` — _only generate records based on the Object-prototype, do not generate any record with null-prototype_
 
 **Usages:**
 


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

For now, users will have to explicitly ask for it. But in the next major, the null-prototype will be the default.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
