### PR TITLE
🐛 Better rejection handling in `scheduleSequence`

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
+++ b/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
@@ -157,24 +157,24 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     let resolveSequenceTask = () => {};
     const sequenceTask = new Promise<void>((resolve) => (resolveSequenceTask = resolve));
 
-    const onDone = () => {
-      status.done = true;
-      resolveSequenceTask();
-    };
-    const onFaulty = () => {
+    const onFaultyItemNoThrow = () => {
       status.faulty = true;
       resolveSequenceTask();
     };
-    const onFaultyNoop = () => {
-      /* Discarding UnhandledPromiseRejectionWarning */
-      /* No need to call resolveSequenceTask as it should already have been triggered */
+    const onFaultyItem = (error: unknown) => {
+      onFaultyItemNoThrow(); // Faulty must resolve sequence as soon as possible without any extra then
+      throw error; // Faulty must stay faulty to avoid calling next items
+    };
+    const onDone = () => {
+      status.done = true;
+      resolveSequenceTask();
     };
 
     let previouslyScheduled = dummyResolvedPromise;
     for (const item of sequenceBuilders) {
       const [builder, label, metadata] =
         typeof item === 'function' ? [item, item.name, undefined] : [item.builder, item.label, item.metadata];
-      const onNext = () => {
+      const onNextItem = () => {
         // We schedule a successful promise that will trigger builder directly when triggered
         const scheduled = this.scheduleInternal(
           'sequence',
@@ -184,12 +184,16 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
           customAct || defaultSchedulerAct,
           () => builder(),
         );
-        scheduled.catch(onFaulty);
         return scheduled;
       };
-      previouslyScheduled = previouslyScheduled.then(onNext);
+      // We will run current item if and only if the one preceeding it succeeds
+      // Otherwise, we mark the run as "failed" and ignore any subsequent item (including this one)
+      previouslyScheduled = previouslyScheduled.then(onNextItem, onFaultyItem);
     }
-    previouslyScheduled.then(onDone, onFaultyNoop);
+    // Once last item is done, the full sequence can be considered as successful
+    // If it failed (or any preceeding one failed), then the sequence should be marked as failed (already marked for others)
+    // We always handle Promise rejection of previouslyScheduled internally, in other words no error will bubble outside
+    previouslyScheduled.then(onDone, onFaultyItemNoThrow);
 
     // TODO Prefer getter instead of sharing the variable itself
     //      Would need to stop supporting <es5


### PR DESCRIPTION
**👀 Potentially risky** (risk: low)

The PR #4714 started to rewrite part of the method to make it easier to evolve. In its original implementation each scheduled item was defining its own error handling on the side and a global error handing was responsible to capture any last crash.

This new approach puts the local item-related error handling in the then-sequence and not forked from it.

In theory, it should not break anything, but as it plays with Promises we can have unwantingly added some extra then step or dropped one. As such it should probably not be released outside of a minor or major version.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
