### PR TITLE
✅ Better snapshots tests implying stacktraces

### DIFF
--- a/.yarn/versions/f1098851.yml
+++ b/.yarn/versions/f1098851.yml
@@ -1,0 +1,2 @@
+declined:
+  - fast-check

--- a/packages/fast-check/test/e2e/NoRegression.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegression.spec.ts
@@ -1,4 +1,5 @@
 import fc from '../../src/fast-check';
+import { runWithSanitizedStack } from './__test-helpers__/StackSanitizer';
 import {
   IncreaseCommand,
   DecreaseCommand,
@@ -28,655 +29,797 @@ const settings = { seed: 42, verbose: 2 };
 
 describe(`NoRegression`, () => {
   it('.filter', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.nat().filter((n) => n % 3 !== 0),
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.nat().filter((n) => n % 3 !== 0),
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('.map', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.nat().map((n) => String(n)),
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.nat().map((n) => String(n)),
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('.chain', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.nat(20).chain((n) => fc.clone(fc.nat(n), n)),
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.nat(20).chain((n) => fc.clone(fc.nat(n), n)),
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('float', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.float(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.float(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('gen', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.gen(), (gen) => {
-          const v1 = gen(fc.integer);
-          const v2 = gen(fc.integer);
-          return testFunc(`${v1}-${v2}`);
-        }),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.gen(), (gen) => {
+            const v1 = gen(fc.integer);
+            const v2 = gen(fc.integer);
+            return testFunc(`${v1}-${v2}`);
+          }),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('double', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.double(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.double(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('integer', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.integer(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.integer(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('nat', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.nat(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.nat(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('maxSafeInteger', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.maxSafeInteger(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.maxSafeInteger(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('maxSafeNat', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.maxSafeNat(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.maxSafeNat(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('string', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.string(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.string(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('asciiString', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.asciiString(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.asciiString(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   // // Jest Snapshot seems not to support incomplete surrogate pair correctly
   // it('string16bits', () => {
-  //   expect(() => fc.assert(fc.property(fc.string16bits(), v => testFunc(v + v)), settings)).toThrowErrorMatchingSnapshot();
+  //   expect(runWithSanitizedStack(() => fc.assert(fc.property(fc.string16bits(), v => testFunc(v + v)), settings))).toThrowErrorMatchingSnapshot();
   // });
   it('stringOf', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.stringOf(fc.constantFrom('a', 'b')), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.stringOf(fc.constantFrom('a', 'b')), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('stringMatching', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.stringMatching(/(^|\s)a+[^a][b-eB-E]+[^b-eB-E](\s|$)/), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.stringMatching(/(^|\s)a+[^a][b-eB-E]+[^b-eB-E](\s|$)/), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('unicodeString', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.unicodeString(), (v) => testFunc(v + v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.unicodeString(), (v) => testFunc(v + v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('fullUnicodeString', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.fullUnicodeString(), (v) => testFunc(v + v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.fullUnicodeString(), (v) => testFunc(v + v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('hexaString', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.hexaString(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.hexaString(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('base64String', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.base64String(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.base64String(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('lorem', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.lorem(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.lorem(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('mapToConstant', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.mapToConstant({ num: 26, build: (v) => String.fromCharCode(v + 0x61) }),
-          fc.mapToConstant({ num: 26, build: (v) => String.fromCharCode(v + 0x61) }),
-          (a, b) => testFunc(a + b),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.mapToConstant({ num: 26, build: (v) => String.fromCharCode(v + 0x61) }),
+            fc.mapToConstant({ num: 26, build: (v) => String.fromCharCode(v + 0x61) }),
+            (a, b) => testFunc(a + b),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('option', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.option(fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.option(fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('oneof', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.oneof<any>(fc.nat(), fc.char()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.oneof<any>(fc.nat(), fc.char()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('oneof[weighted]', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.oneof<any>({ weight: 1, arbitrary: fc.nat() }, { weight: 5, arbitrary: fc.char() }), testFunc),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.oneof<any>({ weight: 1, arbitrary: fc.nat() }, { weight: 5, arbitrary: fc.char() }), testFunc),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('clone', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.clone(fc.nat(), 2), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.clone(fc.nat(), 2), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('shuffledSubarray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.shuffledSubarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), (v) =>
-          testFunc(v.join('')),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.shuffledSubarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), (v) =>
+            testFunc(v.join('')),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('subarray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.subarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), (v) =>
-          testFunc(v.join('')),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.subarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), (v) =>
+            testFunc(v.join('')),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.array(fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.array(fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('sparseArray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.sparseArray(fc.nat()),
-          (v) =>
-            // Sum of first element of each group should be less or equal to 10
-            // If a group starts at index 0, the whole group is ignored
-            Object.entries(v).reduce((acc, [index, cur]) => {
-              if (index === '0' || v[Number(index) - 1] !== undefined) return acc;
-              else return acc + cur;
-            }, 0) <= 10,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.sparseArray(fc.nat()),
+            (v) =>
+              // Sum of first element of each group should be less or equal to 10
+              // If a group starts at index 0, the whole group is ignored
+              Object.entries(v).reduce((acc, [index, cur]) => {
+                if (index === '0' || v[Number(index) - 1] !== undefined) return acc;
+                else return acc + cur;
+              }, 0) <= 10,
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('sparseArray({noTrailingHole:true})', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.sparseArray(fc.nat(), { noTrailingHole: true }),
-          (v) =>
-            // Sum of first element of each group should be less or equal to 10
-            // If a group starts at index 0, the whole group is ignored
-            Object.entries(v).reduce((acc, [index, cur]) => {
-              if (index === '0' || v[Number(index) - 1] !== undefined) return acc;
-              else return acc + cur;
-            }, 0) <= 10,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.sparseArray(fc.nat(), { noTrailingHole: true }),
+            (v) =>
+              // Sum of first element of each group should be less or equal to 10
+              // If a group starts at index 0, the whole group is ignored
+              Object.entries(v).reduce((acc, [index, cur]) => {
+                if (index === '0' || v[Number(index) - 1] !== undefined) return acc;
+                else return acc + cur;
+              }, 0) <= 10,
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('infiniteStream', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.infiniteStream(fc.nat()), (s) => testFunc([...s.take(10)])),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.infiniteStream(fc.nat()), (s) => testFunc([...s.take(10)])),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uniqueArray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uniqueArray(fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uniqueArray(fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uniqueArray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uniqueArray(fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uniqueArray(fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('tuple', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.tuple(fc.nat(), fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.tuple(fc.nat(), fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('int8Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.int8Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.int8Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uint8Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uint8Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uint8Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uint8ClampedArray', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uint8ClampedArray(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uint8ClampedArray(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('int16Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.int16Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.int16Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uint16Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uint16Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uint16Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('int32Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.int32Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.int32Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uint32Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uint32Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uint32Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('float32Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.float32Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.float32Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('float64Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.float64Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.float64Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('record', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { withDeletedKeys: true }), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { withDeletedKeys: true }), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('dictionary', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.dictionary(fc.string(), fc.nat()), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.dictionary(fc.string(), fc.nat()), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('anything', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.anything(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.anything(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('object', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.object(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.object(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('json', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.json(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.json(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('jsonValue', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.jsonValue(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.jsonValue(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('unicodeJson', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.unicodeJson(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.unicodeJson(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('unicodeJsonValue', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.unicodeJsonValue(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.unicodeJsonValue(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('compareFunc', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.compareFunc(), (f) => testFunc(f(1, 2))),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.compareFunc(), (f) => testFunc(f(1, 2))),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('func', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.func(fc.nat()), (f) => testFunc(f())),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.func(fc.nat()), (f) => testFunc(f())),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('ipV4', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.ipV4(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.ipV4(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('ipV4Extended', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.ipV4Extended(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.ipV4Extended(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('ipV6', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.ipV6(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.ipV6(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('domain', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.domain(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.domain(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webAuthority', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webAuthority(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webAuthority(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webSegment', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webSegment(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webSegment(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webFragments', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webFragments(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webFragments(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webQueryParameters', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webQueryParameters(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webQueryParameters(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webPath', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webPath(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webPath(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('webUrl', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.webUrl(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.webUrl(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('emailAddress', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.emailAddress(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.emailAddress(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('date', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.date(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.date(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('ulid', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.ulid(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.ulid(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uuid', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uuid(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uuid(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('uuidV', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.uuidV(4), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.uuidV(4), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('letrec', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.letrec((tie) => ({
-            // Trick to be able to shrink from node to leaf
-            tree: fc.nat(1).chain((id) => (id === 0 ? tie('leaf') : tie('node'))),
-            node: fc.record({ left: tie('tree'), right: tie('tree') }),
-            leaf: fc.nat(21),
-          })).tree,
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.letrec((tie) => ({
+              // Trick to be able to shrink from node to leaf
+              tree: fc.nat(1).chain((id) => (id === 0 ? tie('leaf') : tie('node'))),
+              node: fc.record({ left: tie('tree'), right: tie('tree') }),
+              leaf: fc.nat(21),
+            })).tree,
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('letrec (oneof:maxDepth)', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.letrec((tie) => ({
-            tree: fc.oneof({ withCrossShrink: true, maxDepth: 2 }, tie('leaf'), tie('node')),
-            node: fc.record({ a: tie('tree'), b: tie('tree'), c: tie('tree') }),
-            leaf: fc.nat(21),
-          })).tree,
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.letrec((tie) => ({
+              tree: fc.oneof({ withCrossShrink: true, maxDepth: 2 }, tie('leaf'), tie('node')),
+              node: fc.record({ a: tie('tree'), b: tie('tree'), c: tie('tree') }),
+              leaf: fc.nat(21),
+            })).tree,
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('letrec (oneof:depthSize)', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.letrec((tie) => ({
-            tree: fc.oneof({ withCrossShrink: true, depthSize: 'small' }, tie('leaf'), tie('node')),
-            node: fc.record({ a: tie('tree'), b: tie('tree'), c: tie('tree') }),
-            leaf: fc.nat(21),
-          })).tree,
-          (v) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.letrec((tie) => ({
+              tree: fc.oneof({ withCrossShrink: true, depthSize: 'small' }, tie('leaf'), tie('node')),
+              node: fc.record({ a: tie('tree'), b: tie('tree'), c: tie('tree') }),
+              leaf: fc.nat(21),
+            })).tree,
+            (v) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('commands', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.commands([
-            fc.nat().map((n) => new IncreaseCommand(n)),
-            fc.nat().map((n) => new DecreaseCommand(n)),
-            fc.constant(new EvenCommand()),
-            fc.constant(new OddCommand()),
-            fc.nat().map((n) => new CheckLessThanCommand(n + 1)),
-          ]),
-          (cmds) => {
-            const setup = () => ({
-              model: { count: 0 },
-              real: {},
-            });
-            try {
-              fc.modelRun(setup, cmds);
-              return true;
-            } catch (err) {
-              return false;
-            }
-          },
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.commands([
+              fc.nat().map((n) => new IncreaseCommand(n)),
+              fc.nat().map((n) => new DecreaseCommand(n)),
+              fc.constant(new EvenCommand()),
+              fc.constant(new OddCommand()),
+              fc.nat().map((n) => new CheckLessThanCommand(n + 1)),
+            ]),
+            (cmds) => {
+              const setup = () => ({
+                model: { count: 0 },
+                real: {},
+              });
+              try {
+                fc.modelRun(setup, cmds);
+                return true;
+              } catch (err) {
+                return false;
+              }
+            },
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
@@ -701,63 +844,71 @@ describe(`NoRegression`, () => {
     ).rejects.toThrowErrorMatchingSnapshot();
   });
   it('context', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.context(), fc.nat(), (ctx, v) => {
-          ctx.log(`Value was ${v}`);
-          return testFunc(v);
-        }),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.context(), fc.nat(), (ctx, v) => {
+            ctx.log(`Value was ${v}`);
+            return testFunc(v);
+          }),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
 
   it('Promise<number>', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          fc.integer().map((v) => [v, Promise.resolve(v)] as const),
-          ([v, _p]) => testFunc(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            fc.integer().map((v) => [v, Promise.resolve(v)] as const),
+            ([v, _p]) => testFunc(v),
+          ),
+          settings,
         ),
-        settings,
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('user defined examples', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.string(), (v) => testFunc(v)),
-        { ...settings, examples: [['hi'], ['hello'], ['hey']] },
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.string(), (v) => testFunc(v)),
+          { ...settings, examples: [['hi'], ['hello'], ['hey']] },
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('user defined examples (including not shrinkable values)', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(
-          // Shrinkable: built-in
-          fc.nat(),
-          // Cannot shrinking: missing unmapper
-          fc.nat().map((v) => String(v)),
-          // Shrinkable: unmapper provided
-          fc.nat().map(
-            (v) => String(v),
-            (v) => Number(v),
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(
+            // Shrinkable: built-in
+            fc.nat(),
+            // Cannot shrinking: missing unmapper
+            fc.nat().map((v) => String(v)),
+            // Shrinkable: unmapper provided
+            fc.nat().map(
+              (v) => String(v),
+              (v) => Number(v),
+            ),
+            // Shrinkable: filter can shrink given the value to shrink matches the predicate
+            fc.nat().filter((v) => v % 2 === 0),
+            (a, b, c, d) => testFunc([a, b, c, d]),
           ),
-          // Shrinkable: filter can shrink given the value to shrink matches the predicate
-          fc.nat().filter((v) => v % 2 === 0),
-          (a, b, c, d) => testFunc([a, b, c, d]),
+          {
+            ...settings,
+            examples: [
+              [1, '2', '3', 4],
+              [5, '6', '7', 8],
+              [9, '10', '11', 12],
+              [13, '14', '15', 16],
+              [17, '18', '19', 20],
+            ],
+          },
         ),
-        {
-          ...settings,
-          examples: [
-            [1, '2', '3', 4],
-            [5, '6', '7', 8],
-            [9, '10', '11', 12],
-            [13, '14', '15', 16],
-            [17, '18', '19', 20],
-          ],
-        },
       ),
     ).toThrowErrorMatchingSnapshot();
   });

--- a/packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts
@@ -1,4 +1,5 @@
 import fc from '../../src/fast-check';
+import { runWithSanitizedStack } from './__test-helpers__/StackSanitizer';
 //declare function BigInt(n: number | bigint | string): bigint;
 
 const testFunc = (value: unknown) => {
@@ -24,98 +25,122 @@ describe(`NoRegression BigInt`, () => {
   const settings = { seed: 42, verbose: 2 };
 
   it('bigIntN', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigIntN(100), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigIntN(100), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigUintN', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigUintN(100), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigUintN(100), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigInt', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigInt(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigInt(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigInt({min})', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigInt({ min: BigInt(1) << BigInt(16) }), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigInt({ min: BigInt(1) << BigInt(16) }), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigInt({max})', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigInt({ max: BigInt(1) << BigInt(64) }), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigInt({ max: BigInt(1) << BigInt(64) }), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigInt({min, max})', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigInt({ min: BigInt(1) << BigInt(16), max: BigInt(1) << BigInt(64) }), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigInt({ min: BigInt(1) << BigInt(16), max: BigInt(1) << BigInt(64) }), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigUint', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigUint(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigUint(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigUint({max})', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigUint({ max: BigInt(1) << BigInt(96) }), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigUint({ max: BigInt(1) << BigInt(96) }), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigInt64Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigInt64Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigInt64Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('bigUint64Array', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.bigUint64Array(), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.bigUint64Array(), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('mixedCase', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.mixedCase(fc.constant('cCbAabBAcaBCcCACcABaCAaAabBACaBcBb')), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.mixedCase(fc.constant('cCbAabBAcaBCcCACcABaCAaAabBACaBcBb')), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });
   it('mixedCase(stringOf)', () => {
-    expect(() =>
-      fc.assert(
-        fc.property(fc.mixedCase(fc.stringOf(fc.constantFrom('a', 'b', 'c'))), (v) => testFunc(v)),
-        settings,
+    expect(
+      runWithSanitizedStack(() =>
+        fc.assert(
+          fc.property(fc.mixedCase(fc.stringOf(fc.constantFrom('a', 'b', 'c'))), (v) => testFunc(v)),
+          settings,
+        ),
       ),
     ).toThrowErrorMatchingSnapshot();
   });

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
@@ -5,7 +5,8 @@ exports[`NoRegressionStack not a function (with cause) 1`] = `
 { seed: 42, path: "0:0", endOnFailure: true }
 Counterexample: [0]
 Shrunk 1 time(s)
-"
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
 `;
 
 exports[`NoRegressionStack not a function 1`] = `
@@ -21,12 +22,28 @@ Got TypeError: v is not a function
     at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
     at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
     at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
-    at _toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
-    at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:?:?)
-    at Object.throwingMatcher [as toThrowErrorMatchingSnapshot] (node_modules/expect/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)"
+    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack return false (with cause) 1`] = `
+"Property failed after 2 tests
+{ seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: [0,1]
+Shrunk 32 time(s)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack return false 1`] = `
+"Property failed after 2 tests
+{ seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: [0,1]
+Shrunk 32 time(s)
+Got error: Property failed by returning false
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
 `;
 
 exports[`NoRegressionStack throw (with cause) 1`] = `
@@ -34,7 +51,8 @@ exports[`NoRegressionStack throw (with cause) 1`] = `
 { seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
 Counterexample: [0,1]
 Shrunk 32 time(s)
-"
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
 `;
 
 exports[`NoRegressionStack throw 1`] = `
@@ -50,10 +68,7 @@ Got error: a must be >= b
     at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
     at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
     at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
-    at _toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (node_modules/jest-snapshot/build/index.js:?:?)
-    at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:?:?)
-    at Object.throwingMatcher [as toThrowErrorMatchingSnapshot] (node_modules/expect/build/index.js:?:?)
-    at Object.toThrowErrorMatchingSnapshot (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)"
+    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
 `;

--- a/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
+++ b/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
@@ -14,7 +14,7 @@ function sanitizeStack(initialMessage: string) {
       lines.length - 1 - [...lines].reverse().findIndex((line) => line.includes('node_modules/jest-'));
     lines.splice(firstLineWithJest, lastLineWithJest - firstLineWithJest + 1);
   }
-  return lines.filter((line) => !line.includes('node_modules/jest-circus')).join('\n');
+  return lines.join('\n');
 }
 
 /** Wrap a potentially throwing code within a caller that would sanitize the returned Error */

--- a/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
+++ b/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
@@ -1,0 +1,29 @@
+function sanitizeStack(initialMessage: string) {
+  const lines = initialMessage
+    .split('\n')
+    .map((line) => (line.trimStart().startsWith('at ') ? line.replace(/\\/g, '/') : line))
+    .join('\n')
+    .replace(/at [^(]*fast-check\/(packages|node_modules)(.*):\d+:\d+/g, 'at $1$2:?:?') // line for the spec file itself
+    .replace(/at (.*) \(.*fast-check\/(packages|node_modules)(.*):\d+:\d+\)/g, 'at $1 ($2$3:?:?)') // any import linked to internals of fast-check
+    .replace(/at (.*) \(.*\/(\.yarn|Yarn)\/.*\/(node_modules\/.*):\d+:\d+\)/g, 'at $1 ($3:?:?)') // reducing risks of changes on bumps: .yarn (Linux and Mac), Yarn (Windows)
+    .split('\n');
+  // Drop internals of Jest from the stack: internals of jest, subject to regular changes and OS dependent
+  const firstLineWithJest = lines.findIndex((line) => line.includes('node_modules/jest-'));
+  if (firstLineWithJest !== -1) {
+    const lastLineWithJest =
+      lines.length - 1 - [...lines].reverse().findIndex((line) => line.includes('node_modules/jest-'));
+    lines.splice(firstLineWithJest, lastLineWithJest - firstLineWithJest + 1);
+  }
+  return lines.filter((line) => !line.includes('node_modules/jest-circus')).join('\n');
+}
+
+/** Wrap a potentially throwing code within a caller that would sanitize the returned Error */
+export function runWithSanitizedStack(run: () => void) {
+  return (): void => {
+    try {
+      run();
+    } catch (err) {
+      throw new Error(sanitizeStack((err as Error).message));
+    }
+  };
+}


### PR DESCRIPTION
The current snapshots implying stacktraces were luckily never displaying any stack. Indeed stacks never get displayed for the specs NoRegression and NoRegressionBigInt.

We want to make these tests able to support stacks and sanitize them as we already do for NoRegressionStack. As a consequence we extracted the helper defined in NoRegressionStack and used it for the others.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
