### PR TITLE
✅ Fix `isCorrect` check on double

### DIFF
--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -285,14 +285,24 @@ describe('double (integration)', () => {
     }
     if (extra.min !== undefined && !Number.isNaN(v)) {
       if (extra.minExcluded) {
-        expect(v).toBeGreaterThan(extra.min); // should always be strictly greater than min when specified
+        if (Object.is(extra.min, -0)) {
+          expect(v).not.toBe(-0);
+          expect(v).toBeGreaterThanOrEqual(extra.min);
+        } else {
+          expect(v).toBeGreaterThan(extra.min); // should always be strictly greater than min when specified
+        }
       } else {
         expect(v).toBeGreaterThanOrEqual(extra.min); // should always be greater than min when specified
       }
     }
     if (extra.max !== undefined && !Number.isNaN(v)) {
       if (extra.maxExcluded) {
-        expect(v).toBeLessThan(extra.max); // should always be strictly smaller than max when specified
+        if (Object.is(extra.min, +0)) {
+          expect(v).not.toBe(+0);
+          expect(v).toBeLessThanOrEqual(extra.max);
+        } else {
+          expect(v).toBeLessThan(extra.max); // should always be strictly smaller than max when specified
+        }
       } else {
         expect(v).toBeLessThanOrEqual(extra.max); // should always be smaller than max when specified
       }
@@ -325,7 +335,7 @@ describe('double (integration)', () => {
   });
 
   it('should only produce correct values', () => {
-    assertProduceCorrectValues(doubleBuilder, isCorrect, { extraParameters });
+    assertProduceCorrectValues(doubleBuilder, isCorrect, { extraParameters, assertParameters: { seed: 339726521 } });
   });
 
   it('should produce values seen as shrinkable without any context', () => {


### PR DESCRIPTION
The check has been used for a while in the tests of double. Unfortunately it poorly behave with -0/+0.

We just make it even more stable by fixing this subtle special case.

Fixes #4564

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
