### PR TITLE
⚡️ Faster scheduling of `scheduleSequence`

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
+++ b/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
@@ -155,27 +155,30 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     // Placeholder resolver, immediately replaced by the one retrieved in `new Promise`
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     let resolveSequenceTask = () => {};
-    const sequenceTask = new Promise<void>((resolve) => (resolveSequenceTask = resolve));
+    const sequenceTask = new Promise<{ done: boolean; faulty: boolean }>((resolve) => {
+      resolveSequenceTask = () => resolve({ done: status.done, faulty: status.faulty });
+    });
 
     const onFaultyItemNoThrow = () => {
       status.faulty = true;
       resolveSequenceTask();
-    };
-    const onFaultyItem = (error: unknown) => {
-      onFaultyItemNoThrow(); // Faulty must resolve sequence as soon as possible without any extra then
-      throw error; // Faulty must stay faulty to avoid calling next items
     };
     const onDone = () => {
       status.done = true;
       resolveSequenceTask();
     };
 
-    let previouslyScheduled = dummyResolvedPromise;
-    for (const item of sequenceBuilders) {
-      const [builder, label, metadata] =
-        typeof item === 'function' ? [item, item.name, undefined] : [item.builder, item.label, item.metadata];
-      const onNextItem = () => {
-        // We schedule a successful promise that will trigger builder directly when triggered
+    const registerNextBuilder = (index: number, previous: PromiseLike<unknown>) => {
+      if (index >= sequenceBuilders.length) {
+        // All builders have been scheduled, we handle termination:
+        // if the last one succeeds then we are done, if it fails then the sequence should be marked as failed
+        previous.then(onDone, onFaultyItemNoThrow);
+        return;
+      }
+      previous.then(() => {
+        const item = sequenceBuilders[index];
+        const [builder, label, metadata] =
+          typeof item === 'function' ? [item, item.name, undefined] : [item.builder, item.label, item.metadata];
         const scheduled = this.scheduleInternal(
           'sequence',
           label,
@@ -184,16 +187,11 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
           customAct || defaultSchedulerAct,
           () => builder(),
         );
-        return scheduled;
-      };
-      // We will run current item if and only if the one preceeding it succeeds
-      // Otherwise, we mark the run as "failed" and ignore any subsequent item (including this one)
-      previouslyScheduled = previouslyScheduled.then(onNextItem, onFaultyItem);
-    }
-    // Once last item is done, the full sequence can be considered as successful
-    // If it failed (or any preceeding one failed), then the sequence should be marked as failed (already marked for others)
-    // We always handle Promise rejection of previouslyScheduled internally, in other words no error will bubble outside
-    previouslyScheduled.then(onDone, onFaultyItemNoThrow);
+        registerNextBuilder(index + 1, scheduled);
+      }, onFaultyItemNoThrow);
+    };
+
+    registerNextBuilder(0, dummyResolvedPromise);
 
     // TODO Prefer getter instead of sharing the variable itself
     //      Would need to stop supporting <es5
@@ -201,11 +199,7 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     //   get done() { return status.done },
     //   get faulty() { return status.faulty }
     // };
-    return Object.assign(status, {
-      task: Promise.resolve(sequenceTask).then(() => {
-        return { done: status.done, faulty: status.faulty };
-      }),
-    });
+    return Object.assign(status, { task: sequenceTask });
   }
 
   count(): number {


### PR DESCRIPTION
**👀 Potentially risky** (risk: low)

With #3891, our target is to make scheduling faster. Scheduling is one of the built-in arbitrary provided by fast-check. It aims to ease detection of race-conditions by offering a simple way to detect such issues in your code.

Up-to-now the code was doing a bit too many await/then letting it give back the hand many times in a row while it could have been faster to take it back. Additionally, this past behaviour (that we are trying to fix with many PRs) used to be strange as awaiting 1 was ok, but 10-times was not. More precisely there was a number of await working and passed this number it stopped to work as usual and users started to need to use other approaches (drop the `waitAll`).

This set of PRs not only addresses a potential perf concern but also clarify what should work so that it appears more determistic for the final users.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [x] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
