### PR TITLE
📝 Add `idonttrustlikethat-fast-check` in ecosystem.md

### DIFF
--- a/.yarn/versions/3036316f.yml
+++ b/.yarn/versions/3036316f.yml
@@ -1,0 +1,11 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/expect-type"
+  - "@fast-check/jest"
+  - "@fast-check/packaged"
+  - "@fast-check/poisoning"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/website/docs/ecosystem.md
+++ b/website/docs/ecosystem.md
@@ -148,6 +148,17 @@ More details on the [package itself](https://www.npmjs.com/package/jsverify-to-f
 Convert [io-ts validators](https://gcanti.github.io/io-ts/) into arbitraries for fast-check.  
 More details on the [package itself](https://www.npmjs.com/package/mock-data-gen)!
 
+### `idonttrustlikethat-fast-check` ⚠️
+
+![npm version](https://badge.fury.io/js/idonttrustlikethat-fast-check.svg)
+![monthly downloads](https://img.shields.io/npm/dm/idonttrustlikethat-fast-check)
+![last commit](https://img.shields.io/github/last-commit/nielk/idonttrustlikethat-fast-check)
+![license](https://img.shields.io/npm/l/idonttrustlikethat-fast-check.svg)
+![third party package](https://img.shields.io/badge/-third%20party%20package-%2300abff.svg)
+
+Convert [idonttrustlikethat validators](https://github.com/AlexGalays/idonttrustlikethat) into arbitraries for fast-check.  
+More details on the [package itself](https://www.npmjs.com/package/idonttrustlikethat-fast-check)!
+
 ## Test runners
 
 Although not designed for any particular test runners, some users prefer to have complete integration of fast-check within their preferred test runner. To meet these needs, we have compiled a list of packages that serve as the bridge between your favorite test runner and fast-check.


### PR DESCRIPTION
Hello from Nantes 🐘 !

First off all, thanks for this incredible library !

I made a connector for [idonttrustlikethat](https://github.com/AlexGalays/idonttrustlikethat), it converts validators into arbitraries. Do you mind if I add it to the ecosystem documentation page ?

**_Category:_**

- [ ] ✨ Introduce new features
- [x] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...

**_Potential impacts:_**

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
