### PR TITLE
🏷️(jest) Prefer "import type" over raw "import"

### DIFF
--- a/.yarn/versions/ea83dec9.yml
+++ b/.yarn/versions/ea83dec9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/jest": minor

--- a/packages/jest/src/jest-fast-check-worker.ts
+++ b/packages/jest/src/jest-fast-check-worker.ts
@@ -1,5 +1,6 @@
 import * as fc from 'fast-check';
-import { assert, propertyFor, PropertyForOptions } from '@fast-check/worker';
+import type { PropertyForOptions } from '@fast-check/worker';
+import { assert, propertyFor } from '@fast-check/worker';
 import { jestExpect } from '@jest/expect';
 import { buildTest } from './internals/TestBuilder.js';
 

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -4,8 +4,8 @@ import { promisify } from 'util';
 import { execFile as _execFile } from 'child_process';
 const execFile = promisify(_execFile);
 
-import _fc from 'fast-check';
-import { test as _test, it as _it } from '@fast-check/jest';
+import type _fc from 'fast-check';
+import type { test as _test, it as _it } from '@fast-check/jest';
 declare const fc: typeof _fc;
 declare const runner: typeof _test | typeof _it;
 


### PR DESCRIPTION
While raw "import" works well, it does carry an extra cost:

- bundlers may not optimize it as much as they can and may require to import the linked file even if they don't need to assess typings
- it may produce less optimized bundles (we may refer to unneeded files and thus delay some operations)

Related to #4324

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
