### PR TITLE
 💥 Error with cause by default

### DIFF
--- a/packages/fast-check/src/check/runner/configuration/Parameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/Parameters.ts
@@ -192,13 +192,15 @@ export interface Parameters<T = void> {
    */
   asyncReporter?: (runDetails: RunDetails<T>) => Promise<void>;
   /**
-   * Should the thrown Error include a cause leading to the original Error?
+   * By default the Error causing the failure of the predicate will not be directly exposed within the message
+   * of the Error thown by fast-check. It will be exposed by a cause field attached to the Error.
    *
-   * In such case the original Error will disappear from the message of the Error thrown by fast-check
-   * and only appear within the cause part of it.
+   * The Error with cause has been supported by Node since 16.14.0 and is properly supported in many test runners.
    *
-   * Remark: At the moment, only node (≥16.14.0) and vitest seem to properly display such errors.
-   * Others will just discard the cause at display time.
+   * But if the original Error fails to appear within your test runner,
+   * Or if you prefer the Error to be included directly as part of the message of the resulted Error,
+   * you can toggle this flag and the Error produced by fast-check in case of failure will expose the source Error
+   * as part of the message and not as a cause.
    */
-  errorWithCause?: boolean;
+  includeErrorInReport?: boolean;
 }

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -37,7 +37,7 @@ export class QualifiedParameters<T> {
   ignoreEqualValues: boolean;
   reporter: ((runDetails: RunDetails<T>) => void) | null;
   asyncReporter: ((runDetails: RunDetails<T>) => Promise<void>) | null;
-  errorWithCause: boolean;
+  includeErrorInReport: boolean;
 
   constructor(op?: Parameters<T>) {
     const p = op || {};
@@ -66,7 +66,7 @@ export class QualifiedParameters<T> {
     this.endOnFailure = QualifiedParameters.readBoolean(p, 'endOnFailure');
     this.reporter = QualifiedParameters.readOrDefault(p, 'reporter', null);
     this.asyncReporter = QualifiedParameters.readOrDefault(p, 'asyncReporter', null);
-    this.errorWithCause = QualifiedParameters.readBoolean(p, 'errorWithCause');
+    this.includeErrorInReport = QualifiedParameters.readBoolean(p, 'includeErrorInReport');
   }
 
   toParameters(): Parameters<T> {
@@ -90,7 +90,7 @@ export class QualifiedParameters<T> {
       endOnFailure: this.endOnFailure,
       reporter: orUndefined(this.reporter),
       asyncReporter: orUndefined(this.asyncReporter),
-      errorWithCause: this.errorWithCause,
+      includeErrorInReport: this.includeErrorInReport,
     };
     return parameters;
   }

--- a/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
+++ b/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
@@ -118,7 +118,9 @@ function prettyError(errorInstance: unknown) {
 /** @internal */
 function preFormatFailure<Ts>(out: RunDetailsFailureProperty<Ts>, stringifyOne: (value: Ts) => string) {
   const includeErrorInReport = out.runConfiguration.includeErrorInReport;
-  const messageErrorPart = includeErrorInReport ? `\nGot ${safeReplace(prettyError(out.errorInstance), /^Error: /, 'error: ')}` : '';
+  const messageErrorPart = includeErrorInReport
+    ? `\nGot ${safeReplace(prettyError(out.errorInstance), /^Error: /, 'error: ')}`
+    : '';
   const message = `Property failed after ${out.numRuns} tests\n{ seed: ${out.seed}, path: "${
     out.counterexamplePath
   }", endOnFailure: true }\nCounterexample: ${stringifyOne(out.counterexample)}\nShrunk ${

--- a/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
+++ b/packages/fast-check/src/check/runner/utils/RunDetailsFormatter.ts
@@ -117,10 +117,8 @@ function prettyError(errorInstance: unknown) {
 
 /** @internal */
 function preFormatFailure<Ts>(out: RunDetailsFailureProperty<Ts>, stringifyOne: (value: Ts) => string) {
-  const noErrorInMessage = out.runConfiguration.errorWithCause;
-  const messageErrorPart = noErrorInMessage
-    ? ''
-    : `\nGot ${safeReplace(prettyError(out.errorInstance), /^Error: /, 'error: ')}`;
+  const includeErrorInReport = out.runConfiguration.includeErrorInReport;
+  const messageErrorPart = includeErrorInReport ? `\nGot ${safeReplace(prettyError(out.errorInstance), /^Error: /, 'error: ')}` : '';
   const message = `Property failed after ${out.numRuns} tests\n{ seed: ${out.seed}, path: "${
     out.counterexamplePath
   }", endOnFailure: true }\nCounterexample: ${stringifyOne(out.counterexample)}\nShrunk ${
@@ -279,7 +277,7 @@ async function asyncDefaultReportMessage<Ts>(out: RunDetails<Ts>): Promise<strin
 
 /** @internal */
 function buildError<Ts>(errorMessage: string | undefined, out: RunDetails<Ts> & { failed: true }) {
-  if (!out.runConfiguration.errorWithCause) {
+  if (out.runConfiguration.includeErrorInReport) {
     throw new Error(errorMessage);
   }
   const ErrorWithCause: new (message: string | undefined, options: { cause: unknown }) => Error = Error;

--- a/packages/fast-check/test/e2e/NoRegressionStack.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegressionStack.spec.ts
@@ -3,32 +3,46 @@ import { runWithSanitizedStack } from './__test-helpers__/StackSanitizer';
 
 const settings = { seed: 42, verbose: 0 };
 
-describe(`NoRegressionStack`, () => {
-  it('throw', () => {
-    expect(
-      runWithSanitizedStack(() =>
-        fc.assert(
-          fc.property(fc.nat(), fc.nat(), (a, b) => {
-            if (a < b) {
-              throw new Error('a must be >= b');
-            }
-          }),
-          settings,
+describe.each([{ includeErrorInReport: false }, { includeErrorInReport: true }])(
+  `NoRegressionStack (includeErrorInReport: $includeErrorInReport)`,
+  ({ includeErrorInReport }) => {
+    it('return false', () => {
+      expect(
+        runWithSanitizedStack(() =>
+          fc.assert(
+            fc.property(fc.nat(), fc.nat(), (a, b) => {
+              return a >= b;
+            }),
+            { ...settings, includeErrorInReport },
+          ),
         ),
-      ),
-    ).toThrowErrorMatchingSnapshot();
-  });
-
-  it('not a function', () => {
-    expect(
-      runWithSanitizedStack(() =>
-        fc.assert(
-          fc.property(fc.nat(), (v) => {
-            (v as any)();
-          }),
-          settings,
+      ).toThrowErrorMatchingSnapshot();
+    });
+    it('throw', () => {
+      expect(
+        runWithSanitizedStack(() =>
+          fc.assert(
+            fc.property(fc.nat(), fc.nat(), (a, b) => {
+              if (a < b) {
+                throw new Error('a must be >= b');
+              }
+            }),
+            { ...settings, includeErrorInReport },
+          ),
         ),
-      ),
-    ).toThrowErrorMatchingSnapshot();
-  });
-});
+      ).toThrowErrorMatchingSnapshot();
+    });
+    it('not a function', () => {
+      expect(
+        runWithSanitizedStack(() =>
+          fc.assert(
+            fc.property(fc.nat(), (v) => {
+              (v as any)();
+            }),
+            { ...settings, includeErrorInReport },
+          ),
+        ),
+      ).toThrowErrorMatchingSnapshot();
+    });
+  },
+);

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -5,11 +5,6 @@ exports[`NoRegression (async) .map (to Promise) 1`] = `
 { seed: 42, path: "1:4:0:0:0:0:3:0:0:3:0:1:1:0:2", endOnFailure: true }
 Counterexample: [Promise.resolve(-873632988)]
 Shrunk 14 time(s)
-Got error: Property failed by returning false
-    at AsyncProperty.run (packages/fast-check/src/check/property/AsyncProperty.generic.ts:?:?)
-    at asyncRunIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?
-    at Object.<anonymous> (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
 
 Execution summary:
 [32m√[0m [Promise.resolve(9)]
@@ -57,11 +52,6 @@ Counterexample: [function(...args) {
   return outs[hash('19' + stringify(args)) % outs.length];
 }]
 Shrunk 20 time(s)
-Got error: Property failed by returning false
-    at AsyncProperty.run (packages/fast-check/src/check/property/AsyncProperty.generic.ts:?:?)
-    at asyncRunIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?
-    at Object.<anonymous> (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
 
 Execution summary:
 [32m√[0m [function(...args) {
@@ -659,11 +649,6 @@ exports[`NoRegression (async) infiniteStream (to Promise) 1`] = `
 { seed: 42, path: "0", endOnFailure: true }
 Counterexample: [Stream(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at AsyncProperty.run (packages/fast-check/src/check/property/AsyncProperty.generic.ts:?:?)
-    at asyncRunIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?
-    at Object.<anonymous> (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
 
 Execution summary:
 [31m×[0m [Stream(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]"
@@ -674,11 +659,6 @@ exports[`NoRegression (async) number 1`] = `
 { seed: 42, path: "1:4:0:0:0:0:3:0:0:3:0:1:1:0:2", endOnFailure: true }
 Counterexample: [-873632988]
 Shrunk 14 time(s)
-Got error: Property failed by returning false
-    at AsyncProperty.run (packages/fast-check/src/check/property/AsyncProperty.generic.ts:?:?)
-    at asyncRunIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?
-    at Object.<anonymous> (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
 
 Execution summary:
 [32m√[0m [9]
@@ -727,11 +707,6 @@ Counterexample: [schedulerFor()\`
 -> [task\${6}] promise resolved with value "C"
 -> [task\${5}] promise resolved with value "A"\`]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at AsyncProperty.run (packages/fast-check/src/check/property/AsyncProperty.generic.ts:?:?)
-    at asyncRunIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?
-    at Object.<anonymous> (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
 
 Execution summary:
 [32m√[0m [schedulerFor()\`
@@ -1259,13 +1234,6 @@ exports[`NoRegression .chain 1`] = `
 { seed: 42, path: "36", endOnFailure: true }
 Counterexample: [[11,11,11,11,11,11,11,11,11,11,11,11,11,11]]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]]
@@ -1320,13 +1288,6 @@ exports[`NoRegression .filter 1`] = `
 { seed: 42, path: "1:1:3:2:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
 Counterexample: [855209260]
 Shrunk 17 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [2147483626]
@@ -1361,13 +1322,6 @@ exports[`NoRegression .map 1`] = `
 { seed: 42, path: "1:2:4:3:1:1:0:1:6:0:2", endOnFailure: true }
 Counterexample: ["854975880"]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["2147483626"]
@@ -1410,13 +1364,6 @@ exports[`NoRegression Promise<number> 1`] = `
 { seed: 42, path: "1:4:0:0:0:0:3:0:0:3:0:1:1:0:2", endOnFailure: true }
 Counterexample: [[-873632988,new Promise(() => {/*unknown*/})]]
 Shrunk 14 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[9,new Promise(() => {/*unknown*/})]]
@@ -1459,13 +1406,6 @@ exports[`NoRegression anything 1`] = `
 { seed: 42, path: "0", endOnFailure: true }
 Counterexample: [[null]]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [[null]]
@@ -1477,13 +1417,6 @@ exports[`NoRegression array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:5:4:3:3:1:1:2:1:1:1:1:1", endOnFailure: true }
 Counterexample: [[53219899]]
 Shrunk 18 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -1545,13 +1478,6 @@ exports[`NoRegression asciiString 1`] = `
 { seed: 42, path: "1:1:1:4:1:1:1:2", endOnFailure: true }
 Counterexample: ["\\u0000"]
 Shrunk 7 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -1583,13 +1509,6 @@ exports[`NoRegression base64String 1`] = `
 { seed: 42, path: "2:3:5:5", endOnFailure: true }
 Counterexample: ["AA=="]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -1620,13 +1539,6 @@ exports[`NoRegression clone 1`] = `
 { seed: 42, path: "1:2:4:3:1:1:0:1:6:0:2", endOnFailure: true }
 Counterexample: [[854975880,854975880]]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[2147483626,2147483626]]
@@ -1669,13 +1581,6 @@ exports[`NoRegression commands 1`] = `
 { seed: 42, path: "0:3:2:2:1:2:1:1:2:3:1:5:3:1:1:2:3:1:1:1:1:2:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1", endOnFailure: true }
 Counterexample: [inc[1],check[1] /*replayPath="CC/d:N"*/]
 Shrunk 47 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [inc[456875496],check[2014944499],check[129750014] /*replayPath="CC/d:N"*/]
@@ -1807,13 +1712,6 @@ Counterexample: [function(a, b) {
   return cmp(hA, hB);
 }]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [function(a, b) {
@@ -1863,13 +1761,6 @@ exports[`NoRegression context 1`] = `
 { seed: 42, path: "1:2:4:3:1:1:0:1:6:0:2", endOnFailure: true }
 Counterexample: [{"logs":["Value was 854975880"]},854975880]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [{"logs":["Value was 2147483626"]},2147483626]
@@ -1912,13 +1803,6 @@ exports[`NoRegression date 1`] = `
 { seed: 42, path: "0:0", endOnFailure: true }
 Counterexample: [new Date("1970-01-01T00:00:00.000Z")]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [new Date("1969-12-31T23:59:59.992Z")]
@@ -1930,13 +1814,6 @@ exports[`NoRegression dictionary 1`] = `
 { seed: 42, path: "1:1:1:1:3:1:1:3:1:1:1:1:1:1:2:3:5:7", endOnFailure: true }
 Counterexample: [{"":548742166}]
 Shrunk 17 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [{}]
@@ -2006,13 +1883,6 @@ exports[`NoRegression domain 1`] = `
 { seed: 42, path: "4:0:3:0:0:1:2:1:0:0:0:0", endOnFailure: true }
 Counterexample: ["aa.aa"]
 Shrunk 11 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["s.qf"]
@@ -2045,13 +1915,6 @@ exports[`NoRegression double 1`] = `
 { seed: 42, path: "0:1:1:1", endOnFailure: true }
 Counterexample: [-1e-322]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [-2.9e-322]
@@ -2069,13 +1932,6 @@ exports[`NoRegression emailAddress 1`] = `
 { seed: 42, path: "0:0:0:0:0:0:5:3:0", endOnFailure: true }
 Counterexample: ["a@a.aa"]
 Shrunk 8 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["8i_p#6u@3.ch99e2ux9i70.ccz"]
@@ -2102,13 +1958,6 @@ exports[`NoRegression float 1`] = `
 { seed: 42, path: "0:1:0:1", endOnFailure: true }
 Counterexample: [-4.203895392974451e-45]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [-2.382207389352189e-44]
@@ -2125,13 +1974,6 @@ exports[`NoRegression float32Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:1:1:2:1:1:1:1:1:1:2:1:3:1:2:1:1:1:1:1:1:1", endOnFailure: true }
 Counterexample: [Float32Array.from([9.87484798330909e-39])]
 Shrunk 27 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Float32Array.from([])]
@@ -2203,13 +2045,6 @@ exports[`NoRegression float64Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:2:1:1:1:2:1:1:1:2:1:1:1:1:2:1:1:3:1:1:1:1:1:2:3:1:1:1:1:2:1:2:1:1:4:2:4:2:2:1", endOnFailure: true }
 Counterexample: [Float64Array.from([8.584968169854399e-278])]
 Shrunk 45 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Float64Array.from([])]
@@ -2332,13 +2167,6 @@ exports[`NoRegression fullUnicodeString 1`] = `
 { seed: 42, path: "25:6:3:1:1:1:1", endOnFailure: true }
 Counterexample: [" "]
 Shrunk 6 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -2399,13 +2227,6 @@ Counterexample: [function(...args) {
   return outs[hash('-27' + stringify(args)) % outs.length];
 }]
 Shrunk 12 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [function(...args) {
@@ -2607,13 +2428,6 @@ exports[`NoRegression gen 1`] = `
 { seed: 42, path: "0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
 Counterexample: [[0,-1]]
 Shrunk 28 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [[9,-132539150]]
@@ -2654,13 +2468,6 @@ exports[`NoRegression hexaString 1`] = `
 { seed: 42, path: "5:1:1:10:1:5:0", endOnFailure: true }
 Counterexample: ["66"]
 Shrunk 6 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -2707,13 +2514,6 @@ exports[`NoRegression infiniteStream 1`] = `
 { seed: 42, path: "0", endOnFailure: true }
 Counterexample: [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]"
@@ -2724,13 +2524,6 @@ exports[`NoRegression int8Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1", endOnFailure: true }
 Counterexample: [Int8Array.from([-11])]
 Shrunk 5 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Int8Array.from([])]
@@ -2755,13 +2548,6 @@ exports[`NoRegression int16Array 1`] = `
 { seed: 42, path: "1:1:0:2:3:2:7", endOnFailure: true }
 Counterexample: [Int16Array.from([2110])]
 Shrunk 6 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Int16Array.from([])]
@@ -2801,13 +2587,6 @@ exports[`NoRegression int32Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:5:4:3:3:1:1:2:1:1:1:1:1", endOnFailure: true }
 Counterexample: [Int32Array.from([53219899])]
 Shrunk 18 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Int32Array.from([])]
@@ -2869,13 +2648,6 @@ exports[`NoRegression integer 1`] = `
 { seed: 42, path: "1:4:0:0:0:0:3:0:0:3:0:1:1:0:2", endOnFailure: true }
 Counterexample: [-873632988]
 Shrunk 14 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [9]
@@ -2918,13 +2690,6 @@ exports[`NoRegression ipV4 1`] = `
 { seed: 42, path: "8:0:0:1:5:1", endOnFailure: true }
 Counterexample: ["0.0.110.0"]
 Shrunk 5 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["248.242.2.252"]
@@ -2956,13 +2721,6 @@ exports[`NoRegression ipV4Extended 1`] = `
 { seed: 42, path: "0:0:0:1:0:0:1:1:1:0:2:0:8", endOnFailure: true }
 Counterexample: ["0.1287199"]
 Shrunk 12 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["0x2.15541234"]
@@ -3000,13 +2758,6 @@ exports[`NoRegression ipV6 1`] = `
 { seed: 42, path: "0:0:0:0", endOnFailure: true }
 Counterexample: ["::0"]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["31::4a"]
@@ -3020,13 +2771,6 @@ exports[`NoRegression json 1`] = `
 { seed: 42, path: "0:10", endOnFailure: true }
 Counterexample: ["[\\"\\\\\\\\\\"]"]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["[\\"\\\\\\\\;mRs\\"]"]
@@ -3056,13 +2800,6 @@ exports[`NoRegression jsonValue 1`] = `
 { seed: 42, path: "0:10", endOnFailure: true }
 Counterexample: [["\\\\"]]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [["\\\\;mRs"]]
@@ -3092,13 +2829,6 @@ exports[`NoRegression letrec (oneof:depthSize) 1`] = `
 { seed: 42, path: "36:1:0:0:6:4:4:4:4", endOnFailure: true }
 Counterexample: [{"a":0,"b":0,"c":{"a":{"a":11,"b":0,"c":0},"b":0,"c":0}}]
 Shrunk 8 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [21]
@@ -3180,13 +2910,6 @@ exports[`NoRegression letrec (oneof:maxDepth) 1`] = `
 { seed: 42, path: "31:1:0:1:4:4", endOnFailure: true }
 Counterexample: [{"a":0,"b":{"a":0,"b":11,"c":0},"c":0}]
 Shrunk 5 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [21]
@@ -3247,13 +2970,6 @@ exports[`NoRegression letrec 1`] = `
 { seed: 42, path: "11:2:1:0:1:4:4:0", endOnFailure: true }
 Counterexample: [{"left":{"left":0,"right":{"left":0,"right":{"left":0,"right":0}}},"right":11}]
 Shrunk 7 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [{"left":4,"right":{"left":{"left":{"left":{"left":{"left":4,"right":18},"right":{"left":8,"right":21}},"right":18},"right":{"left":{"left":{"left":0,"right":19},"right":{"left":17,"right":1}},"right":13}},"right":{"left":{"left":{"left":2,"right":{"left":20,"right":{"left":3,"right":{"left":12,"right":{"left":{"left":{"left":3,"right":8},"right":7},"right":19}}}}},"right":{"left":21,"right":14}},"right":17}}}]
@@ -3298,13 +3014,6 @@ exports[`NoRegression lorem 1`] = `
 { seed: 42, path: "1:1:0:0:0", endOnFailure: true }
 Counterexample: ["ullamcorper leo"]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["tristique"]
@@ -3322,13 +3031,6 @@ exports[`NoRegression mapToConstant 1`] = `
 { seed: 42, path: "3", endOnFailure: true }
 Counterexample: ["a","a"]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["z","i"]
@@ -3342,13 +3044,6 @@ exports[`NoRegression maxSafeInteger 1`] = `
 { seed: 42, path: "0:1:0", endOnFailure: true }
 Counterexample: [-11]
 Shrunk 2 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [-44]
@@ -3365,13 +3060,6 @@ exports[`NoRegression maxSafeNat 1`] = `
 { seed: 42, path: "0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:3:2:0:0:3:0:0:0:0:0:0:1:2:0:1:2:2:0:3", endOnFailure: true }
 Counterexample: [253873198799]
 Shrunk 34 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [9007199254740940]
@@ -3437,13 +3125,6 @@ exports[`NoRegression nat 1`] = `
 { seed: 42, path: "1:2:4:3:1:1:0:1:6:0:2", endOnFailure: true }
 Counterexample: [854975880]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [2147483626]
@@ -3486,13 +3167,6 @@ exports[`NoRegression object 1`] = `
 { seed: 42, path: "1:1:0:0:1:2:2:5:3:3:3:3:5:4:3:3:4:3:3:3:3:3:4:3:3:3:3:3:3:3:3:3:3:4:4:5:3:4:3:3:3:3:6:3:7:3:3:3", endOnFailure: true }
 Counterexample: [{"":{"":[-6.8158624976587944e-192]}}]
 Shrunk 47 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [{}]
@@ -3704,13 +3378,6 @@ exports[`NoRegression oneof 1`] = `
 { seed: 42, path: "4:1:2:0:0:3:0:1:0:1:0:0:0:1:7", endOnFailure: true }
 Counterexample: [210974299]
 Shrunk 14 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [2147483646]
@@ -3756,13 +3423,6 @@ exports[`NoRegression oneof[weighted] 1`] = `
 { seed: 42, path: "23:1:0:0:0:0:5:8:4:0:0:0:1:0", endOnFailure: true }
 Counterexample: [57429880]
 Shrunk 13 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["{"]
@@ -3829,13 +3489,6 @@ exports[`NoRegression option 1`] = `
 { seed: 42, path: "3", endOnFailure: true }
 Counterexample: [null]
 Shrunk 0 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [2147483646]
@@ -3849,13 +3502,6 @@ exports[`NoRegression record 1`] = `
 { seed: 42, path: "4:2:2:0:0:3:0:1:0:1:0:0:0:1:7:1", endOnFailure: true }
 Counterexample: [{"k1":210974299}]
 Shrunk 15 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [{"k1":2147483646}]
@@ -3904,13 +3550,6 @@ exports[`NoRegression shuffledSubarray 1`] = `
 { seed: 42, path: "1:2:0:5", endOnFailure: true }
 Counterexample: [[2,2]]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -3935,13 +3574,6 @@ exports[`NoRegression sparseArray 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:1:3:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:3:3:3", endOnFailure: true }
 Counterexample: [[,11]]
 Shrunk 36 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[,,,,,,,,,,,,,,,,,,,]]
@@ -4060,13 +3692,6 @@ exports[`NoRegression sparseArray({noTrailingHole:true}) 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:1:3:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:3:3", endOnFailure: true }
 Counterexample: [[,11]]
 Shrunk 35 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -4181,13 +3806,6 @@ exports[`NoRegression string 1`] = `
 { seed: 42, path: "9:1", endOnFailure: true }
 Counterexample: ["CC"]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -4223,13 +3841,6 @@ exports[`NoRegression stringMatching 1`] = `
 { seed: 42, path: "0:1:1:1:1:0", endOnFailure: true }
 Counterexample: ["a B  "]
 Shrunk 5 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["aa!cBcBx\\t"]
@@ -4249,13 +3860,6 @@ exports[`NoRegression stringOf 1`] = `
 { seed: 42, path: "1:1:0", endOnFailure: true }
 Counterexample: ["aa"]
 Shrunk 2 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -4272,13 +3876,6 @@ exports[`NoRegression subarray 1`] = `
 { seed: 42, path: "46:4", endOnFailure: true }
 Counterexample: [[4,4]]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -4343,13 +3940,6 @@ exports[`NoRegression tuple 1`] = `
 { seed: 42, path: "0:0:1:1:4:1:0:0:0:2:0:0:1:1", endOnFailure: true }
 Counterexample: [[0,743987633]]
 Shrunk 13 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [[2147483626,2014944498]]
@@ -4392,13 +3982,6 @@ exports[`NoRegression uint8Array 1`] = `
 { seed: 42, path: "2:7:2:3:3", endOnFailure: true }
 Counterexample: [Uint8Array.from([110])]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Uint8Array.from([])]
@@ -4432,13 +4015,6 @@ exports[`NoRegression uint8ClampedArray 1`] = `
 { seed: 42, path: "2:7:2:3:3", endOnFailure: true }
 Counterexample: [Uint8ClampedArray.from([110])]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Uint8ClampedArray.from([])]
@@ -4472,13 +4048,6 @@ exports[`NoRegression uint16Array 1`] = `
 { seed: 42, path: "1:1:0:2:1:4:1:6:1:1:2", endOnFailure: true }
 Counterexample: [Uint16Array.from([8550])]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Uint16Array.from([])]
@@ -4521,13 +4090,6 @@ exports[`NoRegression uint32Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:5:1:1:2:4:1:2:1:3:1:4:2:1", endOnFailure: true }
 Counterexample: [Uint32Array.from([305109899])]
 Shrunk 19 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [Uint32Array.from([])]
@@ -4593,13 +4155,6 @@ exports[`NoRegression ulid 1`] = `
 { seed: 42, path: "0:0:0:0", endOnFailure: true }
 Counterexample: ["00000000000000000000000000"]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["7ZZZZZZZZDZ0AWTX6YQCVVJ1XW"]
@@ -4613,13 +4168,6 @@ exports[`NoRegression unicodeJson 1`] = `
 { seed: 42, path: "1:1:0:1:3:3:4:3:3:3:4:3:3:3:3:4:4:5:3:3:3:3:3:3:4:3:3:3:3:3:4:3:6:4:3:6:3:4:3:3:5:4:3:6:4", endOnFailure: true }
 Counterexample: ["{\\"\\":{\\"\\":5.9196851432654755e-210}}"]
 Shrunk 44 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["[\\"⾼㥤ⱓ巡\\"]"]
@@ -4826,13 +4374,6 @@ exports[`NoRegression unicodeJsonValue 1`] = `
 { seed: 42, path: "1:1:0:1:3:3:4:3:3:3:4:3:3:3:3:4:4:5:3:3:3:3:3:3:4:3:3:3:3:3:4:3:6:4:3:6:3:4:3:3:5:4:3:6:4", endOnFailure: true }
 Counterexample: [{"":{"":5.9196851432654755e-210}}]
 Shrunk 44 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [["⾼㥤ⱓ巡"]]
@@ -5039,13 +4580,6 @@ exports[`NoRegression unicodeString 1`] = `
 { seed: 42, path: "25:6:3:1:1:1:1", endOnFailure: true }
 Counterexample: [" "]
 Shrunk 6 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -5101,13 +4635,6 @@ exports[`NoRegression uniqueArray 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:5:4:3:3:1:1:2:1:1:1:1:1", endOnFailure: true }
 Counterexample: [[53219899]]
 Shrunk 18 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -5169,13 +4696,6 @@ exports[`NoRegression uniqueArray 2`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:5:4:3:3:1:1:2:1:1:1:1:1", endOnFailure: true }
 Counterexample: [[53219899]]
 Shrunk 18 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [[]]
@@ -5237,13 +4757,6 @@ exports[`NoRegression user defined examples (including not shrinkable values) 1`
 { seed: 42, path: "2:0:4", endOnFailure: true }
 Counterexample: [0,"10","11",0]
 Shrunk 2 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [1,"2","3",4]
@@ -5266,13 +4779,6 @@ exports[`NoRegression user defined examples 1`] = `
 { seed: 42, path: "1:1:17", endOnFailure: true }
 Counterexample: ["ll"]
 Shrunk 2 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["hi"]
@@ -5320,13 +4826,6 @@ exports[`NoRegression uuid 1`] = `
 { seed: 42, path: "0:0:0:0:0", endOnFailure: true }
 Counterexample: ["00000000-0000-1000-8000-000000000000"]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["ffffffe8-9cf2-3819-8000-0004ffffffe4"]
@@ -5341,13 +4840,6 @@ exports[`NoRegression uuidV 1`] = `
 { seed: 42, path: "0:0:0:0:0", endOnFailure: true }
 Counterexample: ["00000000-0000-4000-8000-000000000000"]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["ffffffe8-9cf2-4819-8000-0004ffffffe4"]
@@ -5362,13 +4854,6 @@ exports[`NoRegression webAuthority 1`] = `
 { seed: 42, path: "1:0", endOnFailure: true }
 Counterexample: ["a.cc"]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m ["bz089axab-ea.ia"]
@@ -5385,13 +4870,6 @@ exports[`NoRegression webFragments 1`] = `
 { seed: 42, path: "10:1:5:2:2:1:1:4:2:2:1:2", endOnFailure: true }
 Counterexample: ["%F1%BB%80%80"]
 Shrunk 11 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -5448,13 +4926,6 @@ exports[`NoRegression webPath 1`] = `
 { seed: 42, path: "38:3:1:8:7:3:3:4:3:3:4", endOnFailure: true }
 Counterexample: ["/%F0%AA%80%80"]
 Shrunk 10 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -5555,13 +5026,6 @@ exports[`NoRegression webQueryParameters 1`] = `
 { seed: 42, path: "10:1:5:2:2:1:1:4:2:2:1:2", endOnFailure: true }
 Counterexample: ["%F1%BB%80%80"]
 Shrunk 11 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -5618,13 +5082,6 @@ exports[`NoRegression webSegment 1`] = `
 { seed: 42, path: "2:2:0:17", endOnFailure: true }
 Counterexample: ["::"]
 Shrunk 3 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]
@@ -5675,13 +5132,6 @@ exports[`NoRegression webUrl 1`] = `
 { seed: 42, path: "0:0:0:0:0", endOnFailure: true }
 Counterexample: ["http://a.aa"]
 Shrunk 4 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegression.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["http://e.pv/p%EF%8D%9D"]

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegressionBigInt.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegressionBigInt.spec.ts.snap
@@ -5,13 +5,6 @@ exports[`NoRegression BigInt bigInt 1`] = `
 { seed: 42, path: "1:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:2:0:0:0:0:0:0:0:1:0:1:0:0:0:0:0:0:0:0:0:0:1:0:1:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:2:0:1:1:0:1:0:2:0:0:0:1:0:0:1:1:0", endOnFailure: true }
 Counterexample: [-39395841487650527926240175269879659877n]
 Shrunk 231 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [-68n]
@@ -278,13 +271,6 @@ exports[`NoRegression BigInt bigInt({max}) 1`] = `
 { seed: 42, path: "1:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:2:0:0:0:0:0:0:0:1:0:1:0:0:0:0:0:0:0:0:0:0:1:0:1:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:2:0:1:1:0:1:0:2:0:0:0:1:0:0:1:1:0", endOnFailure: true }
 Counterexample: [-39395841487650527926240175269879659877n]
 Shrunk 231 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [-47n]
@@ -551,13 +537,6 @@ exports[`NoRegression BigInt bigInt({min, max}) 1`] = `
 { seed: 42, path: "0:0", endOnFailure: true }
 Counterexample: [65536n]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [18446744073709551598n]
@@ -569,13 +548,6 @@ exports[`NoRegression BigInt bigInt({min}) 1`] = `
 { seed: 42, path: "0:0", endOnFailure: true }
 Counterexample: [65536n]
 Shrunk 1 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [57896044618658097711785492504343953926634992332820282019728792003960859787248n]
@@ -587,13 +559,6 @@ exports[`NoRegression BigInt bigInt64Array 1`] = `
 { seed: 42, path: "1:1:0:0:3:1:2:2:2:1:1:1:4:1:2:2:1:1:1:1:1:1:1:2:1:2:2:1:1:1:1:1:1:1:1:1:2:10:1", endOnFailure: true }
 Counterexample: [BigInt64Array.from([4164375494697153299n])]
 Shrunk 38 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [BigInt64Array.from([])]
@@ -708,13 +673,6 @@ exports[`NoRegression BigInt bigIntN 1`] = `
 { seed: 42, path: "1:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:2:0:0:0:0:0:0:1:0:0:0:0:0:0:1:1:0:0:0:0:0:0:0:0:0:0:1:0:1:1:1:0:0:1:0:0:0:1:2:1:0:0:1:0:0:0:0:0:3:0:1:1", endOnFailure: true }
 Counterexample: [4194867847541098797699n]
 Shrunk 77 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [-18n]
@@ -825,13 +783,6 @@ exports[`NoRegression BigInt bigUint 1`] = `
 { seed: 42, path: "0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:1:0:0:0:0:1:0:0:0:0:0:2:0:0:0:4:0:0:2:0:1:1:1:1:0:0:0:0:0:0:1:0:1:0:1:0", endOnFailure: true }
 Counterexample: [85075794168298103635341375769565987988n]
 Shrunk 232 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [115792089237316195423570985008687907853269984665640564039457584007913129639892n]
@@ -1099,13 +1050,6 @@ exports[`NoRegression BigInt bigUint({max}) 1`] = `
 { seed: 42, path: "0:1:0:0:0:0:0:0:0:1:0:0:0:1:0:1:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:3:0:0:1:1:1:1:2:0:2:0:0:1:0:1:2:2:0:1:3", endOnFailure: true }
 Counterexample: [160187393467674982176938799n]
 Shrunk 70 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [79228162514264337593543950321n]
@@ -1214,13 +1158,6 @@ exports[`NoRegression BigInt bigUint64Array 1`] = `
 { seed: 42, path: "1:1:0:0:2:1:1:1:1:1:2:1:2:2:1:1:1:2:1:1:2:1:1:2:3:1:1:2:3:1:1:3:3:1:1:2:2:1:1:3:1:1:1:1:4:1", endOnFailure: true }
 Counterexample: [BigUint64Array.from([148057437989876990n])]
 Shrunk 45 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [BigUint64Array.from([])]
@@ -1345,13 +1282,6 @@ exports[`NoRegression BigInt bigUintN 1`] = `
 { seed: 42, path: "0:1:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:1:0:1:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:0:0:0:0:0:0:3:0:0:1:1:1:1:2:0:2:0:0:1:0:1:2:2:0:1:3", endOnFailure: true }
 Counterexample: [160187393467674982176938799n]
 Shrunk 74 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m [1267650600228229401496703205352n]
@@ -1464,13 +1394,6 @@ exports[`NoRegression BigInt mixedCase 1`] = `
 { seed: 42, path: "0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:2", endOnFailure: true }
 Counterexample: ["cCbAabBAcaBCcCACcABaCAaAabBAcaBcBB"]
 Shrunk 29 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [31m×[0m ["CCbaabbaCabCccaCcaBAcaAAABbaCabCbb"]
@@ -1515,13 +1438,6 @@ exports[`NoRegression BigInt mixedCase(stringOf) 1`] = `
 { seed: 42, path: "2:6:2", endOnFailure: true }
 Counterexample: ["aa"]
 Shrunk 2 time(s)
-Got error: Property failed by returning false
-    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
-    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
-    at assert (packages/fast-check/test/e2e/NoRegressionBigInt.spec.ts:?:?)
-    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
 
 Execution summary:
 [32m√[0m [""]

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegressionStack.spec.ts.snap
@@ -1,6 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NoRegressionStack not a function 1`] = `
+exports[`NoRegressionStack (includeErrorInReport: false) not a function 1`] = `
+"Property failed after 1 tests
+{ seed: 42, path: "0:0", endOnFailure: true }
+Counterexample: [0]
+Shrunk 1 time(s)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack (includeErrorInReport: false) return false 1`] = `
+"Property failed after 2 tests
+{ seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: [0,1]
+Shrunk 32 time(s)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack (includeErrorInReport: false) throw 1`] = `
+"Property failed after 2 tests
+{ seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: [0,1]
+Shrunk 32 time(s)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack (includeErrorInReport: true) not a function 1`] = `
 "Property failed after 1 tests
 { seed: 42, path: "0:0", endOnFailure: true }
 Counterexample: [0]
@@ -18,7 +45,23 @@ Got TypeError: v is not a function
 Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
 `;
 
-exports[`NoRegressionStack throw 1`] = `
+exports[`NoRegressionStack (includeErrorInReport: true) return false 1`] = `
+"Property failed after 2 tests
+{ seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
+Counterexample: [0,1]
+Shrunk 32 time(s)
+Got error: Property failed by returning false
+    at Property.run (packages/fast-check/src/check/property/Property.generic.ts:?:?)
+    at run (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at runIt (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at Object.check (packages/fast-check/src/check/runner/Runner.ts:?:?)
+    at assert (packages/fast-check/test/e2e/NoRegressionStack.spec.ts:?:?)
+    at run (packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts:?:?)
+
+Hint: Enable verbose mode in order to have the list of all failing values encountered during the run"
+`;
+
+exports[`NoRegressionStack (includeErrorInReport: true) throw 1`] = `
 "Property failed after 2 tests
 { seed: 42, path: "1:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0", endOnFailure: true }
 Counterexample: [0,1]

--- a/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
+++ b/packages/fast-check/test/e2e/__test-helpers__/StackSanitizer.ts
@@ -17,13 +17,16 @@ function sanitizeStack(initialMessage: string) {
   return lines.filter((line) => !line.includes('node:internal')).join('\n');
 }
 
+type ErrorWithCause = Error & { cause: unknown };
+const ErrorWithCause: new (message: string | undefined, options: { cause: unknown }) => Error = Error;
+
 /** Wrap a potentially throwing code within a caller that would sanitize the returned Error */
 export function runWithSanitizedStack(run: () => void) {
   return (): void => {
     try {
       run();
     } catch (err) {
-      throw new Error(sanitizeStack((err as Error).message));
+      throw new ErrorWithCause(sanitizeStack((err as Error).message), { cause: (err as ErrorWithCause).cause });
     }
   };
 }
@@ -34,7 +37,7 @@ export function asyncRunWithSanitizedStack(run: () => Promise<void>) {
     try {
       await run();
     } catch (err) {
-      throw new Error(sanitizeStack((err as Error).message));
+      throw new ErrorWithCause(sanitizeStack((err as Error).message), { cause: (err as ErrorWithCause).cause });
     }
   };
 }

--- a/packages/fast-check/test/unit/check/runner/Runner.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/Runner.spec.ts
@@ -617,8 +617,19 @@ describe('Runner', () => {
         `[[${v1.toString()},${JSON.stringify(v2)}],${JSON.stringify(v2)},${v1.toString()}]`,
       );
     });
-    it('Should put the orginal error in error message', () => {
-      expect(() => rAssert(failingProperty, { seed: 42 })).toThrowError(`Got error: error in failingProperty`);
+    it('Should put the original error as cause', () => {
+      expect(() => {
+        try {
+          rAssert(failingProperty, { seed: 42 });
+        } catch (err) {
+          throw (err as any).cause;
+        }
+      }).toThrowError(`Got error: error in failingProperty`);
+    });
+    it('Should put the original error in error message when includeErrorInReport', () => {
+      expect(() => rAssert(failingProperty, { seed: 42, includeErrorInReport: true })).toThrowError(
+        `Got error: error in failingProperty`,
+      );
     });
     describe('Impact of VerbosityLevel in case of failure', () => {
       const baseErrorMessage = '';

--- a/packages/fast-check/test/unit/check/runner/Runner.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/Runner.spec.ts
@@ -624,7 +624,7 @@ describe('Runner', () => {
         } catch (err) {
           throw (err as any).cause;
         }
-      }).toThrowError(`Got error: error in failingProperty`);
+      }).toThrowError('error in failingProperty');
     });
     it('Should put the original error in error message when includeErrorInReport', () => {
       expect(() => rAssert(failingProperty, { seed: 42, includeErrorInReport: true })).toThrowError(

--- a/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
@@ -25,7 +25,7 @@ const parametersArbitrary = fc.record(
     endOnFailure: fc.boolean(),
     reporter: fc.func(fc.constant(undefined)),
     asyncReporter: fc.func(fc.constant(Promise.resolve(undefined))),
-    errorWithCause: fc.boolean(),
+    includeErrorInReport: fc.boolean(),
   },
   { requiredKeys: [] },
 );

--- a/packages/worker/test/e2e/__test-helpers__/ThrowWithCause.ts
+++ b/packages/worker/test/e2e/__test-helpers__/ThrowWithCause.ts
@@ -1,0 +1,10 @@
+export async function expectThrowWithCause(
+  promise: Promise<unknown>,
+  errorCause: string | RegExp | Error,
+): Promise<void> {
+  await expect(
+    promise.catch((err) => {
+      throw (err as any).cause;
+    }),
+  ).rejects.toThrowError(errorCause);
+}

--- a/packages/worker/test/e2e/blockEventLoop.spec.ts
+++ b/packages/worker/test/e2e/blockEventLoop.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@fast-check/worker';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { blockEventLoopProperty } from './__properties__/blockEventLoop.cjs';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -20,7 +21,7 @@ if (isMainThread) {
         const expectedError = /Property timeout: exceeded limit of 1000 milliseconds/;
 
         // Act / Assert
-        await expect(assert(blockEventLoopProperty, options)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(blockEventLoopProperty, options), expectedError);
       },
       jestTimeout,
     );

--- a/packages/worker/test/e2e/failing.spec.ts
+++ b/packages/worker/test/e2e/failing.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@fast-check/worker';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { failingProperty } from './__properties__/failing.cjs';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -19,7 +20,7 @@ if (isMainThread) {
         const expectedError = /I'm a failing property/;
 
         // Act / Assert
-        await expect(assert(failingProperty, defaultOptions)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(failingProperty, defaultOptions), expectedError);
       },
       jestTimeout,
     );

--- a/packages/worker/test/e2e/noWorker.spec.ts
+++ b/packages/worker/test/e2e/noWorker.spec.ts
@@ -1,6 +1,7 @@
 import { isMainThread } from 'node:worker_threads';
 import fc, { type Parameters } from 'fast-check';
 import { assert } from '@fast-check/worker';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -36,7 +37,7 @@ if (isMainThread) {
         const expectedError = /Property failed by returning false/;
 
         // Act / Assert
-        await expect(assert(property, defaultOptions)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(property, defaultOptions), expectedError);
       },
       jestTimeout,
     );

--- a/packages/worker/test/e2e/predicateIsolation.spec.ts
+++ b/packages/worker/test/e2e/predicateIsolation.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@fast-check/worker';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { predicateIsolation } from './__properties__/predicateIsolation.cjs';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -32,7 +33,7 @@ if (isMainThread) {
         const expectedError = /Encounter counters: property, for isolation level: property/;
 
         // Act / Assert
-        await expect(assert(predicateIsolation.propertyLevel, options)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(predicateIsolation.propertyLevel, options), expectedError);
       },
       jestTimeout,
     );
@@ -45,7 +46,7 @@ if (isMainThread) {
         const expectedError = /Encounter counters: file, for isolation level: file/;
 
         // Act / Assert
-        await expect(assert(predicateIsolation.fileLevel, options)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(predicateIsolation.fileLevel, options), expectedError);
       },
       jestTimeout,
     );

--- a/packages/worker/test/e2e/propertyIsolation.spec.ts
+++ b/packages/worker/test/e2e/propertyIsolation.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@fast-check/worker';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { propertyIsolation } from './__properties__/propertyIsolation.cjs';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -45,7 +46,7 @@ if (isMainThread) {
         await expect(assert(propertyIsolation.fileLevelWarmUp, defaultOptions)).resolves.not.toThrow();
 
         // Act / Assert
-        await expect(assert(propertyIsolation.fileLevelRun, defaultOptions)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(propertyIsolation.fileLevelRun, defaultOptions), expectedError);
       },
       jestTimeout,
     );

--- a/packages/worker/test/e2e/unregistered.spec.ts
+++ b/packages/worker/test/e2e/unregistered.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@fast-check/worker';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import { buildUnregisteredProperty } from './__properties__/unregistered.cjs';
+import { expectThrowWithCause } from './__test-helpers__/ThrowWithCause';
 
 if (isMainThread) {
   describe('@fast-check/worker', () => {
@@ -20,7 +21,7 @@ if (isMainThread) {
         const expectedError = /Unregistered predicate/;
 
         // Act / Assert
-        await expect(assert(unregisteredProperty, defaultOptions)).rejects.toThrowError(expectedError);
+        await expectThrowWithCause(assert(unregisteredProperty, defaultOptions), expectedError);
       },
       jestTimeout,
     );


### PR DESCRIPTION
**💥 Breaking change**

Until now, fast-check have been merging the content and stack of the original Error that caused the property to fail into its own Error. With the recent (2022) introduction of cause on Errors, this complex logic can be dropped in favor of the native cause mechanism.

This PR makes cause mode the default. Before this PR, toggling it was possible via `errorWithCause: true` on `fc.assert`.

Given not all test runners properly support causes attached to the Error, we offer a fallback for users willing to preserve the old behaviour. It can be toggled via `includeErrorInReport: true` on `fc.assert`.

Related to #4416.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
