### PR TITLE
🐛 Also produce null-prototype at root level of generated `object` when requested to

### DIFF
--- a/.yarn/versions/64364831.yml
+++ b/.yarn/versions/64364831.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/object.ts
+++ b/packages/fast-check/src/arbitrary/object.ts
@@ -10,6 +10,7 @@ export type { ObjectConstraints };
 function objectInternal(constraints: QualifiedObjectConstraints): Arbitrary<Record<string, unknown>> {
   return dictionary(constraints.key, anyArbitraryBuilder(constraints), {
     maxKeys: constraints.maxKeys,
+    noNullPrototype: !constraints.withNullPrototype,
     size: constraints.size,
   });
 }


### PR DESCRIPTION
Our current implementation of `fc.object` with `withNullPrototype: true` was not producing any null-prototype instances at the root. With that fix, it will now produce some.

As the change fixes a slightly minor bug that could cause replays to break (the version including it, would not replay to the same values), it might not be included into a patch but wait for a minor).

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [x] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [x] Generated values
- [x] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
