### PR TITLE
🔥 Un-export internals found by Knip

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/builders/CharacterRangeArbitraryBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/builders/CharacterRangeArbitraryBuilder.ts
@@ -41,7 +41,7 @@ export const buildLowerAlphaNumericArbitrary = (others: string[]): Arbitrary<str
   mapToConstant(lowerCaseMapper, numericMapper, { num: others.length, build: (v) => others[v] });
 
 /** @internal */
-export const buildAlphaNumericArbitrary = (others: string[]): Arbitrary<string> =>
+const buildAlphaNumericArbitrary = (others: string[]): Arbitrary<string> =>
   mapToConstant(lowerCaseMapper, upperCaseMapper, numericMapper, { num: others.length, build: (v) => others[v] });
 
 /** @internal */

--- a/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/UintToBase32String.ts
@@ -91,7 +91,7 @@ function smallUintToBase32StringMapper(num: number): string {
 }
 
 /** @internal */
-export function uintToBase32StringMapper(num: number, paddingLength: number): string {
+function uintToBase32StringMapper(num: number, paddingLength: number): string {
   const head = ~~(num / 0x40000000);
   const tail = num & 0x3fffffff;
   return pad(smallUintToBase32StringMapper(head), paddingLength - 6) + pad(smallUintToBase32StringMapper(tail), 6);

--- a/packages/fast-check/src/utils/stringify.ts
+++ b/packages/fast-check/src/utils/stringify.ts
@@ -132,7 +132,7 @@ function isSparseArray(arr: unknown[]): boolean {
 }
 
 /** @internal */
-export function stringifyInternal<Ts>(
+function stringifyInternal<Ts>(
   value: Ts,
   previousValues: any[],
   getAsyncContent: (p: Promise<unknown> | WithAsyncToStringMethod) => AsyncContent,


### PR DESCRIPTION
As our next major is close enough, let's wait it to drop such internals from the exports. Even if they are not linked to any officially exposed entry-points they might be referenced by some users.

Fixes #4552

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
