### PR TITLE
💄 Add extra spacing on top of CTA

### DIFF
--- a/website/src/components/HomepageHeader/styles.module.css
+++ b/website/src/components/HomepageHeader/styles.module.css
@@ -20,6 +20,10 @@
   }
 }
 
+.subTitle {
+  margin-bottom: 1.25rem;
+}
+
 .subTitle .taglineBadges {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Before the fix #4712, the Call To Action (aka CTA) for "Quick Start - 5min" used to be after a 1.25rem spacing (20px).

The fix, dropped that spacing putting the CTA button to close from its preceding title. We just put back (part of) this spacing.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
