### PR TITLE
👷 Mark final check as failed and not skipped

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -474,10 +474,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - if: needs.job1.result == 'success'
+      - if: needs.job2.result == 'success'
         name: Success
         run: echo "Success"
-      - if: needs.job1.result != 'success'
+      - if: needs.job2.result != 'success'
         name: Failure
         run: exit 1
 

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -432,8 +432,8 @@ jobs:
           yarn workspaces foreach -pvi --no-private exec "cd test-types && yarn dlx -p typescript tsc --noEmit --skipLibCheck --strict --exactOptionalPropertyTypes *.mts"
 
   # Job to confirm every required job passed
-  all_checks_passed:
-    name: 'All checks passed'
+  pre_all_checks_passed:
+    name: 'Pre All checks passed'
     needs:
       - production_packages
       - documentation
@@ -448,36 +448,16 @@ jobs:
     steps:
       - name: Success
         run: echo "Success"
-
-  job1:
-    name: 'J1'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sleep
-        run: sleep 2
-      - name: Success
-        run: echo 1
-
-  job2:
-    name: 'J2'
-    needs:
-      - job1
-    runs-on: ubuntu-latest
-    steps:
-      - name: Success
-        run: echo "Success"
-
-  job3:
-    name: 'J3'
-    needs:
-      - job2
+  all_checks_passed:
+    name: 'All checks passed'
+    needs: pre_all_checks_passed
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - if: needs.job2.result == 'success'
+      - if: needs.pre_all_checks_passed.result == 'success'
         name: Success
         run: echo "Success"
-      - if: needs.job2.result != 'success'
+      - if: needs.pre_all_checks_passed.result != 'success'
         name: Failure
         run: exit 1
 

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -449,6 +449,38 @@ jobs:
       - name: Success
         run: echo "Success"
 
+  job1:
+    name: 'J1'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep
+        run: sleep 10
+      - name: Failure
+        run: exit 1
+
+  job2:
+    name: 'J2'
+    needs:
+      - job1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "Success"
+
+  job3:
+    name: 'J3'
+    needs:
+      - j2
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.job1.result == 'success'
+        name: Success
+        run: echo "Success"
+      - if: needs.job1.result != 'success'
+        name: Failure
+        run: exit 1
+
   # Publication jobs
   publish_documentation:
     name: 'Publish documentation'

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -470,7 +470,7 @@ jobs:
   job3:
     name: 'J3'
     needs:
-      - j2
+      - job2
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -454,9 +454,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sleep
-        run: sleep 10
-      - name: Failure
-        run: exit 1
+        run: sleep 2
+      - name: Success
+        run: echo 1
 
   job2:
     name: 'J2'


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

Our current final job "All checks passed" as considered as OK when skipped. We defined that job to easily capture the fact that all our required jobs passed. Unfortunately GitHub considers that skipped or success are OK statuses for required jobs.

As a consequence, we adopted another pattern made of two jobs. One that should aggregate the status of the required ones into a: success or skipped. And one translating the skip into a failed.

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
