### PR TITLE
✅ Faster CI with one property for arbitraries

### DIFF
--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
@@ -44,6 +44,7 @@ type Checks<T, U> = {
   // > assertShrinkProducesCorrectValues with option (v, _, arb) => arb.canShrinkWithoutContext(v)
   sameValueWithoutInitialContext?: {
     isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
+    isNotApplicable?: (v: T) => boolean;
   };
   shrinkableWithoutContext?: Record<string, never>;
   strictlySmallerValue?: {
@@ -92,6 +93,10 @@ export function assertValidArbitrary<T, U = never>(
           let g4: Value<T> | null = requiresG4
             ? equivalentTo!.otherArbitrary(extraParameters).generate(randomFromSeed(seed), biasFactor)
             : null;
+          const sameValueWithoutInitialContextApplicable =
+            sameValueWithoutInitialContext !== undefined &&
+            (sameValueWithoutInitialContext.isNotApplicable === undefined ||
+              !sameValueWithoutInitialContext.isNotApplicable(g1.value_));
           while (g1 !== null && g2 !== null) {
             // Extract relevant values
             const v1 = g1.value;
@@ -109,7 +114,7 @@ export function assertValidArbitrary<T, U = never>(
                 assertEquality(equivalentTo.isEqualContext, v1, v4, extraParameters);
               }
             }
-            if (sameValueWithoutInitialContext !== undefined) {
+            if (sameValueWithoutInitialContext !== undefined && sameValueWithoutInitialContextApplicable) {
               assertEquality(sameValueWithoutInitialContext.isEqual, v1, v3, extraParameters);
             }
             if (shrinkableWithoutContext !== undefined) {

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
@@ -18,70 +18,58 @@ function poisoningAfterEach(nestedAfterEach: () => void) {
   }
 }
 
-// Minimal requirements
-// > The following assertions are supposed to be fulfilled by any of the arbitraries
-// > provided by fast-check.
-
-export function assertProduceSameValueGivenSameSeed<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
-  options: {
+type Checks<T, U> = {
+  // Minimal requirements
+  // > The following assertions are supposed to be fulfilled by any of the arbitraries
+  // > provided by fast-check.
+  sameValueGivenSameSeed: {
     isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
-    noInitialContext?: boolean;
+  };
+  // Optional requirements
+  // > The following requirements are optional as they do not break the design of fast-check when they are not totally ensured
+  // > But some of them are really recommended to build valid arbitraries that can be used.
+  correctValues?: {
+    isCorrect: (v: T, extraParameters: U, arb: Arbitrary<T>) => void | boolean;
+  };
+  equivalentTo?: {
+    otherArbitrary: (extraParameters: U) => Arbitrary<T>;
+    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
+    isEqualContext?: (c1: unknown, c2: unknown, extraParameters: U) => void | boolean;
+  };
+  // Extra requirements
+  // The assertions above can be configured to push generators even further. They ensure more complex invariants.
+  // Following assertions are mostly derived from the one above.
+  // > assertShrinkProducesSameValueGivenSameSeed with option {noInitialContext:true}
+  // > assertGenerateProducesCorrectValues with option isCorrect: (v, _, arb) => arb.canShrinkWithoutContext(v)
+  // > assertShrinkProducesCorrectValues with option (v, _, arb) => arb.canShrinkWithoutContext(v)
+  sameValueWithoutInitialContext?: {
+    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
+  };
+  shrinkableWithoutContext?: Record<string, never>;
+  strictlySmallerValue?: {
+    isStrictlySmaller: (vNew: T, vOld: T, extraParameters: U) => void | boolean;
+  };
+};
+
+export function assertValidArbitrary<T, U = never>(
+  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
+  checks: Checks<T, U>,
+  options: {
     extraParameters?: fc.Arbitrary<U>;
     assertParameters?: fc.Parameters<unknown>;
   } = {},
 ): void {
   const {
-    isEqual,
-    noInitialContext,
-    extraParameters: extra = fc.constant(undefined as unknown as U) as fc.Arbitrary<U>,
-    assertParameters,
-  } = options;
-  fc.assert(
-    fc
-      .property(
-        fc.integer().noShrink(),
-        biasFactorArbitrary(),
-        fc.infiniteStream(fc.nat({ max: 20 })),
-        extra,
-        (seed, biasFactor, shrinkPath, extraParameters) => {
-          // Arrange
-          const arb = arbitraryBuilder(extraParameters);
+    sameValueGivenSameSeed,
+    correctValues,
+    equivalentTo,
+    sameValueWithoutInitialContext,
+    shrinkableWithoutContext,
+    strictlySmallerValue,
+  } = checks;
+  const requiresG3 = sameValueWithoutInitialContext !== undefined;
+  const requiresG4 = equivalentTo !== undefined;
 
-          // Act / Assert
-          let g1: Value<T> | null = arb.generate(randomFromSeed(seed), biasFactor);
-          let g2: Value<T> | null = arb.generate(randomFromSeed(seed), biasFactor);
-          if (noInitialContext) {
-            const originalG2 = g2!;
-            g2 = new Value(originalG2.value_, undefined, () => originalG2.value);
-          }
-          while (g1 !== null && g2 !== null) {
-            assertEquality(isEqual, g1.value, g2.value, extraParameters);
-            const pos = shrinkPath.next().value;
-            g1 = arb.shrink(g1.value_, g1.context).getNthOrLast(pos);
-            g2 = arb.shrink(g2.value_, g2.context).getNthOrLast(pos);
-          }
-          expect(g1).toBe(null);
-          expect(g2).toBe(null);
-        },
-      )
-      .afterEach(poisoningAfterEach),
-    assertParameters,
-  );
-}
-
-// Optional requirements
-// > The following requirements are optional as they do not break the design of fast-check when they are not totally ensured
-// > But some of them are really recommended to build valid arbitraries that can be used.
-
-export function assertProduceCorrectValues<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
-  isCorrect: (v: T, extraParameters: U, arb: Arbitrary<T>) => void | boolean,
-  options: {
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {},
-): void {
   const { extraParameters: extra = fc.constant(undefined as unknown as U) as fc.Arbitrary<U>, assertParameters } =
     options;
   fc.assert(
@@ -93,56 +81,78 @@ export function assertProduceCorrectValues<T, U = never>(
         extra,
         (seed, biasFactor, shrinkPath, extraParameters) => {
           // Arrange
+          const previousValue: { value?: T } = {};
           const arb = arbitraryBuilder(extraParameters);
 
           // Act / Assert
-          let g: Value<T> | null = arb.generate(randomFromSeed(seed), biasFactor);
-          while (g !== null) {
-            assertCorrectness(isCorrect, g.value, extraParameters, arb);
+          let g1: Value<T> | null = arb.generate(randomFromSeed(seed), biasFactor);
+          let g2: Value<T> | null = arb.generate(randomFromSeed(seed), biasFactor);
+          const tempG3 = requiresG3 ? arb.generate(randomFromSeed(seed), biasFactor) : null!;
+          let g3: Value<T> | null = requiresG3 ? new Value(tempG3.value_, undefined, () => tempG3.value) : null;
+          let g4: Value<T> | null = requiresG4
+            ? equivalentTo!.otherArbitrary(extraParameters).generate(randomFromSeed(seed), biasFactor)
+            : null;
+          while (g1 !== null && g2 !== null) {
+            // Extract relevant values
+            const v1 = g1.value;
+            const v2 = g2.value;
+            const v3 = requiresG3 ? g3!.value : null!;
+            const v4 = requiresG4 ? g4!.value : null!;
+            // Perform each check
+            assertEquality(sameValueGivenSameSeed.isEqual, v1, v2, extraParameters);
+            if (correctValues !== undefined) {
+              assertCorrectness(correctValues.isCorrect, v1, extraParameters, arb);
+            }
+            if (equivalentTo !== undefined) {
+              assertEquality(equivalentTo.isEqual, v1, v4, extraParameters);
+              if (equivalentTo.isEqualContext !== undefined) {
+                assertEquality(equivalentTo.isEqualContext, v1, v4, extraParameters);
+              }
+            }
+            if (sameValueWithoutInitialContext !== undefined) {
+              assertEquality(sameValueWithoutInitialContext.isEqual, v1, v3, extraParameters);
+            }
+            if (shrinkableWithoutContext !== undefined) {
+              assertCorrectness((v, _, arb) => arb.canShrinkWithoutContext(v), v1, extraParameters, arb);
+            }
+            if (strictlySmallerValue) {
+              // eslint-disable-next-line no-inner-declarations
+              function isStrictlySmallerInternal(v: T, extraParameters: U) {
+                try {
+                  if (!('value' in previousValue)) {
+                    return true;
+                  }
+                  const vNew = v;
+                  const vOld = previousValue.value!;
+                  try {
+                    const out = strictlySmallerValue!.isStrictlySmaller(vNew, vOld, extraParameters);
+                    expect(out).not.toBe(false);
+                  } catch (err) {
+                    throw new Error(
+                      `Expect: ${fc.stringify(vNew)} to be strictly smaller than ${fc.stringify(
+                        vOld,
+                      )}\n\nGot error: ${err}`,
+                    );
+                  }
+                } finally {
+                  previousValue.value = v;
+                }
+              }
+              assertCorrectness(isStrictlySmallerInternal, v1, extraParameters, arb);
+            }
+
             const pos = shrinkPath.next().value;
-            g = arb.shrink(g.value, g.context).getNthOrLast(pos);
+            g1 = arb.shrink(g1.value_, g1.context).getNthOrLast(pos);
+            g2 = arb.shrink(g2.value_, g2.context).getNthOrLast(pos);
+            g3 = requiresG3 ? arb.shrink(g3!.value_, g3!.context).getNthOrLast(pos) : null;
+            g4 = requiresG4 ? arb.shrink(g4!.value_, g4!.context).getNthOrLast(pos) : null;
           }
-          expect(g).toBe(null);
+          expect(g1).toBe(null);
+          expect(g2).toBe(null);
+          expect(g3).toBe(null);
+          expect(g4).toBe(null);
         },
       )
-      .afterEach(poisoningAfterEach),
-    assertParameters,
-  );
-}
-
-export function assertGenerateEquivalentTo<T, U = never>(
-  arbitraryBuilderA: (extraParameters: U) => Arbitrary<T>,
-  arbitraryBuilderB: (extraParameters: U) => Arbitrary<T>,
-  options: {
-    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
-    isEqualContext?: (c1: unknown, c2: unknown, extraParameters: U) => void | boolean;
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {},
-): void {
-  const {
-    isEqual,
-    isEqualContext,
-    extraParameters: extra = fc.constant(undefined as unknown as U) as fc.Arbitrary<U>,
-    assertParameters,
-  } = options;
-  fc.assert(
-    fc
-      .property(fc.integer().noShrink(), biasFactorArbitrary(), extra, (seed, biasFactor, extraParameters) => {
-        // Arrange
-        const arbA = arbitraryBuilderA(extraParameters);
-        const arbB = arbitraryBuilderB(extraParameters);
-
-        // Act
-        const gA = arbA.generate(randomFromSeed(seed), biasFactor);
-        const gB = arbB.generate(randomFromSeed(seed), biasFactor);
-
-        // Assert
-        assertEquality(isEqual, gA.value, gB.value, extraParameters);
-        if (isEqualContext) {
-          assertEquality(isEqualContext, gA.context, gB.context, extraParameters);
-        }
-      })
       .afterEach(poisoningAfterEach),
     assertParameters,
   );
@@ -154,62 +164,6 @@ export function assertGenerateEquivalentTo<T, U = never>(
 // > assertShrinkProducesSameValueGivenSameSeed with option {noInitialContext:true}
 // > assertGenerateProducesCorrectValues with option isCorrect: (v, _, arb) => arb.canShrinkWithoutContext(v)
 // > assertShrinkProducesCorrectValues with option (v, _, arb) => arb.canShrinkWithoutContext(v)
-
-export function assertShrinkProducesSameValueWithoutInitialContext<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
-  options: {
-    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {},
-): void {
-  return assertProduceSameValueGivenSameSeed(arbitraryBuilder, { ...options, noInitialContext: true });
-}
-
-export function assertProduceValuesShrinkableWithoutContext<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
-  options: {
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {},
-): void {
-  return assertProduceCorrectValues(arbitraryBuilder, (v, _, arb) => arb.canShrinkWithoutContext(v), options);
-}
-
-export function assertShrinkProducesStrictlySmallerValue<T, U = never>(
-  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
-  isStrictlySmaller: (vNew: T, vOld: T, extraParameters: U) => void | boolean,
-  options: {
-    extraParameters?: fc.Arbitrary<U>;
-    assertParameters?: fc.Parameters<unknown>;
-  } = {},
-): void {
-  const previousValue: { value?: T } = {};
-  function arbitraryBuilderInternal(...args: Parameters<typeof arbitraryBuilder>) {
-    delete previousValue.value;
-    return arbitraryBuilder(...args);
-  }
-  function isStrictlySmallerInternal(v: T, extraParameters: U) {
-    try {
-      if (!('value' in previousValue)) {
-        return true;
-      }
-      const vNew = v;
-      const vOld = previousValue.value!;
-      try {
-        const out = isStrictlySmaller(vNew, vOld, extraParameters);
-        expect(out).not.toBe(false);
-      } catch (err) {
-        throw new Error(
-          `Expect: ${fc.stringify(vNew)} to be strictly smaller than ${fc.stringify(vOld)}\n\nGot error: ${err}`,
-        );
-      }
-    } finally {
-      previousValue.value = v;
-    }
-  }
-  return assertProduceCorrectValues(arbitraryBuilderInternal, isStrictlySmallerInternal, options);
-}
 
 export function assertProduceSomeSpecificValues<T, U = never>(
   arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
@@ -228,11 +182,18 @@ export function assertProduceSomeSpecificValues<T, U = never>(
     return true; // success of the property
   }
   try {
-    assertProduceCorrectValues(arbitraryBuilder, detectSpecificValue, {
-      ...options,
-      // We default numRuns to 1000, but let user override it whenever needed
-      assertParameters: { numRuns: 1000, ...options.assertParameters, endOnFailure: true },
-    });
+    assertValidArbitrary(
+      arbitraryBuilder,
+      {
+        sameValueGivenSameSeed: { isEqual: () => true }, // check ignored
+        correctValues: { isCorrect: detectSpecificValue },
+      },
+      {
+        ...options,
+        // We default numRuns to 1000, but let user override it whenever needed
+        assertParameters: { numRuns: 1000, ...options.assertParameters, endOnFailure: true },
+      },
+    );
   } catch (err) {
     // no-op
   }
@@ -254,16 +215,22 @@ export function assertGenerateIndependentOfSize<T, U = never>(
     isEqualContext,
     assertParameters,
   } = options;
-  assertGenerateEquivalentTo(
+  assertValidArbitrary(
     (extra) => arbitraryBuilder(extra.requested),
-    (extra) => withConfiguredGlobal(extra.global, () => arbitraryBuilder(extra.requested)),
+    {
+      sameValueGivenSameSeed: { isEqual: () => true }, // check ignored
+      equivalentTo: {
+        otherArbitrary: (extra) => withConfiguredGlobal(extra.global, () => arbitraryBuilder(extra.requested)),
+        isEqual: isEqual !== undefined ? (a, b, extra) => isEqual(a, b, extra.requested) : undefined,
+        isEqualContext:
+          isEqualContext !== undefined ? (a, b, extra) => isEqualContext(a, b, extra.requested) : undefined,
+      },
+    },
     {
       extraParameters: fc.record({
         requested: extraParameters,
         global: fc.record({ defaultSizeToMaxWhenMaxSpecified: fc.boolean(), baseSize: sizeArb }, { requiredKeys: [] }),
       }),
-      isEqual: isEqual !== undefined ? (a, b, extra) => isEqual(a, b, extra.requested) : undefined,
-      isEqualContext: isEqualContext !== undefined ? (a, b, extra) => isEqualContext(a, b, extra.requested) : undefined,
       assertParameters,
     },
   );

--- a/packages/fast-check/test/unit/arbitrary/_internals/ArrayInt64Arbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/ArrayInt64Arbitrary.spec.ts
@@ -6,13 +6,7 @@ import { ArrayInt64 } from '../../../../src/arbitrary/_internals/helpers/ArrayIn
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { buildShrinkTree, renderTree } from '../__test-helpers__/ShrinkTree';
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 
 describe('arrayInt64', () => {
   if (typeof BigInt === 'undefined') {
@@ -396,24 +390,18 @@ describe('arrayInt64 (integration)', () => {
   const arrayInt64Builder = (extra: Extra) =>
     arrayInt64(toArrayInt64(extra.min, false), toArrayInt64(extra.max, false));
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(arrayInt64Builder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(arrayInt64Builder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(arrayInt64Builder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(arrayInt64Builder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(arrayInt64Builder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      arrayInt64Builder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
@@ -2,13 +2,7 @@ import * as fc from 'fast-check';
 import { BigIntArbitrary } from '../../../../src/arbitrary/_internals/BigIntArbitrary';
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree, walkTree } from '../__test-helpers__/ShrinkTree';
 import { Stream } from '../../../../src/stream/Stream';
 
@@ -241,24 +235,18 @@ describe('BigIntArbitrary (integration)', () => {
 
   const bigIntBuilder = (extra: Extra) => new BigIntArbitrary(extra.min, extra.max);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(bigIntBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(bigIntBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(bigIntBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(bigIntBuilder, { extraParameters });
-  });
-
-  it('should shrink towards strictly smaller values', () => {
-    assertShrinkProducesStrictlySmallerValue(bigIntBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      bigIntBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 
   describe('shrink', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/CloneArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/CloneArbitrary.spec.ts
@@ -5,13 +5,7 @@ import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { cloneMethod, hasCloneMethod } from '../../../../src/check/symbols';
 import { Random } from '../../../../src/random/generator/Random';
 import { Stream } from '../../../../src/stream/Stream';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { FakeIntegerArbitrary, fakeArbitrary } from '../__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { buildShrinkTree, renderTree, walkTree } from '../__test-helpers__/ShrinkTree';
@@ -159,25 +153,18 @@ describe('CloneArbitrary (integration)', () => {
 
   const cloneBuilder = (extra: Extra) => new CloneArbitrary(new FakeIntegerArbitrary(), extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(cloneBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(cloneBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    // Only when equal regarding Object.is
-    assertProduceValuesShrinkableWithoutContext(cloneBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(cloneBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink (if underlyings do)', () => {
-    assertShrinkProducesStrictlySmallerValue(cloneBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      cloneBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {}, // Only when equal regarding Object.is
+        sameValueWithoutInitialContext: {}, // if underlyings do
+        strictlySmallerValue: { isStrictlySmaller }, // if underlyings do
+      },
+      { extraParameters },
+    );
   });
 
   it('should produce the right shrinking tree', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/ConstantArbitrary.spec.ts
@@ -2,12 +2,7 @@ import fc from 'fast-check';
 import { ConstantArbitrary } from '../../../../src/arbitrary/_internals/ConstantArbitrary';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { cloneMethod } from '../../../../src/check/symbols';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, walkTree } from '../__test-helpers__/ShrinkTree';
 
 describe('ConstantArbitrary', () => {
@@ -214,20 +209,17 @@ describe('ConstantArbitrary (integration)', () => {
 
   const constantBuilder = (extra: Extra) => new ConstantArbitrary(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(constantBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(constantBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(constantBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(constantBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      constantBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 
   it('should not re-use twice the same instance of cloneable', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/FrequencyArbitrary.spec.ts
@@ -3,12 +3,7 @@ import { FrequencyArbitrary, _Constraints } from '../../../../src/arbitrary/_int
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { FakeIntegerArbitrary, fakeArbitrary } from '../__test-helpers__/ArbitraryHelpers';
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesStrictlySmallerValue,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import * as DepthContextMock from '../../../../src/arbitrary/_internals/helpers/DepthContext';
 import { Stream } from '../../../../src/stream/Stream';
 import { sizeArb } from '../__test-helpers__/SizeHelpers';
@@ -753,19 +748,16 @@ describe('FrequencyArbitrary (integration)', () => {
       'test',
     );
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(frequencyBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(frequencyBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(frequencyBuilder, { extraParameters });
-  });
-
-  it('should shrink towards strictly smaller values (if underlyings do)', () => {
-    assertShrinkProducesStrictlySmallerValue(frequencyBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      frequencyBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
@@ -3,11 +3,7 @@ import { IntegerArbitrary } from '../../../../src/arbitrary/_internals/IntegerAr
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from '../__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree, walkTree } from '../__test-helpers__/ShrinkTree';
 
@@ -231,24 +227,18 @@ describe('IntegerArbitrary (integration)', () => {
 
   const integerBuilder = (extra: Extra) => new IntegerArbitrary(extra.min, extra.max);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(integerBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(integerBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(integerBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(integerBuilder, { extraParameters });
-  });
-
-  it('should shrink towards strictly smaller values', () => {
-    assertShrinkProducesStrictlySmallerValue(integerBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      integerBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 
   describe('shrink', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/MixedCaseArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/MixedCaseArbitrary.spec.ts
@@ -1,11 +1,5 @@
 import fc from 'fast-check';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { MixedCaseArbitrary } from '../../../../src/arbitrary/_internals/MixedCaseArbitrary';
 import { stringOf } from '../../../../src/arbitrary/stringOf';
 import { nat } from '../../../../src/arbitrary/nat';
@@ -188,24 +182,18 @@ describe('MixedCaseArbitrary (integration)', () => {
       (rawString) => rawString.toUpperCase(),
     );
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(mixedCaseBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(mixedCaseBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(mixedCaseBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(mixedCaseBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink (if underlyings do)', () => {
-    assertShrinkProducesStrictlySmallerValue(mixedCaseBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      mixedCaseBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {}, // if underlyings do
+        strictlySmallerValue: { isStrictlySmaller }, // if underlyings do
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
@@ -3,10 +3,7 @@ import { StreamArbitrary } from '../../../../src/arbitrary/_internals/StreamArbi
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { cloneIfNeeded, hasCloneMethod } from '../../../../src/check/symbols';
 import { Stream } from '../../../../src/stream/Stream';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { FakeIntegerArbitrary, fakeArbitrary } from '../__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 
@@ -277,11 +274,10 @@ describe('StreamArbitrary (integration)', () => {
 
   const streamBuilder = () => new StreamArbitrary(sourceArb);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(streamBuilder, { isEqual });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(streamBuilder, isCorrect);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(streamBuilder, {
+      sameValueGivenSameSeed: { isEqual },
+      correctValues: { isCorrect },
+    });
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/_internals/SubarrayArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/SubarrayArbitrary.spec.ts
@@ -1,13 +1,7 @@
 import * as fc from 'fast-check';
 import { SubarrayArbitrary } from '../../../../src/arbitrary/_internals/SubarrayArbitrary';
 
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -185,24 +179,18 @@ describe('SubarrayArbitrary (integration)', () => {
   const SubarrayArbitraryBuilder = (extra: Extra) =>
     new SubarrayArbitrary(extra.data, extra.isOrdered, extra.minLength, extra.maxLength);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(SubarrayArbitraryBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(SubarrayArbitraryBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(SubarrayArbitraryBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(SubarrayArbitraryBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(SubarrayArbitraryBuilder, isStrictlySmallerValue, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      SubarrayArbitraryBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller: isStrictlySmallerValue },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/_internals/TupleArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/TupleArbitrary.spec.ts
@@ -4,13 +4,7 @@ import { FakeIntegerArbitrary, fakeArbitrary } from '../__test-helpers__/Arbitra
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { cloneMethod, hasCloneMethod } from '../../../../src/check/symbols';
 import { Stream } from '../../../../src/stream/Stream';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from '../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree, walkTree } from '../__test-helpers__/ShrinkTree';
 import { Arbitrary } from '../../../../src/check/arbitrary/definition/Arbitrary';
 import { Random } from '../../../../src/random/generator/Random';
@@ -258,24 +252,14 @@ describe('TupleArbitrary (integration)', () => {
   const tupleBuilder = () =>
     new TupleArbitrary([new FakeIntegerArbitrary(), new FakeIntegerArbitrary(), new FakeIntegerArbitrary()]);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(tupleBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(tupleBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(tupleBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(tupleBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink (if underlyings do)', () => {
-    assertShrinkProducesStrictlySmallerValue(tupleBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(tupleBuilder, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {}, // if underlyings do
+      strictlySmallerValue: { isStrictlySmaller }, // if underlyings do
+    });
   });
 
   it('should produce the right shrinking tree', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
@@ -6,12 +6,7 @@ import {
   ObjectConstraints,
 } from '../../../../../src/arbitrary/_internals/helpers/QualifiedObjectConstraints';
 
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceSomeSpecificValues,
-  assertProduceValuesShrinkableWithoutContext,
-} from '../../__test-helpers__/ArbitraryAssertions';
+import { assertProduceSomeSpecificValues, assertValidArbitrary } from '../../__test-helpers__/ArbitraryAssertions';
 import { computeObjectDepth } from '../../__test-helpers__/ComputeObjectDepth';
 import { computeObjectMaxKeys } from '../../__test-helpers__/ComputeObjectMaxKeys';
 import { sizeArb } from '../../__test-helpers__/SizeHelpers';
@@ -155,21 +150,19 @@ describe('anyArbitraryBuilder (integration)', () => {
 
   const anyArbitraryBuilderBuilder = (extra: Extra) => anyArbitraryBuilder(toQualifiedObjectConstraints(extra));
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(anyArbitraryBuilderBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(anyArbitraryBuilderBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(anyArbitraryBuilderBuilder, {
-      // For the moment, we are not able to reverse "object-string" values.
-      // In the future our fc.string() should be able to shrink them given it does not receive any constraint on the length
-      // but for the moment it somehow assume that it cannot shrink strings having strictly more than 10 characters (value of maxLength when not specified).
-      extraParameters: extraParameters.map((extra) => ({ ...extra, withObjectString: false })),
-    });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      anyArbitraryBuilderBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        // For the moment, we are not able to reverse "object-string" values.
+        // In the future our fc.string() should be able to shrink them given it does not receive any constraint on the length
+        // but for the moment it somehow assume that it cannot shrink strings having strictly more than 10 characters (value of maxLength when not specified).
+        shrinkableWithoutContext: { isNotApplicable: (_v, extra) => !!extra.withObjectString },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
@@ -4,12 +4,7 @@ import { typedIntArrayArbitraryArbitraryBuilder } from '../../../../../src/arbit
 import { FakeIntegerArbitrary, fakeArbitrary, fakeArbitraryStaticValue } from '../../__test-helpers__/ArbitraryHelpers';
 
 import * as ArrayMock from '../../../../../src/arbitrary/array';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from '../../__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from '../../__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -164,22 +159,17 @@ describe('typedIntArrayArbitraryArbitraryBuilder (integration)', () => {
       ({ min = 0, max = min }) => new FakeIntegerArbitrary(min, max - min),
     );
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(typedIntArrayArbitraryArbitraryBuilderBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(typedIntArrayArbitraryArbitraryBuilderBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(typedIntArrayArbitraryArbitraryBuilderBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(typedIntArrayArbitraryArbitraryBuilderBuilder, {
-      extraParameters,
-    });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      typedIntArrayArbitraryArbitraryBuilderBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/array.spec.ts
@@ -4,13 +4,7 @@ import { array } from '../../../src/arbitrary/array';
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as ArrayArbitraryMock from '../../../src/arbitrary/_internals/ArrayArbitrary';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { isStrictlySmallerArray } from './__test-helpers__/ArrayHelpers';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
@@ -271,24 +265,18 @@ describe('array (integration)', () => {
 
   const arrayBuilder = (extra: Extra) => array(new FakeIntegerArbitrary(), extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(arrayBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(arrayBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(arrayBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(arrayBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(arrayBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      arrayBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/ascii.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ascii.spec.ts
@@ -4,13 +4,7 @@ import { ascii } from '../../../src/arbitrary/ascii';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -56,24 +50,14 @@ describe('ascii (integration)', () => {
 
   const asciiBuilder = () => ascii();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(asciiBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(asciiBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(asciiBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(asciiBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(asciiBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(asciiBuilder, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+      strictlySmallerValue: { isStrictlySmaller },
+    });
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/asciiString.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/asciiString.spec.ts
@@ -1,12 +1,7 @@
 import * as fc from 'fast-check';
 import { asciiString } from '../../../src/arbitrary/asciiString';
 
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 describe('asciiString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
@@ -32,19 +27,16 @@ describe('asciiString (integration)', () => {
 
   const asciiStringBuilder = (extra: Extra) => asciiString(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(asciiStringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(asciiStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(asciiStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(asciiStringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      asciiStringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/base64.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/base64.spec.ts
@@ -4,13 +4,7 @@ import { base64 } from '../../../src/arbitrary/base64';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -70,24 +64,14 @@ describe('base64 (integration)', () => {
 
   const base64Builder = () => base64();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(base64Builder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(base64Builder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(base64Builder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(base64Builder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(base64Builder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(base64Builder, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+      strictlySmallerValue: { isStrictlySmaller },
+    });
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/base64String.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/base64String.spec.ts
@@ -1,11 +1,7 @@
 import * as fc from 'fast-check';
 import { base64String } from '../../../src/arbitrary/base64String';
 
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 import * as ArrayMock from '../../../src/arbitrary/array';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
@@ -160,16 +156,16 @@ describe('base64String (integration)', () => {
 
   const base64StringBuilder = (extra: Extra) => base64String(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(base64StringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(base64StringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(base64StringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      base64StringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   // assertShrinkProducesSameValueWithoutInitialContext is not applicable for base64String has some values will not shrink exactly the same way.

--- a/packages/fast-check/test/unit/arbitrary/char.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/char.spec.ts
@@ -5,11 +5,7 @@ import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
@@ -56,24 +52,17 @@ describe('char (integration)', () => {
 
   const charBuilder = () => char();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(charBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(charBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(charBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(charBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(charBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      charBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/char16bits.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/char16bits.spec.ts
@@ -4,13 +4,7 @@ import { char16bits } from '../../../src/arbitrary/char16bits';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -57,24 +51,14 @@ describe('char16bits (integration)', () => {
 
   const char16bitsBuilder = () => char16bits();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(char16bitsBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(char16bitsBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(char16bitsBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(char16bitsBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(char16bitsBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(char16bitsBuilder, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+      strictlySmallerValue: { isStrictlySmaller },
+    });
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/compareFunc.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/compareFunc.spec.ts
@@ -2,11 +2,9 @@ import * as fc from 'fast-check';
 import { compareFunc } from '../../../src/arbitrary/compareFunc';
 
 import { hasCloneMethod, cloneIfNeeded } from '../../../src/check/symbols';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { assertToStringIsSameFunction } from './__test-helpers__/ToStringIsSameFunction';
+import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 
 describe('compareFunc (integration)', () => {
   const compareFuncBuilder = () => compareFunc();
@@ -86,3 +84,31 @@ describe('compareFunc (integration)', () => {
     );
   });
 });
+
+// Helpers
+
+function assertProduceSameValueGivenSameSeed<T, U = never>(
+  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
+  options: {
+    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
+    extraParameters?: fc.Arbitrary<U>;
+    assertParameters?: fc.Parameters<unknown>;
+  } = {},
+): void {
+  assertValidArbitrary(arbitraryBuilder, { sameValueGivenSameSeed: { isEqual: options.isEqual } }, options);
+}
+
+function assertProduceCorrectValues<T, U = never>(
+  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
+  isCorrect: (v: T, extraParameters: U, arb: Arbitrary<T>) => void | boolean,
+  options: {
+    extraParameters?: fc.Arbitrary<U>;
+    assertParameters?: fc.Parameters<unknown>;
+  } = {},
+): void {
+  assertValidArbitrary(
+    arbitraryBuilder,
+    { sameValueGivenSameSeed: { isEqual: () => true }, correctValues: { isCorrect } },
+    options,
+  );
+}

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -2,11 +2,7 @@ import fc from 'fast-check';
 import { date } from '../../../src/arbitrary/date';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 import * as IntegerMock from '../../../src/arbitrary/integer';
@@ -181,24 +177,18 @@ describe('date (integration)', () => {
 
   const dateBuilder = (extra: Extra) => date(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(dateBuilder, { extraParameters, isEqual });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(dateBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(dateBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(dateBuilder, { extraParameters, isEqual });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(dateBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      dateBuilder,
+      {
+        sameValueGivenSameSeed: {isEqual},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {isEqual},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/dictionary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/dictionary.spec.ts
@@ -6,9 +6,7 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { Random } from '../../../src/random/generator/Random';
 import { Stream } from '../../../src/stream/Stream';
 import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 describe('dictionary (integration)', () => {
@@ -66,16 +64,16 @@ describe('dictionary (integration)', () => {
     return dictionary(keyArb, valueArb, constraints);
   };
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(dictionaryBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(dictionaryBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
-    assertProduceValuesShrinkableWithoutContext(dictionaryBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      dictionaryBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/domain.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/domain.spec.ts
@@ -3,12 +3,7 @@ import { domain, DomainConstraints } from '../../../src/arbitrary/domain';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { URL } from 'url';
 
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
 
@@ -45,32 +40,23 @@ describe('domain (integration)', () => {
     { requiredKeys: [] },
   );
 
-  const isCorrect = isValidDomainWithExtension;
-
-  const isCorrectForURL = (domain: string) => {
+  const isCorrect = (domain: string) => {
+    expect(isValidDomainWithExtension(domain)).toBe(true);
     expect(() => new URL(`http://${domain}`)).not.toThrow();
   };
 
   const domainBuilder = (extra: Extra) => domain(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(domainBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(domainBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should only produce correct values regarding `new URL`', () => {
-    assertProduceCorrectValues(domainBuilder, isCorrectForURL, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(domainBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(domainBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      domainBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -19,13 +19,7 @@ import { doubleToIndex, indexToDouble } from '../../../src/arbitrary/_internals/
 import { fakeArbitrary, fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
 
-import {
-  assertProduceCorrectValues,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 import * as ArrayInt64ArbitraryMock from '../../../src/arbitrary/_internals/ArrayInt64Arbitrary';
 
@@ -324,24 +318,18 @@ describe('double (integration)', () => {
 
   const doubleBuilder = (extra: Extra) => double(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(doubleBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(doubleBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(doubleBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(doubleBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(doubleBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      doubleBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/emailAddress.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/emailAddress.spec.ts
@@ -2,12 +2,7 @@ import fc from 'fast-check';
 import { emailAddress, EmailAddressConstraints } from '../../../src/arbitrary/emailAddress';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
 
@@ -55,20 +50,17 @@ describe('emailAddress (integration)', () => {
 
   const emailAddressBuilder = () => emailAddress();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(emailAddressBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(emailAddressBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(emailAddressBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(emailAddressBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      emailAddressBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -20,13 +20,7 @@ import {
 import { fakeArbitrary, fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
 
-import {
-  assertProduceCorrectValues,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 import * as IntegerMock from '../../../src/arbitrary/integer';
 
@@ -326,24 +320,18 @@ describe('float (integration)', () => {
 
   const floatBuilder = (extra: Extra) => float(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(floatBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(floatBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(floatBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(floatBuilder, { extraParameters });
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(floatBuilder, isStrictlySmaller, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      floatBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
@@ -2,10 +2,7 @@ import * as fc from 'fast-check';
 import { float32Array, Float32ArrayConstraints } from '../../../src/arbitrary/float32Array';
 
 import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
@@ -52,20 +49,17 @@ describe('float32Array (integration)', () => {
 
   const float32ArrayBuilder = (extra: Extra) => float32Array(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(float32ArrayBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(float32ArrayBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(float32ArrayBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(float32ArrayBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      float32ArrayBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
@@ -2,10 +2,7 @@ import * as fc from 'fast-check';
 import { float64Array, Float64ArrayConstraints } from '../../../src/arbitrary/float64Array';
 
 import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
+ assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
@@ -52,20 +49,17 @@ describe('float64Array (integration)', () => {
 
   const float64ArrayBuilder = (extra: Extra) => float64Array(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(float64ArrayBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(float64ArrayBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(float64ArrayBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(float64ArrayBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      float64ArrayBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/fullUnicode.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/fullUnicode.spec.ts
@@ -5,11 +5,7 @@ import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
@@ -59,24 +55,17 @@ describe('fullUnicode (integration)', () => {
 
   const fullUnicodeBuilder = () => fullUnicode();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(fullUnicodeBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(fullUnicodeBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(fullUnicodeBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(fullUnicodeBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(fullUnicodeBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      fullUnicodeBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/fullUnicodeString.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/fullUnicodeString.spec.ts
@@ -2,12 +2,7 @@ import * as fc from 'fast-check';
 import { fullUnicodeString } from '../../../src/arbitrary/fullUnicodeString';
 
 import { Value } from '../../../src/check/arbitrary/definition/Value';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
 describe('fullUnicodeString (integration)', () => {
@@ -41,20 +36,17 @@ describe('fullUnicodeString (integration)', () => {
 
   const fullUnicodeStringBuilder = (extra: Extra) => fullUnicodeString(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(fullUnicodeStringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(fullUnicodeStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(fullUnicodeStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(fullUnicodeStringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      fullUnicodeStringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/func.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/func.spec.ts
@@ -6,10 +6,7 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { hasCloneMethod, cloneIfNeeded, cloneMethod } from '../../../src/check/symbols';
 import { Random } from '../../../src/random/generator/Random';
 import { Stream } from '../../../src/stream/Stream';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { FakeIntegerArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import { assertToStringIsSameFunction } from './__test-helpers__/ToStringIsSameFunction';
 
@@ -134,3 +131,31 @@ describe('func (integration)', () => {
     );
   });
 });
+
+// Helpers
+
+function assertProduceSameValueGivenSameSeed<T, U = never>(
+  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
+  options: {
+    isEqual?: (v1: T, v2: T, extraParameters: U) => void | boolean;
+    extraParameters?: fc.Arbitrary<U>;
+    assertParameters?: fc.Parameters<unknown>;
+  } = {},
+): void {
+  assertValidArbitrary(arbitraryBuilder, { sameValueGivenSameSeed: { isEqual: options.isEqual } }, options);
+}
+
+function assertProduceCorrectValues<T, U = never>(
+  arbitraryBuilder: (extraParameters: U) => Arbitrary<T>,
+  isCorrect: (v: T, extraParameters: U, arb: Arbitrary<T>) => void | boolean,
+  options: {
+    extraParameters?: fc.Arbitrary<U>;
+    assertParameters?: fc.Parameters<unknown>;
+  } = {},
+): void {
+  assertValidArbitrary(
+    arbitraryBuilder,
+    { sameValueGivenSameSeed: { isEqual: () => true }, correctValues: { isCorrect } },
+    options,
+  );
+}

--- a/packages/fast-check/test/unit/arbitrary/hexa.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/hexa.spec.ts
@@ -4,13 +4,7 @@ import { hexa } from '../../../src/arbitrary/hexa';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
   jest.resetModules();
@@ -60,24 +54,14 @@ describe('hexa (integration)', () => {
 
   const hexaBuilder = () => hexa();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(hexaBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(hexaBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(hexaBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(hexaBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(hexaBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(hexaBuilder, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+      strictlySmallerValue: { isStrictlySmaller },
+    });
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/hexaString.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/hexaString.spec.ts
@@ -2,10 +2,7 @@ import * as fc from 'fast-check';
 import { hexaString } from '../../../src/arbitrary/hexaString';
 
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 describe('hexaString (integration)', () => {
@@ -31,19 +28,16 @@ describe('hexaString (integration)', () => {
 
   const hexaStringBuilder = (extra: Extra) => hexaString(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(hexaStringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(hexaStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(hexaStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(hexaStringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      hexaStringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/ipV4.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ipV4.spec.ts
@@ -2,10 +2,7 @@ import { ipV4 } from '../../../src/arbitrary/ipV4';
 
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
@@ -21,20 +18,16 @@ describe('ipV4 (integration)', () => {
 
   const ipV4Builder = () => ipV4();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(ipV4Builder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(ipV4Builder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(ipV4Builder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(ipV4Builder);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      ipV4Builder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/ipV4Extended.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ipV4Extended.spec.ts
@@ -1,12 +1,7 @@
 import { ipV4Extended } from '../../../src/arbitrary/ipV4Extended';
 
 import { Value } from '../../../src/check/arbitrary/definition/Value';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
 describe('ipV4Extended (integration)', () => {
@@ -34,20 +29,16 @@ describe('ipV4Extended (integration)', () => {
 
   const ipV4ExtendedBuilder = () => ipV4Extended();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(ipV4ExtendedBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(ipV4ExtendedBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(ipV4ExtendedBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(ipV4ExtendedBuilder);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      ipV4ExtendedBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/ipV6.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ipV6.spec.ts
@@ -2,11 +2,7 @@ import { ipV6 } from '../../../src/arbitrary/ipV6';
 
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertGenerateIndependentOfSize,
+  assertGenerateIndependentOfSize,assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
@@ -54,20 +50,16 @@ describe('ipV6 (integration)', () => {
 
   const ipV6Builder = () => ipV6();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(ipV6Builder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(ipV6Builder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(ipV6Builder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(ipV6Builder);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      ipV6Builder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+    );
   });
 
   it('should be independent of global settings overriding defaults on size', () => {

--- a/packages/fast-check/test/unit/arbitrary/jsonValue.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/jsonValue.spec.ts
@@ -1,12 +1,7 @@
 import fc from 'fast-check';
 
 import { jsonValue, JsonSharedConstraints } from '../../../src/arbitrary/jsonValue';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { computeObjectDepth } from './__test-helpers__/ComputeObjectDepth';
 import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKeys';
 import { sizeArb } from './__test-helpers__/SizeHelpers';
@@ -46,25 +41,19 @@ describe('jsonValue (integration)', () => {
 
   const jsonValueBuilder = (extra: Extra) => jsonValue(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(jsonValueBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(jsonValueBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(jsonValueBuilder, { extraParameters });
-  });
-
-  // Property: should be able to shrink to the same values without initial context
-  // Is partially applicable given the fact that: Object.keys() has a specific handling of integer keys over string ones.
-  // eg.: Object.keys({"2": "2", "0": "0", "C": "C", "A": "A", "B": "B", "1": "1"}) -> ["0", "1", "2", "C", "A", "B"]
-  // As a consequence there is no way to rebuild the source array of tuples (key, value) in the right order in such case (when numerics).
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(
-      (extra) => jsonValueBuilder(extra).filter((o) => !isObjectWithNumericKeys(o)),
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      jsonValueBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        // Property: should be able to shrink to the same values without initial context
+        // Is partially applicable given the fact that: Object.keys() has a specific handling of integer keys over string ones.
+        // eg.: Object.keys({"2": "2", "0": "0", "C": "C", "A": "A", "B": "B", "1": "1"}) -> ["0", "1", "2", "C", "A", "B"]
+        // As a consequence there is no way to rebuild the source array of tuples (key, value) in the right order in such case (when numerics).
+        sameValueWithoutInitialContext: { isNotApplicable: isObjectWithNumericKeys },
+      },
       { extraParameters },
     );
   });

--- a/packages/fast-check/test/unit/arbitrary/letrec.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/letrec.spec.ts
@@ -4,12 +4,7 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { Stream } from '../../../src/stream/Stream';
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
-import {
-  assertGenerateEquivalentTo,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 describe('letrec', () => {
   describe('builder', () => {
@@ -326,23 +321,18 @@ describe('letrec (integration)', () => {
     return a;
   };
 
-  it('should generate the values as-if we directly called the target arbitrary', () => {
-    assertGenerateEquivalentTo(letrecBuilder, () => new FakeIntegerArbitrary(), {
-      isEqualContext: (c1, c2) => {
-        expect(c2).toEqual(c1);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(letrecBuilder, {
+      sameValueGivenSameSeed: {},
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+      equivalentTo: {
+        // generate the values as-if we directly called the target arbitrary
+        otherArbitrary: () => new FakeIntegerArbitrary(),
+        isEqualContext: (c1, c2) => {
+          expect(c2).toEqual(c1);
+        },
       },
     });
-  });
-
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(letrecBuilder);
-  });
-
-  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
-    assertProduceValuesShrinkableWithoutContext(letrecBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(letrecBuilder);
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/lorem.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/lorem.spec.ts
@@ -1,11 +1,6 @@
 import fc from 'fast-check';
 import { lorem, LoremConstraints } from '../../../src/arbitrary/lorem';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 describe('lorem', () => {
   it('should reject any negative or zero maxCount whatever the mode', () =>
@@ -66,19 +61,16 @@ describe('lorem (integration)', () => {
 
   const loremBuilder = (extra: Extra) => lorem(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(loremBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(loremBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(loremBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(loremBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      loremBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/mapToConstant.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/mapToConstant.spec.ts
@@ -2,10 +2,7 @@ import fc from 'fast-check';
 import { mapToConstant } from '../../../src/arbitrary/mapToConstant';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
@@ -73,20 +70,17 @@ describe('mapToConstant (integration)', () => {
     return mapToConstant(...entries);
   };
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(mapToConstantBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(mapToConstantBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(mapToConstantBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(mapToConstantBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      mapToConstantBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it('should be able to shrink c given hexa-like entries', () => {

--- a/packages/fast-check/test/unit/arbitrary/option.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/option.spec.ts
@@ -3,12 +3,7 @@ import { option, OptionConstraints } from '../../../src/arbitrary/option';
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import * as FrequencyArbitraryMock from '../../../src/arbitrary/_internals/FrequencyArbitrary';
 import * as ConstantMock from '../../../src/arbitrary/constant';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { sizeArb } from './__test-helpers__/SizeHelpers';
 
 function beforeEachHook() {
@@ -107,19 +102,16 @@ describe('option (integration)', () => {
 
   const optionBuilder = (extra: Extra) => option(new FakeIntegerArbitrary(), { ...extra, nil: null });
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(optionBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(optionBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
-    assertProduceValuesShrinkableWithoutContext(optionBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(optionBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      optionBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/record.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/record.spec.ts
@@ -3,10 +3,7 @@ import { record, RecordConstraints } from '../../../src/arbitrary/record';
 import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 import * as PartialRecordArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder';
@@ -292,19 +289,16 @@ describe('record (integration)', () => {
     return record(recordModel, constraints);
   };
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(recordBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(recordBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context (if underlyings do)', () => {
-    assertProduceValuesShrinkableWithoutContext(recordBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context (if underlyings do)', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(recordBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      recordBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {}, // if underlyings do
+        sameValueWithoutInitialContext: {}, // if underlyings do
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/sparseArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/sparseArray.spec.ts
@@ -7,11 +7,7 @@ import { FakeIntegerArbitrary, fakeArbitrary, fakeArbitraryStaticValue } from '.
 import * as RestrictedIntegerArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/RestrictedIntegerArbitraryBuilder';
 import * as TupleMock from '../../../src/arbitrary/tuple';
 import * as UniqueMock from '../../../src/arbitrary/uniqueArray';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { MaxLengthUpperBound } from '../../../src/arbitrary/_internals/helpers/MaxLengthFromMinLength';
@@ -184,20 +180,20 @@ describe('sparseArray (integration)', () => {
 
   const sparseArrayBuilder = (extra: Extra) => sparseArray(new FakeIntegerArbitrary(), extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(sparseArrayBuilder, { extraParameters, isEqual });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(sparseArrayBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    // Remark: It will not shrink towards the exact same values for various reasons,
-    // - when noTrailingHole=false, there is no real way to buid back the targetLength
-    // - the key-value pairs will most of the time not be in the same ordered as the build order,
-    //   thus it will lead to a different shrink order
-    assertProduceValuesShrinkableWithoutContext(sparseArrayBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      sparseArrayBuilder,
+      {
+        sameValueGivenSameSeed: { isEqual },
+        correctValues: { isCorrect },
+        // Remark: It will not shrink towards the exact same values for various reasons,
+        // - when noTrailingHole=false, there is no real way to buid back the targetLength
+        // - the key-value pairs will most of the time not be in the same ordered as the build order,
+        //   thus it will lead to a different shrink order
+        shrinkableWithoutContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/string.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/string.spec.ts
@@ -2,12 +2,7 @@ import * as fc from 'fast-check';
 import { string } from '../../../src/arbitrary/string';
 
 import { Value } from '../../../src/check/arbitrary/definition/Value';
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
 describe('string (integration)', () => {
@@ -34,20 +29,17 @@ describe('string (integration)', () => {
 
   const stringBuilder = (extra: Extra) => string(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(stringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(stringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(stringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(stringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      stringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 
   it.each`

--- a/packages/fast-check/test/unit/arbitrary/string16bits.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/string16bits.spec.ts
@@ -1,12 +1,7 @@
 import * as fc from 'fast-check';
 import { string16bits } from '../../../src/arbitrary/string16bits';
 
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 describe('string16bits (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
@@ -28,19 +23,16 @@ describe('string16bits (integration)', () => {
 
   const string16bitsBuilder = (extra: Extra) => string16bits(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(string16bitsBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(string16bitsBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(string16bitsBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(string16bitsBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      string16bitsBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -1,9 +1,7 @@
 import * as fc from 'fast-check';
 import { stringMatching } from '../../../src/arbitrary/stringMatching';
 
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
+import {assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 describe('stringMatching (integration)', () => {
@@ -14,12 +12,15 @@ describe('stringMatching (integration)', () => {
   // isCorrect has to clone the instance of RegExp to make sure not to depend on its internal state
   const isCorrect = (value: string, extra: Extra) => new RegExp(extra.regex.source, extra.regex.flags).test(value);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(stringMatchingBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(stringMatchingBuilder, isCorrect, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      stringMatchingBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+      },
+      { extraParameters },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/stringOf.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringOf.spec.ts
@@ -5,10 +5,7 @@ import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { Random } from '../../../src/random/generator/Random';
 import { Stream } from '../../../src/stream/Stream';
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 
 describe('stringOf (integration)', () => {
@@ -30,17 +27,19 @@ describe('stringOf (integration)', () => {
 
   const stringOfBuilder = (extra: Extra) => stringOf(new PatternsArbitrary(extra.patterns), extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(stringOfBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      stringOfBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        shrinkableWithoutContext: {},
+        // sameValueWithoutInitialContext is not fully supported by stringOf
+        // Indeed depending how much the source strings overlaps there are possibly many possible ways to build a given string
+        // so also many possible ways to shrink it.
+      },
+      { extraParameters },
+    );
   });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(stringOfBuilder, { extraParameters });
-  });
-
-  // assertShrinkProducesSameValueWithoutInitialContext is not fully supported by stringOf
-  // Indeed depending how much the source strings overlaps there are possibly many possible ways to build a given string
-  // so also many possible ways to shrink it.
 
   it.each`
     source                             | patterns        | constraints

--- a/packages/fast-check/test/unit/arbitrary/ulid.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ulid.spec.ts
@@ -5,12 +5,7 @@ import { fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 import * as _IntegerMock from '../../../src/arbitrary/integer';
 import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
-import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
 function beforeEachHook() {
@@ -61,19 +56,12 @@ describe('ulid (integration)', () => {
     expect(u).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/);
   };
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(ulid);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(ulid, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(ulid);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(ulid);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(ulid, {
+      sameValueGivenSameSeed: {},
+      correctValues: { isCorrect },
+      shrinkableWithoutContext: {},
+      sameValueWithoutInitialContext: {},
+    });
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/unicode.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/unicode.spec.ts
@@ -5,11 +5,7 @@ import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertProduceCorrectValues,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertShrinkProducesStrictlySmallerValue,
-  assertProduceSameValueGivenSameSeed,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 
 function beforeEachHook() {
@@ -60,24 +56,17 @@ describe('unicode (integration)', () => {
 
   const unicodeBuilder = () => unicode();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(unicodeBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(unicodeBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(unicodeBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(unicodeBuilder);
-  });
-
-  it('should preserve strictly smaller ordering in shrink', () => {
-    assertShrinkProducesStrictlySmallerValue(unicodeBuilder, isStrictlySmaller);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      unicodeBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        strictlySmallerValue: { isStrictlySmaller },
+      },
+    );
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/unicodeJsonValue.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/unicodeJsonValue.spec.ts
@@ -1,12 +1,7 @@
 import fc from 'fast-check';
 
 import { unicodeJsonValue, JsonSharedConstraints } from '../../../src/arbitrary/unicodeJsonValue';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { computeObjectDepth } from './__test-helpers__/ComputeObjectDepth';
 import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKeys';
 import { sizeArb } from './__test-helpers__/SizeHelpers';
@@ -46,25 +41,19 @@ describe('unicodeJsonValue (integration)', () => {
 
   const unicodeJsonValueBuilder = (extra: Extra) => unicodeJsonValue(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(unicodeJsonValueBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(unicodeJsonValueBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(unicodeJsonValueBuilder, { extraParameters });
-  });
-
-  // Property: should be able to shrink to the same values without initial context
-  // Is partially applicable given the fact that: Object.keys() has a specific handling of integer keys over string ones.
-  // eg.: Object.keys({"2": "2", "0": "0", "C": "C", "A": "A", "B": "B", "1": "1"}) -> ["0", "1", "2", "C", "A", "B"]
-  // As a consequence there is no way to rebuild the source array of tuples (key, value) in the right order in such case (when numerics).
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(
-      (extra) => unicodeJsonValueBuilder(extra).filter((o) => !isObjectWithNumericKeys(o)),
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      unicodeJsonValueBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        // Property: should be able to shrink to the same values without initial context
+        // Is partially applicable given the fact that: Object.keys() has a specific handling of integer keys over string ones.
+        // eg.: Object.keys({"2": "2", "0": "0", "C": "C", "A": "A", "B": "B", "1": "1"}) -> ["0", "1", "2", "C", "A", "B"]
+        // As a consequence there is no way to rebuild the source array of tuples (key, value) in the right order in such case (when numerics).
+        sameValueWithoutInitialContext: { isNotApplicable: isObjectWithNumericKeys },
+      },
       { extraParameters },
     );
   });

--- a/packages/fast-check/test/unit/arbitrary/unicodeString.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/unicodeString.spec.ts
@@ -1,12 +1,7 @@
 import * as fc from 'fast-check';
 import { unicodeString } from '../../../src/arbitrary/unicodeString';
 
-import {
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 
 describe('unicodeString (integration)', () => {
   type Extra = { minLength?: number; maxLength?: number };
@@ -32,19 +27,16 @@ describe('unicodeString (integration)', () => {
 
   const unicodeStringBuilder = (extra: Extra) => unicodeString(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(unicodeStringBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(unicodeStringBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(unicodeStringBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(unicodeStringBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      unicodeStringBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
@@ -4,12 +4,7 @@ import { uniqueArray, UniqueArrayConstraints } from '../../../src/arbitrary/uniq
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as ArrayArbitraryMock from '../../../src/arbitrary/_internals/ArrayArbitrary';
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { sizeRelatedGlobalConfigArb } from './__test-helpers__/SizeHelpers';
@@ -333,27 +328,23 @@ describe('uniqueArray (integration)', () => {
   );
   const uniqueArrayBuilder = (extra: Extra) => uniqueArray(integerUpTo10000AndNaNOrMinusZero, extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(uniqueArrayBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      uniqueArrayBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+        // Property: should preserve strictly smaller ordering in shrink
+        // Is not applicable in the case of `set` as some values may not be in the "before" version
+        // of the array while they can suddenly appear on shrink. They might have been hidden because
+        // another value inside the array shadowed them. While on shrink those entries shadowing others
+        // may have disappear.
+      },
+      { extraParameters },
+    );
   });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(uniqueArrayBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(uniqueArrayBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(uniqueArrayBuilder, { extraParameters });
-  });
-
-  // Property: should preserve strictly smaller ordering in shrink
-  // Is not applicable in the case of `set` as some values may not be in the "before" version
-  // of the array while they can suddenly appear on shrink. They might have been hidden because
-  // another value inside the array shadowed them. While on shrink those entries shadowing others
-  // may have disappear.
 
   it.each`
     source                                       | constraints

--- a/packages/fast-check/test/unit/arbitrary/uuid.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uuid.spec.ts
@@ -6,10 +6,7 @@ import * as _IntegerMock from '../../../src/arbitrary/integer';
 import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
 import {
-  assertProduceSameValueGivenSameSeed,
-  assertProduceCorrectValues,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
+  assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
@@ -61,21 +58,17 @@ describe('uuid (integration)', () => {
     expect(u).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[12345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   };
 
-  const uuidVBuilder = () => uuid();
+  const uuidBuilder = () => uuid();
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(uuidVBuilder);
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(uuidVBuilder, isCorrect);
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(uuidVBuilder);
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(uuidVBuilder);
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      uuidBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/uuidV.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uuidV.spec.ts
@@ -6,10 +6,7 @@ import * as _IntegerMock from '../../../src/arbitrary/integer';
 import { Arbitrary } from '../../../src/check/arbitrary/definition/Arbitrary';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
 import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
+ assertValidArbitrary
 } from './__test-helpers__/ArbitraryAssertions';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
@@ -81,19 +78,16 @@ describe('uuidV (integration)', () => {
 
   const uuidVBuilder = (extra: Extra) => uuidV(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(uuidVBuilder, { extraParameters });
-  });
-
-  it('should only produce correct values', () => {
-    assertProduceCorrectValues(uuidVBuilder, isCorrect, { extraParameters });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(uuidVBuilder, { extraParameters });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(uuidVBuilder, { extraParameters });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      uuidVBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });

--- a/packages/fast-check/test/unit/arbitrary/webAuthority.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/webAuthority.spec.ts
@@ -2,12 +2,7 @@ import fc from 'fast-check';
 import { webAuthority, WebAuthorityConstraints } from '../../../src/arbitrary/webAuthority';
 import { URL } from 'url';
 
-import {
-  assertProduceCorrectValues,
-  assertProduceSameValueGivenSameSeed,
-  assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
-} from './__test-helpers__/ArbitraryAssertions';
+import { assertValidArbitrary } from './__test-helpers__/ArbitraryAssertions';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
 
 function beforeEachHook() {
@@ -19,40 +14,34 @@ beforeEach(beforeEachHook);
 
 describe('webAuthority (integration)', () => {
   type Extra = WebAuthorityConstraints;
-  const extraParametersBuilder: (onlySmall?: boolean) => fc.Arbitrary<Extra> = (onlySmall?: boolean) =>
-    fc.record(
-      {
-        withIPv4: fc.boolean(),
-        withIPv4Extended: fc.boolean(),
-        withIPv6: fc.boolean(),
-        withPort: fc.boolean(),
-        withUserInfo: fc.boolean(),
-        size: onlySmall ? fc.constantFrom('-1', '=', 'xsmall', 'small') : fc.oneof(sizeArb, relativeSizeArb),
-      },
-      { requiredKeys: [] },
-    );
+  const extraParameters = fc.record(
+    {
+      withIPv4: fc.boolean(),
+      withIPv4Extended: fc.boolean(),
+      withIPv6: fc.boolean(),
+      withPort: fc.boolean(),
+      withUserInfo: fc.boolean(),
+      size: fc.oneof(sizeArb, relativeSizeArb),
+    },
+    { requiredKeys: [] },
+  );
 
-  const isCorrectForURL = (webAuthority: string) => {
+  const isCorrect = (webAuthority: string) => {
     expect(() => new URL(`http://${webAuthority}`)).not.toThrow();
   };
 
   const webAuthorityBuilder = (extra: Extra) => webAuthority(extra);
 
-  it('should produce the same values given the same seed', () => {
-    assertProduceSameValueGivenSameSeed(webAuthorityBuilder, { extraParameters: extraParametersBuilder() });
-  });
-
-  it('should only produce correct values regarding `new URL`', () => {
-    assertProduceCorrectValues(webAuthorityBuilder, isCorrectForURL, { extraParameters: extraParametersBuilder() });
-  });
-
-  it('should produce values seen as shrinkable without any context', () => {
-    assertProduceValuesShrinkableWithoutContext(webAuthorityBuilder, { extraParameters: extraParametersBuilder(true) });
-  });
-
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(webAuthorityBuilder, {
-      extraParameters: extraParametersBuilder(true),
-    });
+  it('should be a valid arbitrary', () => {
+    assertValidArbitrary(
+      webAuthorityBuilder,
+      {
+        sameValueGivenSameSeed: {},
+        correctValues: { isCorrect },
+        shrinkableWithoutContext: {},
+        sameValueWithoutInitialContext: {},
+      },
+      { extraParameters },
+    );
   });
 });


### PR DESCRIPTION
Up-to-now, checks for characteristics of the arbitraries have been executed in seperated properties. While it worked well and allowed better error reporting, it tend to increase by a lot the time of the checks and thus our time to deploy new versions and fixes of fast-check.

In our target to make our CI faster we tried to gather them into a single check. It's not exactly what we would recommend ideally but given the number of things the properties we manipulate here are dealing with (scanning a possibly infinite tree), we falled onto that option.

Let's see what's the CI thinks of it :)

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
