### PR TITLE
♻️(worker) Prepare worker's internals to Property type of fast-check 4

### DIFF
--- a/.yarn/versions/c752060b.yml
+++ b/.yarn/versions/c752060b.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/worker": patch
+
+declined:
+  - "@fast-check/jest"

--- a/packages/worker/src/internals/NoopWorkerProperty.ts
+++ b/packages/worker/src/internals/NoopWorkerProperty.ts
@@ -25,4 +25,10 @@ export class NoopWorkerProperty<Ts> implements WorkerProperty<Ts> {
   run(): Promise<PreconditionFailure | PropertyFailure | null> {
     throw new Error('Method not implemented.');
   }
+  runBeforeEach(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  runAfterEach(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
 }


### PR DESCRIPTION
Starting at the version 4 of fast-check, properties will have to define `runBeforeEach` and `runAfterEach` (related PR #4208). We just adapted an internal of the worker package to be compatible with that. It's mostly a typing stuff as not doing so would result in the same behaviour at runtime (aka not implemented vs not a function).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
