### PR TITLE
✅ More stable snapshot tests on stack traces

### DIFF
--- a/.yarn/versions/1fb65208.yml
+++ b/.yarn/versions/1fb65208.yml
@@ -1,0 +1,2 @@
+declined:
+  - fast-check

--- a/packages/fast-check/test/e2e/NoRegressionStack.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegressionStack.spec.ts
@@ -42,8 +42,8 @@ function sanitize(run: () => void) {
       const initialMessage = (err as Error).message;
       const lines = initialMessage
         .replace(/\\/g, '/')
-        .replace(/at [^(]*fast-check\/(packages|node_modules)(.*)/g, 'at $1$2')
-        .replace(/at (.*) \(.*fast-check\/(packages|node_modules)(.*)\)/g, 'at $1 ($2$3)')
+        .replace(/at [^(]*fast-check\/(packages|node_modules)(.*):\d+:\d+/g, 'at $1$2:?:?') // line for the spec file itself
+        .replace(/at (.*) \(.*fast-check\/(packages|node_modules)(.*):\d+:\d+\)/g, 'at $1 ($2$3:?:?)') // any import linked to internals of fast-check
         .replace(/at (.*) \(.*\/(\.yarn|Yarn)\/.*\/(node_modules\/.*):\d+:\d+\)/g, 'at $1 ($3:?:?)') // reducing risks of changes on bumps: .yarn (Linux and Mac), Yarn (Windows)
         .split('\n');
       throw new Error(

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
@@ -6,19 +6,19 @@ exports[`NoRegressionStack not a function 1`] = `
 Counterexample: [0]
 Shrunk 1 time(s)
 Got TypeError: v is not a function
-    at v (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:26:14)
-    at Property.p [as predicate] (packages/fast-check/src/check/property/Property.ts:25:56)
-    at Property.predicate [as run] (packages/fast-check/src/check/property/Property.generic.ts:138:27)
-    at run (packages/fast-check/src/check/runner/Runner.ts:37:26)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:140:7)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:192:15)
-    at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:24:12)
-    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:40:7)
+    at v (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
+    at Property.p [as predicate] (packages/fast-check/src/check/property/Property.ts:?:?)
+    at Property.predicate [as run] (packages/fast-check/src/check/property/Property.generic.ts:?:?)
+    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
+    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
     at _toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
     at Object.toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
     at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:?:?)
     at Object.throwingMatcher [as toThrowErrorMatchingSnapshot] (node_modules/expect/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:31:7)"
+    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)"
 `;
 
 exports[`NoRegressionStack throw 1`] = `
@@ -27,17 +27,17 @@ exports[`NoRegressionStack throw 1`] = `
 Counterexample: [0,1]
 Shrunk 32 time(s)
 Got error: a must be >= b
-    at packages/fast-check/test/e2e/NoRegressionStack.spec.ts:12:21
-    at Property.p [as predicate] (packages/fast-check/src/check/property/Property.ts:25:56)
-    at Property.predicate [as run] (packages/fast-check/src/check/property/Property.generic.ts:138:27)
-    at run (packages/fast-check/src/check/runner/Runner.ts:37:26)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:140:7)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:192:15)
-    at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:9:12)
-    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:40:7)
+    at packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?
+    at Property.p [as predicate] (packages/fast-check/src/check/property/Property.ts:?:?)
+    at Property.predicate [as run] (packages/fast-check/src/check/property/Property.generic.ts:?:?)
+    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
+    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
     at _toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
     at Object.toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
     at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:?:?)
     at Object.throwingMatcher [as toThrowErrorMatchingSnapshot] (node_modules/expect/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:18:7)"
+    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)"
 `;


### PR DESCRIPTION
We now ignore lines in the snapshots captured in the E2E ensuring we can capture some stacks.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
