### PR TITLE
⚡️(packaged) Bulk delete directory and content

### DIFF
--- a/.yarn/versions/fa1f000f.yml
+++ b/.yarn/versions/fa1f000f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/packaged": minor

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -25,13 +25,13 @@ function tryAdd<T>(set: Set<T>, value: T): boolean {
 }
 
 /** @internal */
-function buildNormalizedPublishedDirectoriesSet(packageRoot: string, publishedFiles: string[]): Set<string> {
+function buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles: string[]): Set<string> {
   const normalizedPublishedDirectoriesSet = new Set<string>();
 
   // Scanning published files one by one to add our their directories as "directories to be preserved/published"
-  for (const filePath of publishedFiles) {
+  for (const filePath of normalizedPublishedFiles) {
     // Dropping one directory at a time from the path until we already know about thi precise directory to stop the scan earlier
-    let directory = path.normalize(path.join(packageRoot, path.dirname(filePath)));
+    let directory = path.dirname(filePath); // already normalized
     while (directory !== '' && !tryAdd(normalizedPublishedDirectoriesSet, directory)) {
       const lastSep = directory.lastIndexOf(path.sep);
       if (lastSep === -1) {
@@ -54,10 +54,9 @@ export async function removeNonPublishedFiles(
   const kept: string[] = [];
   const removed: string[] = [];
   const publishedFiles = await computePublishedFiles(packageRoot);
-  const normalizedPublishedFilesSet = new Set(
-    publishedFiles.map((filename) => path.normalize(path.join(packageRoot, filename))),
-  );
-  const normalizedPublishedDirectoriesSet = buildNormalizedPublishedDirectoriesSet(packageRoot, publishedFiles);
+  const normalizedPublishedFiles = publishedFiles.map((filename) => path.normalize(path.join(packageRoot, filename)));
+  const normalizedPublishedFilesSet = new Set(normalizedPublishedFiles);
+  const normalizedPublishedDirectoriesSet = buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles);
 
   const rootNodeModulesPath = path.join(packageRoot, 'node_modules');
 

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -21,6 +21,10 @@ export async function computePublishedFiles(packageRoot: string): Promise<string
 function tryAdd<T>(set: Set<T>, value: T): boolean {
   const sizeBefore = set.size;
   set.add(value);
+  if (set.size !== sizeBefore)
+    console.log('++ ' + value);
+  else
+    console.log('xx ' + value);
   return set.size !== sizeBefore;
 }
 
@@ -31,6 +35,7 @@ function buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles: string
   // Scanning published files one by one to add our their directories as "directories to be preserved/published"
   for (const filePath of normalizedPublishedFiles) {
     // Dropping one directory at a time from the path until we already know about thi precise directory to stop the scan earlier
+    console.log('scanning: ' + filePath);
     let directory = path.dirname(filePath); // already normalized
     while (directory !== '' && !tryAdd(normalizedPublishedDirectoriesSet, directory)) {
       const lastSep = directory.lastIndexOf(path.sep);

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -14,6 +14,22 @@ export async function computePublishedFiles(packageRoot: string): Promise<string
   return files;
 }
 
+/** @internal */
+function buildNormalizedPublishedDirectoriesSet(packageRoot: string, publishedFiles: string[]): Set<string> {
+  const normalizedPublishedDirectoriesSet = new Set<string>()
+  for (const filePath of publishedFiles) {
+    const directorySegments = path.normalize(filePath).split(path.sep).slice(0, -1);
+      let currentAggregatedSegment = path.normalize(packageRoot);
+      const directoryAggregatedSegments: string[] = [];
+      for (const segment of directorySegments) {
+        currentAggregatedSegment = path.join(currentAggregatedSegment, segment);
+        directoryAggregatedSegments.push(currentAggregatedSegment);
+      normalizedPublishedDirectoriesSet.add(currentAggregatedSegment);
+      }
+  }
+  return normalizedPublishedDirectoriesSet
+}
+
 /**
  * Remove from the filesystem any file that will not be published
  * @param packageRoot - The path to the root of the package, eg.: .
@@ -28,18 +44,7 @@ export async function removeNonPublishedFiles(
   const normalizedPublishedFilesSet = new Set(
     publishedFiles.map((filename) => path.normalize(path.join(packageRoot, filename))),
   );
-  const normalizedPublishedDirectoriesSet = new Set(
-    publishedFiles.flatMap((filePath) => {
-      const directorySegments = path.normalize(filePath).split(path.sep).slice(0, -1);
-      let currentAggregatedSegment = path.normalize(packageRoot);
-      const directoryAggregatedSegments: string[] = [];
-      for (const segment of directorySegments) {
-        currentAggregatedSegment = path.join(currentAggregatedSegment, segment);
-        directoryAggregatedSegments.push(currentAggregatedSegment);
-      }
-      return directoryAggregatedSegments;
-    }),
-  );
+  const normalizedPublishedDirectoriesSet = buildNormalizedPublishedDirectoriesSet(packageRoot,publishedFiles)
 
   const rootNodeModulesPath = path.join(packageRoot, 'node_modules');
 

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -21,10 +21,6 @@ export async function computePublishedFiles(packageRoot: string): Promise<string
 function tryAdd<T>(set: Set<T>, value: T): boolean {
   const sizeBefore = set.size;
   set.add(value);
-  if (set.size !== sizeBefore)
-    console.log('++ ' + value);
-  else
-    console.log('xx ' + value);
   return set.size !== sizeBefore;
 }
 
@@ -35,9 +31,8 @@ function buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles: string
   // Scanning published files one by one to add our their directories as "directories to be preserved/published"
   for (const filePath of normalizedPublishedFiles) {
     // Dropping one directory at a time from the path until we already know about thi precise directory to stop the scan earlier
-    console.log('scanning: ' + filePath);
     let directory = path.dirname(filePath); // already normalized
-    while (directory !== '' && !tryAdd(normalizedPublishedDirectoriesSet, directory)) {
+    while (directory !== '' && tryAdd(normalizedPublishedDirectoriesSet, directory)) {
       const lastSep = directory.lastIndexOf(path.sep);
       if (lastSep === -1) {
         break;
@@ -77,7 +72,6 @@ async function traverseAndRemoveNonPublishedFiles(
       } else {
         out.removed.push(normalizedItemPath);
         if (!opts.dryRun) {
-          console.log('rm -r: ' + itemPath);
           awaitedTasks.push(fs.rm(itemPath, { recursive: true }));
         }
       }
@@ -87,7 +81,6 @@ async function traverseAndRemoveNonPublishedFiles(
       } else {
         out.removed.push(normalizedItemPath);
         if (!opts.dryRun) {
-          console.log('rm: ' + itemPath);
           awaitedTasks.push(fs.rm(itemPath));
         }
       }

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -91,9 +91,7 @@ export async function removeNonPublishedFiles(
 
   const out: { kept: string[]; removed: string[] } = { kept: [], removed: [] };
   const normalizedPackageRoot = path.normalize(packageRoot);
-  const normalizedPublishedFiles = publishedFiles.map((filename) =>
-    path.normalize(path.join(normalizedPackageRoot, filename)),
-  );
+  const normalizedPublishedFiles = publishedFiles.map((filename) => path.join(normalizedPackageRoot, filename));
   const normalizedPublishedFilesSet = new Set(normalizedPublishedFiles);
   const normalizedPublishedDirectoriesSet = buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles);
   const traverseOpts = {

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -68,7 +68,7 @@ async function traverseAndRemoveNonPublishedFiles(
       out.kept.push(itemPath);
       awaitedTasks.push(traverseAndRemoveNonPublishedFiles(itemPath, out, opts));
     } else if (opts.publishedFiles.has(itemPath)) {
-        out.kept.push(itemPath);
+      out.kept.push(itemPath);
     } else {
       out.removed.push(itemPath);
       if (!opts.dryRun) {
@@ -91,7 +91,9 @@ export async function removeNonPublishedFiles(
 
   const out: { kept: string[]; removed: string[] } = { kept: [], removed: [] };
   const normalizedPackageRoot = path.normalize(packageRoot);
-  const normalizedPublishedFiles = publishedFiles.map((filename) => path.normalize(path.join(normalizedPackageRoot, filename)));
+  const normalizedPublishedFiles = publishedFiles.map((filename) =>
+    path.normalize(path.join(normalizedPackageRoot, filename)),
+  );
   const normalizedPublishedFilesSet = new Set(normalizedPublishedFiles);
   const normalizedPublishedDirectoriesSet = buildNormalizedPublishedDirectoriesSet(normalizedPublishedFiles);
   const traverseOpts = {

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -63,7 +63,7 @@ async function traverseAndRemoveNonPublishedFiles(
   for (const itemName of content) {
     const itemPath = path.join(currentPath, itemName);
     if (itemPath === opts.rootNodeModulesPath) {
-      out.kept.push(normalizedItemPath);
+      out.kept.push(itemPath);
     } else if (opts.publishedDirectories.has(itemPath)) {
       out.kept.push(itemPath);
       awaitedTasks.push(traverseAndRemoveNonPublishedFiles(itemPath, out, opts));

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -72,6 +72,7 @@ async function traverseAndRemoveNonPublishedFiles(
       } else {
         out.removed.push(normalizedItemPath);
         if (!opts.dryRun) {
+          console.log('rm -r: ' + itemPath);
           awaitedTasks.push(fs.rm(itemPath, { recursive: true }));
         }
       }
@@ -81,6 +82,7 @@ async function traverseAndRemoveNonPublishedFiles(
       } else {
         out.removed.push(normalizedItemPath);
         if (!opts.dryRun) {
+          console.log('rm: ' + itemPath);
           awaitedTasks.push(fs.rm(itemPath));
         }
       }

--- a/packages/packaged/src/packaged.ts
+++ b/packages/packaged/src/packaged.ts
@@ -100,6 +100,6 @@ export async function removeNonPublishedFiles(
     publishedDirectories: normalizedPublishedDirectoriesSet,
     publishedFiles: normalizedPublishedFilesSet,
   };
-  await traverseAndRemoveNonPublishedFiles(normalizePackageRoot, out, traverseOpts);
+  await traverseAndRemoveNonPublishedFiles(normalizedPackageRoot, out, traverseOpts);
   return out;
 }

--- a/packages/packaged/test/packaged.spec.ts
+++ b/packages/packaged/test/packaged.spec.ts
@@ -62,10 +62,10 @@ describe('removeNonPublishedFiles', () => {
       // Returns arrays having the expected sizes
       if (!keepNodeModules) {
         expect(kept).toHaveLength(3); // package.json, lib/main.js, lib
-        expect(removed).toHaveLength(10); // src/main.js, src, test/main.js, test, node_modules/dep-a/main.js, node_modules/dep-a, node_modules, src/node_modules/wtf/main.js, src/node_modules/wtf, src/node_modules
+        expect(removed).toHaveLength(3); // src, test, node_modules
       } else {
         expect(kept).toHaveLength(4); // package.json, lib/main.js, lib, node_modules/*
-        expect(removed).toHaveLength(7); // src/main.js, src, test/main.js, test, src/node_modules/wtf/main.js, src/node_modules/wtf, src/node_modules
+        expect(removed).toHaveLength(2); //  src, test
       }
       // Remove unpublished files and keep published ones
       expect(await fileSystem.exists(['package.json'])).toBe(true);
@@ -102,13 +102,99 @@ describe('removeNonPublishedFiles', () => {
       const { kept, removed } = await removeNonPublishedFiles(fileSystem.packagePath);
 
       // Assert
-      expect(kept).toHaveLength(5); // package.sjon, lib/main.js, lib, src2/main.js, src2
-      expect(removed).toHaveLength(3); // .npmignore, src/main.js, src
+      expect(kept).toHaveLength(5); // package.json, lib/main.js, lib, src2/main.js, src2
+      expect(removed).toHaveLength(2); // .npmignore, src
       expect(await fileSystem.exists(['package.json'])).toBe(true);
       expect(await fileSystem.exists(['lib', 'main.js'])).toBe(true);
       expect(await fileSystem.exists(['src2', 'main.js'])).toBe(true);
       expect(await fileSystem.exists(['src'])).toBe(false);
       expect(await fileSystem.exists(['.npmignore'])).toBe(false);
+    });
+  });
+
+  it('should handle TypeScript-like packages having source, build and test files next to each others', async () => {
+    await runPackageTest(async (fileSystem) => {
+      // Arrange
+      const packageJsonContent = {
+        name: 'my-package',
+        version: '0.0.0',
+        files: ['**/*.js', '**/*.d.ts', '!**/*.spec.js', '!**/*.spec.d.ts'],
+        license: 'MIT',
+      };
+      await fileSystem.createFile(['package.json'], JSON.stringify(packageJsonContent));
+      await fileSystem.createFile(['tsconfig.json'], '// empty tsconfig.json');
+      await fileSystem.createFile(['main.ts'], '// empty main.ts');
+      await fileSystem.createFile(['main.d.ts'], '// empty main.d.ts');
+      await fileSystem.createFile(['main.js'], '// empty main.js');
+      await fileSystem.createFile(['main.spec.ts'], '// empty main.spec.ts');
+      await fileSystem.createFile(['main.spec.d.ts'], '// empty main.spec.d.ts');
+      await fileSystem.createFile(['main.spec.js'], '// empty main.spec.js');
+      await fileSystem.createFile(['internals', 'index.ts'], '// empty internals/index.ts');
+      await fileSystem.createFile(['internals', 'index.d.ts'], '// empty internals/index.d.ts');
+      await fileSystem.createFile(['internals', 'index.js'], '// empty internals/index.js');
+      await fileSystem.createFile(['internals', 'index.spec.ts'], '// empty internals/index.spec.ts');
+      await fileSystem.createFile(['internals', 'index.spec.d.ts'], '// empty internals/index.spec.d.ts');
+      await fileSystem.createFile(['internals', 'index.spec.js'], '// empty internals/index.spec.js');
+      await fileSystem.createFile(['internals', 'a', 'item.ts'], '// empty internals/a/item.ts');
+      await fileSystem.createFile(['internals', 'a', 'item.d.ts'], '// empty internals/a/item.d.ts');
+      await fileSystem.createFile(['internals', 'a', 'item.js'], '// empty internals/a/item.js');
+      await fileSystem.createFile(['internals', 'a', 'item.spec.ts'], '// empty internals/a/item.spec.ts');
+      await fileSystem.createFile(['internals', 'a', 'item.spec.d.ts'], '// empty internals/a/item.spec.d.ts');
+      await fileSystem.createFile(['internals', 'a', 'item.spec.js'], '// empty internals/a/item.spec.js');
+      await fileSystem.createFile(['internals', 'b', 'item.ts'], '// empty internals/b/item.ts');
+      await fileSystem.createFile(['internals', 'b', 'item.d.ts'], '// empty internals/b/item.d.ts');
+      await fileSystem.createFile(['internals', 'b', 'item.js'], '// empty internals/b/item.js');
+      await fileSystem.createFile(['internals', 'b', 'item.spec.ts'], '// empty internals/b/item.spec.ts');
+      await fileSystem.createFile(['internals', 'b', 'item.spec.d.ts'], '// empty internals/b/item.spec.d.ts');
+      await fileSystem.createFile(['internals', 'b', 'item.spec.js'], '// empty internals/b/item.spec.js');
+      await fileSystem.createFile(['test', 'index.spec.ts'], '// empty test/index.spec.ts');
+      await fileSystem.createFile(['test', 'index.spec.d.ts'], '// empty test/index.spec.d.ts');
+      await fileSystem.createFile(['test', 'index.spec.js'], '// empty test/index.spec.js');
+
+      // Act
+      const { kept, removed } = await removeNonPublishedFiles(fileSystem.packagePath);
+
+      // Assert
+      expect(kept).toHaveLength(12);
+      // package.json, main.d.ts, main.js,
+      // internals, internals/index.d.ts, internals/index.js,
+      // internals/a, internals/a/item.d.ts, internals/a/item.js,
+      // internals/b, internals/b/item.d.ts, internals/b/item.js
+      expect(removed).toHaveLength(18);
+      // tsconfig.json, main.ts, main.spec.ts, main.spec.d.ts, main.spec.js,
+      // internals/index.ts, internals/index.spec.ts, internals/index.spec.d.ts, internals/index.spec.js,
+      // internals/a/item.ts, internals/a/item.spec.ts, internals/a/item.spec.d.ts, internals/a/item.spec.js,
+      // internals/b/item.ts, internals/b/item.spec.ts, internals/b/item.spec.d.ts, internals/b/item.spec.js,
+      // test
+      expect(await fileSystem.exists(['package.json'])).toBe(true);
+      expect(await fileSystem.exists(['tsconfig.json'])).toBe(false);
+      expect(await fileSystem.exists(['main.ts'])).toBe(false);
+      expect(await fileSystem.exists(['main.d.ts'])).toBe(true);
+      expect(await fileSystem.exists(['main.js'])).toBe(true);
+      expect(await fileSystem.exists(['main.spec.ts'])).toBe(false);
+      expect(await fileSystem.exists(['main.spec.d.ts'])).toBe(false);
+      expect(await fileSystem.exists(['main.spec.js'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'index.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'index.d.ts'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'index.js'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'index.spec.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'index.spec.d.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'index.spec.js'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'a', 'item.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'a', 'item.d.ts'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'a', 'item.js'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'a', 'item.spec.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'a', 'item.spec.d.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'a', 'item.spec.js'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'b', 'item.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'b', 'item.d.ts'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'b', 'item.js'])).toBe(true);
+      expect(await fileSystem.exists(['internals', 'b', 'item.spec.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'b', 'item.spec.d.ts'])).toBe(false);
+      expect(await fileSystem.exists(['internals', 'b', 'item.spec.js'])).toBe(false);
+      expect(await fileSystem.exists(['test', 'index.spec.ts'])).toBe(false);
+      expect(await fileSystem.exists(['test', 'index.spec.d.ts'])).toBe(false);
+      expect(await fileSystem.exists(['test', 'index.spec.js'])).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Up-to-now, in order to delete a directory we were scanning the whole directory item by item. With this new version, as long as the directory is known not to include any published files, we delete it with its content without having to scan it (rm recursively deletes it for us).

It changed the content returned by removed. Now it may inlcude names of parent directories without listing any of the child files in it.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
