### PR TITLE
:bug: use a single types definition for require and import

### DIFF
--- a/packages/fast-check/package.json
+++ b/packages/fast-check/package.json
@@ -7,12 +7,11 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./lib/types/fast-check.d.ts",
       "require": {
-        "types": "./lib/types/fast-check.d.ts",
         "default": "./lib/fast-check.js"
       },
       "import": {
-        "types": "./lib/esm/types/fast-check.d.ts",
         "default": "./lib/esm/fast-check.js"
       }
     }
@@ -28,7 +27,7 @@
   "scripts": {
     "build": "yarn build:publish-cjs && yarn build:publish-esm && yarn build:publish-types && node postbuild/main.cjs",
     "build-ci": "cross-env EXPECT_GITHUB_SHA=true yarn build",
-    "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/esm/types",
+    "build:publish-types": "tsc -p tsconfig.publish.types.json",
     "build:publish-cjs": "tsc -p tsconfig.publish.json",
     "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm && cp package.esm-template.json lib/esm/package.json",
     "typecheck": "tsc --noEmit",

--- a/packages/fast-check/postbuild/main.cjs
+++ b/packages/fast-check/postbuild/main.cjs
@@ -70,16 +70,6 @@ fs.readFile(path.join(__dirname, '../package.json'), (err, data) => {
     console.info(`Package details added onto d.ts version for cjs`);
   }
 
-  const dTsReplacement2 = replace.sync({
-    files: 'lib/esm/types/fast-check-default.d.ts',
-    from: [/__PACKAGE_VERSION__/g, /__COMMIT_HASH__/g],
-    to: [packageVersion, commitHash],
-  });
-  if (dTsReplacement2.length === 1 && dTsReplacement[0].hasChanged) {
-    // eslint-disable-next-line
-    console.info(`Package details added onto d.ts version for esm`);
-  }
-
   function escapeHtml(unsafe) {
     return unsafe
       .replace(/&/g, '&amp;')


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [x] Typings
- [ ] _Other(s):_ ...

This change is motivated by my recent experimentation with esm + [@effect/schema](https://github.com/Effect-TS/schema) + fast-check. During the type-checking, it looks like the tsc uses esm version of the fast-check for my package (as it uses `"type": "module"`) and the cjs version of the fast-check is used for @effect/schema. Probably due to unique symbols and private methods / attributes in the fast-check .d.ts files, the type-checker reports a mismatch.

Please also check and feel free to join the discussion in the [effect discord thread](https://discord.com/channels/795981131316985866/1162783872224854167)