### PR TITLE
👷(expect-type) Move build chain to ESM

### DIFF
--- a/.yarn/versions/e8f05fd9.yml
+++ b/.yarn/versions/e8f05fd9.yml
@@ -1,0 +1,5 @@
+releases:
+  "@fast-check/expect-type": minor
+
+declined:
+  - fast-check

--- a/packages/expect-type/.gitignore
+++ b/packages/expect-type/.gitignore
@@ -1,1 +1,1 @@
-src/esm/**/*.d.ts
+src/cjs/**/*.d.ts

--- a/packages/expect-type/package.json
+++ b/packages/expect-type/package.json
@@ -2,22 +2,22 @@
   "name": "@fast-check/expect-type",
   "description": "Make sure your types are the ones you expect (similar to tsd)",
   "version": "0.1.0",
-  "type": "commonjs",
+  "type": "module",
   "main": "src/main.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "require": {
-        "types": "./src/main.d.ts",
-        "default": "./src/main.js"
+        "types": "./src/cjs/main.d.ts",
+        "default": "./src/cjs/main.js"
       },
       "import": {
-        "types": "./src/esm/main.d.ts",
-        "default": "./src/esm/main.js"
+        "types": "./src/main.d.ts",
+        "default": "./src/main.js"
       }
     }
   },
-  "module": "src/esm/main.js",
+  "module": "src/main.js",
   "types": "src/main.d.ts",
   "files": [
     "src"
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "yarn build:publish-types",
     "build-ci": "yarn build",
-    "build:publish-types": "cp src/*.d.ts src/esm/",
+    "build:publish-types": "cp src/*.d.ts src/cjs/",
     "test": "tsc --noEmit",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/expect-type/src/cjs/main.js
+++ b/packages/expect-type/src/cjs/main.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/no-empty-function */
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.expectType = function expectType() {
+  return function () {};
+};
+exports.expectTypeAssignable = function expectTypeAssignable() {
+  return function () {};
+};

--- a/packages/expect-type/src/cjs/package.json
+++ b/packages/expect-type/src/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/expect-type/src/esm/main.js
+++ b/packages/expect-type/src/esm/main.js
@@ -1,8 +1,0 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-/* eslint-disable @typescript-eslint/no-empty-function */
-export function expectType() {
-  return function () {};
-}
-export function expectTypeAssignable() {
-  return function () {};
-}

--- a/packages/expect-type/src/esm/package.json
+++ b/packages/expect-type/src/esm/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/packages/expect-type/src/main.js
+++ b/packages/expect-type/src/main.js
@@ -1,10 +1,8 @@
-/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-empty-function */
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-exports.expectType = function expectType() {
+export function expectType() {
   return function () {};
-};
-exports.expectTypeAssignable = function expectTypeAssignable() {
+}
+export function expectTypeAssignable() {
   return function () {};
-};
+}


### PR DESCRIPTION
The build chain of `@fast-check/expect-type` has been CommonJS-based since day 1. With ESM moving forward in the ecosystem, it's time to move ourselves to the new standard and adapt our build chains to ESM.

Unfortunately it may have some subtle impacts on our users as our package will not be a CJS one offering a ESM fallback anymore. I will rather be the opposite: an ESM package with a fallback to CJS. It implies that we moved ESM related files closer to the root of the package (we could have kept them in esm/) and moved the CJS ones further in the file structure (we had to move them).

Another subtle impact is that it would impose our users to run at least Node ≥12.17.0.

As such we consider it as a breaking change.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
