### PR TITLE
👷(worker) Move build chain to ESM

### DIFF
--- a/.yarn/versions/a0f8cbb4.yml
+++ b/.yarn/versions/a0f8cbb4.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/worker": minor
+
+declined:
+  - "@fast-check/jest"

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -63,9 +63,11 @@ const property = propertyFor(new URL(import.meta.url), { isolationLevel: 'predic
 
 ## Minimal requirements
 
-- Node ≥14.18.0<sup>(1)</sup><sup>(2)</sup>
+- Node ≥14.18.0<sup>(1)</sup><sup>(2)</sup><sup>(3)</sup>
 - TypeScript ≥4.1 (optional)
 
 _(1): `worker_threads` alone would only require Node ≥10.5.0, but our usage of `require(node:*)` forces us to request at least Node ≥14.18.0_
 
 _(2): this package targets ES2020 specification which is quite well supported (more than 94%) by any Node ≥14.5.0_
+
+_(3): this package requires a version of node able to understand `package.json#exports`, supported by any Node ≥12.17.0_

--- a/packages/worker/package.cjs-template.json
+++ b/packages/worker/package.cjs-template.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/worker/package.esm-template.json
+++ b/packages/worker/package.esm-template.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -2,22 +2,22 @@
   "name": "@fast-check/worker",
   "description": "Provide built-ins to run predicates directly within dedicated workers",
   "version": "0.1.1",
-  "type": "commonjs",
+  "type": "module",
   "main": "lib/main.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "require": {
-        "types": "./lib/main.d.ts",
-        "default": "./lib/main.js"
+        "types": "./lib/cjs/main.d.ts",
+        "default": "./lib/cjs/main.js"
       },
       "import": {
-        "types": "./lib/esm/main.d.ts",
-        "default": "./lib/esm/main.js"
+        "types": "./lib/main.d.ts",
+        "default": "./lib/main.js"
       }
     }
   },
-  "module": "lib/esm/main.js",
+  "module": "lib/main.js",
   "types": "lib/main.d.ts",
   "files": [
     "lib"
@@ -25,10 +25,10 @@
   "scripts": {
     "build": "yarn build:publish-cjs && yarn build:publish-esm && yarn build:publish-types",
     "build-ci": "yarn build",
-    "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/esm",
-    "build:publish-cjs": "tsc -p tsconfig.publish.json",
-    "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm && cp package.esm-template.json lib/esm/package.json",
-    "test": "jest",
+    "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/cjs",
+    "build:publish-cjs": "tsc -p tsconfig.publish.json --outDir lib/cjs && cp package.cjs-template.json lib/cjs/package.json",
+    "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node",
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
     "test-bundle:cjs": "node test-bundle/main.cjs",
     "test-bundle:mjs": "node test-bundle/main.mjs",
     "test-bundle": "yarn test-bundle:cjs && yarn test-bundle:mjs",


### PR DESCRIPTION
The build chain of `@fast-check/worker` has been CommonJS-based since day 1. With ESM moving forward in the ecosystem, it's time to move ourselves to the new standard and adapt our build chains to ESM.

Unfortunately it may have some subtle impacts on our users as our package will not be a CJS one offering a ESM fallback anymore. I will rather be the opposite: an ESM package with a fallback to CJS. It implies that we moved ESM related files closer to the root of the package (we could have kept them in esm/) and moved the CJS ones further in the file structure (we had to move them).

Another subtle impact is that it would impose our users to run at least Node ≥12.17.0. But it was already a requirement for this package.

As such we consider it as a breaking change.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
