### PR TITLE
🏷️(expect-type) Prefer "import type" over raw "import"

### DIFF
--- a/.yarn/versions/0009b7e2.yml
+++ b/.yarn/versions/0009b7e2.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/expect-type": minor
+
+declined:
+  - fast-check

--- a/packages/expect-type/src/main.d.ts
+++ b/packages/expect-type/src/main.d.ts
@@ -1,4 +1,4 @@
-import { IsSame, Extends } from './internals.js';
+import type { IsSame, Extends } from './internals.js';
 export declare function expectType<TExpectedType>(): <TReal>(
   arg: TReal,
   ...noArgs: IsSame<TExpectedType, TReal> extends true ? [string] : [{ expected: TExpectedType; got: TReal }]

--- a/packages/expect-type/test/internals.spec.ts
+++ b/packages/expect-type/test/internals.spec.ts
@@ -1,4 +1,4 @@
-import { Not, And, Or, IsNever, IsUnknown, IsAny, IsSame } from '../src/internals';
+import type { Not, And, Or, IsNever, IsUnknown, IsAny, IsSame } from '../src/internals';
 
 export const Test_Not_true: Not<true> = false;
 export const Test_Not_false: Not<false> = true;


### PR DESCRIPTION
While raw "import" works well, it does carry an extra cost:

- bundlers may not optimize it as much as they can and may require to import the linked file even if they don't need to assess typings
- it may produce less optimized bundles (we may refer to unneeded files and thus delay some operations)

Related to #4324

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
