### PR TITLE
🐛(ava) Properly support `fc.pre`, allow unsuccessful plans on unmatched preconditions

### DIFF
--- a/.yarn/versions/faafb800.yml
+++ b/.yarn/versions/faafb800.yml
@@ -1,0 +1,2 @@
+releases:
+  "@fast-check/ava": patch

--- a/packages/ava/src/ava-fast-check.ts
+++ b/packages/ava/src/ava-fast-check.ts
@@ -46,6 +46,14 @@ function wrapProp<Context, Ts extends NonEmptyArray<any>>(
             return true;
           }
 
+          const encounteredPreconditionFailure = tryResult.errors.some((error) =>
+            fc.PreconditionFailure.isFailure(error.savedError),
+          );
+          if (encounteredPreconditionFailure) {
+            tryResult.discard();
+            fc.pre(false); // precondition failed
+          }
+
           failingTry = tryResult;
           return false;
         }),

--- a/packages/ava/test.sh
+++ b/packages/ava/test.sh
@@ -26,6 +26,9 @@ for expectedContent in \
          "not ok [0-9]* - should fail on not followed plan" \
          "ok [0-9]* - should pass kitchen sink" \
          "not ok [0-9]* - should fail kitchen sink" \
+         "ok [0-9]* - should ignore the result when fc.pre interrupted the execution on synchronous properties" \
+         "ok [0-9]* - should ignore the result when fc.pre interrupted the execution on asynchronous properties" \
+         "ok [0-9]* - should ignore the result when fc.pre interrupted the execution on properties backed by Observables" \
          "ok [0-9]* - should pass as the property fails" \
          "not ok [0-9]* - should fail as the property passes"
 do

--- a/packages/ava/test/testProp.js
+++ b/packages/ava/test/testProp.js
@@ -140,6 +140,40 @@ testProp('should fail kitchen sink', [fc.array(fc.nat())], (t, array) => {
   t.falsy(array.reduce((a, b) => a + (b < 0), 0));
   t.notThrows(() => array());
 });
+testProp(
+  'should ignore the result when fc.pre interrupted the execution on synchronous properties',
+  [fc.nat()],
+  (t, c) => {
+    t.plan(1);
+    fc.pre(c % 2 === 0); // ignore cases with c % 2 === 1
+    t.is(c % 2, 0); // no assertion executed if c % 2 ===1, but given the reason it fc.pre, we want the test to pass
+  },
+);
+testProp(
+  'should ignore the result when fc.pre interrupted the execution on asynchronous properties',
+  [fc.nat()],
+  async (t, c) => {
+    t.plan(1);
+    fc.pre(c % 2 === 0); // ignore cases with c % 2 === 1
+    t.is(c % 2, 0); // no assertion executed if c % 2 ===1, but given the reason it fc.pre, we want the test to pass
+  },
+);
+testProp(
+  'should ignore the result when fc.pre interrupted the execution on properties backed by Observables',
+  [fc.array(fc.nat())],
+  (t, data) => {
+    t.plan(data.length);
+    return new Observable((observer) => {
+      data.forEach((value) => observer.next(value));
+      observer.complete();
+    }).pipe(
+      map((v) => {
+        fc.pre(v % data.length !== 0);
+        t.pass();
+      }),
+    );
+  },
+);
 
 // testProp.failing
 


### PR DESCRIPTION
Our current implementation for ava was suffering for a bad support of `fc.pre`. It considers them as real issues and ignored their "skip meaning".

With that PR we fix that long term bug and makes `fc.pre` behave as it does in usual fast-check.

Fixes #4432

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [x] _Other(s):_ ...
