### PR TITLE
👷(ava) Move build chain to ESM

### DIFF
--- a/packages/ava/package.cjs-template.json
+++ b/packages/ava/package.cjs-template.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/ava/package.esm-template.json
+++ b/packages/ava/package.esm-template.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -28,7 +28,7 @@
     "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/cjs",
     "build:publish-cjs": "tsc -p tsconfig.publish.json --outDir lib/cjs && cp package.cjs-template.json lib/cjs/package.json",
     "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node",
-    "ava-test": "ava --config test/ava.config.cjs -s -t",
+    "ava-test": "ava --config test/ava.config.js -s -t",
     "test": "sh test.sh",
     "test-bundle:cjs": "ava --config test-bundle/ava.config.cjs",
     "test-bundle:mjs": "ava --config test-bundle/ava.config.mjs",

--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -2,22 +2,22 @@
   "name": "@fast-check/ava",
   "description": "Property based testing for AVA based on fast-check",
   "version": "1.2.1",
-  "type": "commonjs",
+  "type": "module",
   "main": "lib/ava-fast-check.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "require": {
-        "types": "./lib/ava-fast-check.d.ts",
-        "default": "./lib/ava-fast-check.js"
+        "types": "./lib/cjs/ava-fast-check.d.ts",
+        "default": "./lib/cjs/ava-fast-check.js"
       },
       "import": {
-        "types": "./lib/esm/ava-fast-check.d.ts",
-        "default": "./lib/esm/ava-fast-check.js"
+        "types": "./lib/ava-fast-check.d.ts",
+        "default": "./lib/ava-fast-check.js"
       }
     }
   },
-  "module": "lib/esm/ava-fast-check.js",
+  "module": "lib/ava-fast-check.js",
   "types": "lib/ava-fast-check.d.ts",
   "files": [
     "lib"
@@ -25,9 +25,9 @@
   "scripts": {
     "build": "yarn build:publish-cjs && yarn build:publish-esm && yarn build:publish-types",
     "build-ci": "yarn build",
-    "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/esm",
-    "build:publish-cjs": "tsc -p tsconfig.publish.json",
-    "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node --outDir lib/esm && cp package.esm-template.json lib/esm/package.json",
+    "build:publish-types": "tsc -p tsconfig.publish.types.json && tsc -p tsconfig.publish.types.json --outDir lib/cjs",
+    "build:publish-cjs": "tsc -p tsconfig.publish.json --outDir lib/cjs && cp package.cjs-template.json lib/cjs/package.json",
+    "build:publish-esm": "tsc -p tsconfig.publish.json --module es2015 --moduleResolution node",
     "ava-test": "ava --config test/ava.config.cjs -s -t",
     "test": "sh test.sh",
     "test-bundle:cjs": "ava --config test-bundle/ava.config.cjs",

--- a/packages/ava/test/ava.config.cjs
+++ b/packages/ava/test/ava.config.cjs
@@ -1,1 +1,0 @@
-module.exports = { files: ['test/testProp.js'] };

--- a/packages/ava/test/ava.config.js
+++ b/packages/ava/test/ava.config.js
@@ -1,0 +1,1 @@
+export default { files: ['test/testProp.js'] };

--- a/packages/ava/test/testProp.js
+++ b/packages/ava/test/testProp.js
@@ -1,7 +1,5 @@
-// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
-const { testProp, fc } = require('../lib/ava-fast-check');
-// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
-const { Observable, map } = require('rxjs');
+import { testProp, fc }  from '../lib/ava-fast-check';
+import { Observable, map } from 'rxjs';
 
 const delay = (duration) =>
   new Promise((resolve) => {

--- a/packages/ava/test/testProp.js
+++ b/packages/ava/test/testProp.js
@@ -1,4 +1,4 @@
-import { testProp, fc }  from '../lib/ava-fast-check';
+import { testProp, fc } from '../lib/ava-fast-check.js';
 import { Observable, map } from 'rxjs';
 
 const delay = (duration) =>


### PR DESCRIPTION
**⚠️ Minor breaking change**

The build chain of `@fast-check/ava` has been CommonJS-based since day 1. With ESM moving forward in the ecosystem, it's time to move ourselves to the new standard and adapt our build chains to ESM.

Unfortunately it may have some subtle impacts on our users as our package will not be a CJS one offering a ESM fallback anymore. I will rather be the opposite: an ESM package with a fallback to CJS. It implies that we moved ESM related files closer to the root of the package (we could have kept them in esm/) and moved the CJS ones further in the file structure (we had to move them).

Another subtle impact is that it would impose our users to run at least Node ≥12.17.0. But it was already a requirement due to ava itself: https://github.com/avajs/ava/blob/v4.0.0/package.json#L23C1-L25C4.

As such we consider it as a breaking change.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
