### PR TITLE
🏷️(poisoning) Prefer "import type" over raw "import"

### DIFF
--- a/.yarn/versions/e3d4b33a.yml
+++ b/.yarn/versions/e3d4b33a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/poisoning": minor
+
+declined:
+  - fast-check

--- a/packages/poisoning/src/internals/CaptureAllGlobals.ts
+++ b/packages/poisoning/src/internals/CaptureAllGlobals.ts
@@ -1,7 +1,7 @@
 import { PoisoningFreeArray, MapSymbol, SortSymbol, ShiftSymbol, PushSymbol } from './PoisoningFreeArray.js';
 import { GetSymbol, HasSymbol, SetSymbol, PoisoningFreeMap } from './PoisoningFreeMap.js';
 import { AddSymbol, HasSymbol as SetHasSymbol, PoisoningFreeSet } from './PoisoningFreeSet.js';
-import { AllGlobals, GlobalDetails } from './types/AllGlobals.js';
+import type { AllGlobals, GlobalDetails } from './types/AllGlobals.js';
 
 const SString = String;
 const safeObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;

--- a/packages/poisoning/src/internals/FilterNonEligibleDiffs.ts
+++ b/packages/poisoning/src/internals/FilterNonEligibleDiffs.ts
@@ -1,4 +1,4 @@
-import { GlobalDetails } from './types/AllGlobals';
+import type { GlobalDetails } from './types/AllGlobals';
 
 /** Check whether or not a global has to be ignored for diff tracking */
 export function shouldIgnoreGlobal(

--- a/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
+++ b/packages/poisoning/src/internals/TrackDiffsOnGlobal.ts
@@ -1,6 +1,6 @@
 import { PoisoningFreeArray, PushSymbol } from './PoisoningFreeArray.js';
 import { EntriesSymbol, HasSymbol } from './PoisoningFreeMap.js';
-import { AllGlobals, GlobalDetails } from './types/AllGlobals.js';
+import type { AllGlobals, GlobalDetails } from './types/AllGlobals.js';
 
 const SString = String;
 const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;

--- a/packages/poisoning/src/internals/types/AllGlobals.ts
+++ b/packages/poisoning/src/internals/types/AllGlobals.ts
@@ -1,5 +1,5 @@
-import { PoisoningFreeMap } from '../PoisoningFreeMap.js';
-import { PoisoningFreeSet } from '../PoisoningFreeSet.js';
+import type { PoisoningFreeMap } from '../PoisoningFreeMap.js';
+import type { PoisoningFreeSet } from '../PoisoningFreeSet.js';
 
 export type GlobalDetails = {
   /**

--- a/packages/poisoning/test/internals/CaptureAllGlobals.spec.ts
+++ b/packages/poisoning/test/internals/CaptureAllGlobals.spec.ts
@@ -1,7 +1,7 @@
 import { captureAllGlobals } from '../../src/internals/CaptureAllGlobals.js';
-import { PoisoningFreeMap } from '../../src/internals/PoisoningFreeMap.js';
+import type { PoisoningFreeMap } from '../../src/internals/PoisoningFreeMap.js';
 import { PoisoningFreeSet } from '../../src/internals/PoisoningFreeSet.js';
-import { GlobalDetails } from '../../src/internals/types/AllGlobals.js';
+import type { GlobalDetails } from '../../src/internals/types/AllGlobals.js';
 
 describe('captureAllGlobals', () => {
   const expectedGlobals = [

--- a/packages/poisoning/test/internals/FilterNonEligibleDiffs.spec.ts
+++ b/packages/poisoning/test/internals/FilterNonEligibleDiffs.spec.ts
@@ -1,4 +1,4 @@
-import { GlobalDetails } from '../../src/internals/types/AllGlobals';
+import type { GlobalDetails } from '../../src/internals/types/AllGlobals';
 import { shouldIgnoreGlobal, shouldIgnoreProperty } from '../../src/internals/FilterNonEligibleDiffs';
 import { PoisoningFreeSet } from '../../src/internals/PoisoningFreeSet';
 

--- a/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
+++ b/packages/poisoning/test/internals/TrackDiffsOnGlobal.spec.ts
@@ -1,7 +1,7 @@
 import { PoisoningFreeMap } from '../../src/internals/PoisoningFreeMap.js';
 import { PoisoningFreeSet } from '../../src/internals/PoisoningFreeSet.js';
 import { trackDiffsOnGlobals } from '../../src/internals/TrackDiffsOnGlobal.js';
-import { AllGlobals, GlobalDetails } from '../../src/internals/types/AllGlobals.js';
+import type { AllGlobals, GlobalDetails } from '../../src/internals/types/AllGlobals.js';
 
 describe('trackDiffsOnGlobals', () => {
   it('should detect added entries', () => {


### PR DESCRIPTION
While raw "import" works well, it does carry an extra cost:

- bundlers may not optimize it as much as they can and may require to import the linked file even if they don't need to assess typings
- it may produce less optimized bundles (we may refer to unneeded files and thus delay some operations)

Related to #4324

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
