### PR TITLE
✅(ava) Extend test coverage to no-assertions cases and observables

### DIFF
--- a/.yarn/versions/6b043ab6.yml
+++ b/.yarn/versions/6b043ab6.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@fast-check/ava"

--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -57,6 +57,7 @@
     "ava": "^5.3.1",
     "esm": "^3.2.25",
     "fast-check": "workspace:*",
+    "rxjs": "^7.8.1",
     "typescript": "~5.2.2"
   },
   "keywords": [

--- a/packages/ava/test.sh
+++ b/packages/ava/test.sh
@@ -3,23 +3,32 @@
 npm run ava-test >test/out.log 2>&1
 
 for expectedContent in \
-         "ok 1 - should never be executed (with seed=48) # SKIP" \
-         "ok 2 - should run first" \
-         "ok 3 - should run after" \
-         "ok 4 - should run serially" \
-         "ok 5 - should pass on truthy synchronous property" \
-         "ok 6 - should pass on truthy asynchronous property" \
-         "not ok 7 - should fail on falsy synchronous property" \
-         "not ok 8 - should fail on falsy asynchronous property" \
-         "not ok 9 - should fail with seed=4242 and path=\"25\" (with seed=4242)" "seed=4242 and path=\"25\"" \
-         "ok 10 - should pass on followed plan" \
-         "not ok 11 - should fail on not followed plan" \
-         "ok 12 - should pass kitchen sink" \
-         "not ok 13 - should fail kitchen sink" \
-         "ok 14 - should pass as the property fails" \
-         "not ok 15 - should fail as the property passes"
+         "ok [0-9]* - should never be executed (with seed=48) # SKIP" \
+         "ok [0-9]* - should run first" \
+         "ok [0-9]* - should run after" \
+         "ok [0-9]* - should run serially" \
+         "ok [0-9]* - should pass on no-failed asserts synchronous property" \
+         "ok [0-9]* - should pass on no-failed asserts asynchronous property" \
+         "not ok [0-9]* - should fail on failing asserts synchronous property" \
+         "not ok [0-9]* - should fail on failing asserts asynchronous property" \
+         "not ok [0-9]* - should fail on synchronous property not running any assertions even if returning undefined" \
+         "not ok [0-9]* - should fail on asynchronous property not running any assertions even if returning undefined" \
+         "not ok [0-9]* - should fail on synchronous property not running any assertions even if returning true" \
+         "not ok [0-9]* - should fail on asynchronous property not running any assertions even if returning true" \
+         "not ok [0-9]* - should fail on synchronous property not running any assertions returning false" \
+         "not ok [0-9]* - should fail on asynchronous property not running any assertions returning false" \
+         "ok [0-9]* - should pass on property returning passing Observable" \
+         "not ok [0-9]* - should fail on property returning failing Observable" \
+         "not ok [0-9]* - should fail with seed=4242 and path=\"25\" (with seed=4242)" \
+         "ok [0-9]* - should pass on followed plan" \
+         "not ok [0-9]* - should fail on not followed plan" \
+         "ok [0-9]* - should pass kitchen sink" \
+         "not ok [0-9]* - should fail kitchen sink" \
+         "ok [0-9]* - should pass as the property fails" \
+         "not ok [0-9]* - should fail as the property passes"
 do
-    cat test/out.log | grep "${expectedContent}" >/dev/null 2>&1
+    echo "Checking: ${expectedContent}"
+    cat test/out.log | grep "^${expectedContent}" >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         cat test/out.log
         echo "=== TEST FAILED ==="

--- a/packages/ava/test.sh
+++ b/packages/ava/test.sh
@@ -17,6 +17,8 @@ for expectedContent in \
          "not ok [0-9]* - should fail on asynchronous property not running any assertions even if returning true" \
          "not ok [0-9]* - should fail on synchronous property not running any assertions returning false" \
          "not ok [0-9]* - should fail on asynchronous property not running any assertions returning false" \
+         "ok [0-9]* - should pass on synchronous properties having only successful assertions even if returning false" \
+         "ok [0-9]* - should pass on asynchronous properties having only successful assertions even if returning false" \
          "ok [0-9]* - should pass on property returning passing Observable" \
          "not ok [0-9]* - should fail on property returning failing Observable" \
          "not ok [0-9]* - should fail with seed=4242 and path=\"25\" (with seed=4242)" \

--- a/packages/ava/test/testProp.js
+++ b/packages/ava/test/testProp.js
@@ -28,21 +28,25 @@ testProp('should fail on failing asserts asynchronous property', [fc.nat()], asy
   t.true(typeof a === 'string');
 });
 testProp(
+  // WARINING: Diverge from fast-check's official behaviour
   'should fail on synchronous property not running any assertions even if returning undefined',
   [fc.constant(undefined)],
   (_t, c) => c,
 );
 testProp(
+  // WARINING: Diverge from fast-check's official behaviour
   'should fail on asynchronous property not running any assertions even if returning undefined',
   [fc.constant(undefined)],
   async (_t, c) => c,
 );
 testProp(
+  // WARINING: Diverge from fast-check's official behaviour
   'should fail on synchronous property not running any assertions even if returning true',
   [fc.constant(true)],
   (_t, c) => c,
 );
 testProp(
+  // WARINING: Diverge from fast-check's official behaviour
   'should fail on asynchronous property not running any assertions even if returning true',
   [fc.constant(true)],
   async (_t, c) => c,
@@ -56,6 +60,24 @@ testProp(
   'should fail on asynchronous property not running any assertions returning false',
   [fc.constant(false)],
   async (_t, c) => c,
+);
+testProp(
+  // WARINING: Diverge from fast-check's official behaviour
+  'should pass on synchronous properties having only successful assertions even if returning false',
+  [fc.nat()],
+  (t, c) => {
+    t.is(typeof c, 'number');
+    return false;
+  },
+);
+testProp(
+  // WARINING: Diverge from fast-check's official behaviour
+  'should pass on asynchronous properties having only successful assertions even if returning false',
+  [fc.nat()],
+  async (t, c) => {
+    t.is(typeof c, 'number');
+    return false;
+  },
 );
 testProp('should pass on property returning passing Observable', [fc.array(fc.nat(), { minLength: 1 })], (t, data) => {
   t.plan(data.length);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,6 +2735,7 @@ __metadata:
     ava: "npm:^5.3.1"
     esm: "npm:^3.2.25"
     fast-check: "workspace:*"
+    rxjs: "npm:^7.8.1"
     typescript: "npm:~5.2.2"
   peerDependencies:
     ava: ">=4.0.0"
@@ -15075,7 +15076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.4":
+"rxjs@npm:^7.5.4, rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:


### PR DESCRIPTION
Following the issue #4432, I wanted to sela a bit more the behaviour expected our not by `@fast-check/ava`.

Some behviours such as:
- not returning nor asserting anything
- returning true without asserting anyhing
- returninfg false
- returning an observable value

Were improperly covered by tests.

We also leveraged this PR to make our tests on ava safer, easier to evolve...

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
