### PR TITLE
⚡️ Speed-up race-condition schedulers

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
+++ b/packages/fast-check/src/arbitrary/_internals/implementations/SchedulerImplem.ts
@@ -18,8 +18,7 @@ type TriggeredTask<TMetaData> = {
 /** @internal */
 export type ScheduledTask<TMetaData> = {
   original: PromiseLike<unknown>;
-  scheduled: PromiseLike<unknown>;
-  trigger: () => void;
+  trigger: () => Promise<unknown>;
   schedulingType: 'promise' | 'function' | 'sequence';
   taskId: number;
   label: string;
@@ -86,27 +85,26 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     customAct: SchedulerAct,
     thenTaskToBeAwaited?: () => PromiseLike<T>,
   ): Promise<T> {
-    let trigger: (() => void) | null = null;
     const taskId = ++this.lastTaskId;
+    let trigger: (() => Promise<unknown>) | undefined = undefined;
     const scheduledPromise = new Promise<T>((resolve, reject) => {
       trigger = () => {
-        (thenTaskToBeAwaited ? task.then(() => thenTaskToBeAwaited()) : task).then(
+        const promise = Promise.resolve(thenTaskToBeAwaited ? task.then(() => thenTaskToBeAwaited()) : task);
+        promise.then(
           (data) => {
             this.log(schedulingType, taskId, label, metadata, 'resolved', data);
-            return resolve(data);
+            resolve(data);
           },
           (err) => {
             this.log(schedulingType, taskId, label, metadata, 'rejected', err);
-            return reject(err);
+            reject(err);
           },
         );
+        return promise;
       };
     });
     this.scheduledTasks.push({
       original: task,
-      scheduled: scheduledPromise,
-      // `trigger` will always be initialised at this point: body of `new Promise` has already been executed
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       trigger: trigger!,
       schedulingType,
       taskId,
@@ -155,27 +153,30 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     // Placeholder resolver, immediately replaced by the one retrieved in `new Promise`
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     let resolveSequenceTask = () => {};
-    const sequenceTask = new Promise<void>((resolve) => (resolveSequenceTask = resolve));
+    const sequenceTask = new Promise<{ done: boolean; faulty: boolean }>((resolve) => {
+      resolveSequenceTask = () => resolve({ done: status.done, faulty: status.faulty });
+    });
 
     const onFaultyItemNoThrow = () => {
       status.faulty = true;
       resolveSequenceTask();
-    };
-    const onFaultyItem = (error: unknown) => {
-      onFaultyItemNoThrow(); // Faulty must resolve sequence as soon as possible without any extra then
-      throw error; // Faulty must stay faulty to avoid calling next items
     };
     const onDone = () => {
       status.done = true;
       resolveSequenceTask();
     };
 
-    let previouslyScheduled = dummyResolvedPromise;
-    for (const item of sequenceBuilders) {
-      const [builder, label, metadata] =
-        typeof item === 'function' ? [item, item.name, undefined] : [item.builder, item.label, item.metadata];
-      const onNextItem = () => {
-        // We schedule a successful promise that will trigger builder directly when triggered
+    const registerNextBuilder = (index: number, previous: PromiseLike<unknown>) => {
+      if (index >= sequenceBuilders.length) {
+        // All builders have been scheduled, we handle termination:
+        // if the last one succeeds then we are done, if it fails then the sequence should be marked as failed
+        previous.then(onDone, onFaultyItemNoThrow);
+        return;
+      }
+      previous.then(() => {
+        const item = sequenceBuilders[index];
+        const [builder, label, metadata] =
+          typeof item === 'function' ? [item, item.name, undefined] : [item.builder, item.label, item.metadata];
         const scheduled = this.scheduleInternal(
           'sequence',
           label,
@@ -184,16 +185,11 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
           customAct || defaultSchedulerAct,
           () => builder(),
         );
-        return scheduled;
-      };
-      // We will run current item if and only if the one preceeding it succeeds
-      // Otherwise, we mark the run as "failed" and ignore any subsequent item (including this one)
-      previouslyScheduled = previouslyScheduled.then(onNextItem, onFaultyItem);
-    }
-    // Once last item is done, the full sequence can be considered as successful
-    // If it failed (or any preceeding one failed), then the sequence should be marked as failed (already marked for others)
-    // We always handle Promise rejection of previouslyScheduled internally, in other words no error will bubble outside
-    previouslyScheduled.then(onDone, onFaultyItemNoThrow);
+        registerNextBuilder(index + 1, scheduled);
+      }, onFaultyItemNoThrow);
+    };
+
+    registerNextBuilder(0, dummyResolvedPromise);
 
     // TODO Prefer getter instead of sharing the variable itself
     //      Would need to stop supporting <es5
@@ -201,11 +197,7 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     //   get done() { return status.done },
     //   get faulty() { return status.faulty }
     // };
-    return Object.assign(status, {
-      task: Promise.resolve(sequenceTask).then(() => {
-        return { done: status.done, faulty: status.faulty };
-      }),
-    });
+    return Object.assign(status, { task: sequenceTask });
   }
 
   count(): number {
@@ -218,19 +210,18 @@ export class SchedulerImplem<TMetaData> implements Scheduler<TMetaData> {
     }
     const taskIndex = this.taskSelector.nextTaskIndex(this.scheduledTasks);
     const [scheduledTask] = this.scheduledTasks.splice(taskIndex, 1);
-    return scheduledTask.customAct(async () => {
-      scheduledTask.trigger(); // release the promise
-      try {
-        await scheduledTask.scheduled; // wait for its completion
-      } catch (_err) {
+    return scheduledTask.customAct(() => {
+      const scheduled = scheduledTask.trigger(); // release the promise
+      return scheduled.catch((_err) => {
         // We ignore failures here, we just want to wait the promise to be resolved (failure or success)
-      }
+      }) as Promise<void>;
     });
   }
 
-  async waitOne(customAct?: SchedulerAct): Promise<void> {
+  waitOne(customAct?: SchedulerAct): Promise<void> {
     const waitAct = customAct || defaultSchedulerAct;
-    await this.act(() => waitAct(async () => await this.internalWaitOne()));
+    const waitOneResult: Promise<unknown> = this.act(() => waitAct(() => this.internalWaitOne()));
+    return waitOneResult as Promise<void>;
   }
 
   async waitAll(customAct?: SchedulerAct): Promise<void> {

--- a/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
@@ -30,7 +30,7 @@ const delay = () => new Promise((r) => setTimeout(r, 0));
 
 describe('SchedulerImplem', () => {
   describe('waitOne', () => {
-    it('should throw when there is no scheduled promise in the pipe', async () => {
+    it('should throw synchronously when there is no scheduled promise in the pipe', () => {
       // Arrange
       const act = jest.fn().mockImplementation((f) => f());
       const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
@@ -39,7 +39,7 @@ describe('SchedulerImplem', () => {
       const s = new SchedulerImplem(act, taskSelector);
 
       // Assert
-      await expect(s.waitOne()).rejects.toMatchInlineSnapshot(`[Error: No task scheduled]`);
+      expect(() => s.waitOne()).toThrowErrorMatchingInlineSnapshot(`"No task scheduled"`);
     });
 
     it('should wrap waitOne call using act whenever specified', async () => {
@@ -177,6 +177,64 @@ describe('SchedulerImplem', () => {
       expect(promiseResolved).toBe(true);
       expect(waitOneResolved).toBe(true);
     });
+
+    it('should schedule for next waitOne anything immediately scheduled', async () => {
+      // Arrange
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(() => s.schedule(Promise.resolve(2)));
+
+      // Assert
+      expect(s.count()).toBe(1); // The promise returning 1 should be queued into the scheduler
+      await s.waitOne();
+      expect(s.count()).toBe(1); // The promise returning 2 should be queued into the scheduler
+    });
+
+    it('should not schedule for next waitOne something scheduled after an intermadiate await', async () => {
+      // Arrange
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(async () => {
+        await 'something already resolved';
+        s.schedule(Promise.resolve(2));
+      });
+
+      // Assert
+      expect(s.count()).toBe(1); // The promise returning 1 should be queued into the scheduler
+      await s.waitOne();
+      expect(s.count()).toBe(0); // The promise returning 2 should NOT be queued into the scheduler...
+      await 'just awaiting something';
+      expect(s.count()).toBe(1); // ...but it will after a simple await
+    });
+
+    it('should not schedule for next waitOne something scheduled after two intermediate await', async () => {
+      // Arrange
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(async () => {
+        await 'something already resolved';
+        await 'another something already resolved';
+        s.schedule(Promise.resolve(2));
+      });
+
+      // Assert
+      expect(s.count()).toBe(1); // The promise returning 1 should be queued into the scheduler
+      await s.waitOne();
+      expect(s.count()).toBe(0); // The promise returning 2 should NOT be queued into the scheduler...
+      await 'just awaiting something';
+      expect(s.count()).toBe(0);
+      await 'just awaiting one more time';
+      expect(s.count()).toBe(1); // ...but it will after two simple await
+    });
   });
 
   describe('waitAll', () => {
@@ -243,6 +301,100 @@ describe('SchedulerImplem', () => {
           expect(locked).toBe(false);
         }),
       ));
+
+    it('should schedule for the same waitAll anything immediately scheduled', async () => {
+      // Arrange
+      const f2 = jest.fn();
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(() => s.schedule(Promise.resolve(2)).then(f2));
+
+      // Assert
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'pending' }), // The promise returning 1 has been scheduled
+      ]);
+      expect(s.count()).toBe(1); // just confirming "count" is aligned with "report"
+      expect(f2).not.toHaveBeenCalled(); // just confirming we don't have lags in the "report"
+      await s.waitAll();
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }), // The promise returning 1 has been completed
+        expect.objectContaining({ status: 'resolved', outputValue: '2' }), // The promise returning 2 has been completed
+      ]);
+      expect(f2).toHaveBeenCalled(); // and completions have been called
+    });
+
+    it('should not schedule for the same waitAll (but for next one) something scheduled after an intermadiate await', async () => {
+      // Arrange
+      const f2 = jest.fn();
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(async () => {
+        await 'something already resolved';
+        s.schedule(Promise.resolve(2)).then(f2);
+      });
+
+      // Assert
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'pending' }), // The promise returning 1 has been scheduled
+      ]);
+      await s.waitAll();
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }), // The promise returning 1 has been completed...
+        expect.objectContaining({ status: 'pending' }), // ...and the one returning 2 has already been scehduled but not executed yet
+      ]);
+      expect(s.count()).toBe(1); // just confirming "count" is aligned with "report"
+      expect(f2).not.toHaveBeenCalled(); // just confirming we don't have lags in the "report"
+      await s.waitAll();
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }), // The promise returning 1 has been completed
+        expect.objectContaining({ status: 'resolved', outputValue: '2' }), // The promise returning 2 has been completed
+      ]);
+      expect(f2).toHaveBeenCalled(); // and completions have been called
+    });
+
+    it('should not schedule for the same waitAll (nor next one) something scheduled after two intermadiate await', async () => {
+      // Arrange
+      const f2 = jest.fn();
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.schedule(Promise.resolve(1)).then(async () => {
+        await 'something already resolved';
+        await 'another something already resolved';
+        s.schedule(Promise.resolve(2)).then(f2);
+      });
+
+      // Assert
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'pending' }), // The promise returning 1 has been scheduled
+      ]);
+      await s.waitAll();
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }), // The promise returning 1 has been completed...
+        // ...but the promise returning 2 has not even been scheduled...
+      ]);
+      await 'just awaiting something';
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }),
+        expect.objectContaining({ status: 'pending' }), // ...but it will after a simple await
+      ]);
+      expect(s.count()).toBe(1); // just confirming "count" is aligned with "report"
+      expect(f2).not.toHaveBeenCalled(); // just confirming we don't have lags in the "report"
+      await s.waitAll();
+      expect(s.report()).toEqual([
+        expect.objectContaining({ status: 'resolved', outputValue: '1' }), // The promise returning 1 has been completed
+        expect.objectContaining({ status: 'resolved', outputValue: '2' }), // The promise returning 2 has been completed
+      ]);
+      expect(f2).toHaveBeenCalled(); // and completions have been called
+    });
   });
 
   describe('waitFor', () => {
@@ -287,10 +439,9 @@ describe('SchedulerImplem', () => {
 
       // Act
       const s = new SchedulerImplem((f) => f(), taskSelector);
-      const sp1 = s.schedule(p1.p);
+      const awaitedTask = s.schedule(p1.p);
       s.schedule(p2.p);
       s.schedule(p3.p);
-      const awaitedTask = sp1.then(() => Symbol());
 
       // Assert
       let waitForEnded = false;
@@ -566,12 +717,10 @@ describe('SchedulerImplem', () => {
 
       // Act
       const s = new SchedulerImplem((f) => f(), taskSelector);
-      const sp1 = s.schedule(p1.p);
-      const sp2 = s.schedule(p2.p);
+      const awaitedTask1 = s.schedule(p1.p);
+      const awaitedTask2 = s.schedule(p2.p);
       s.schedule(p3.p);
       s.schedule(p4.p);
-      const awaitedTask1 = sp1.then(() => Symbol());
-      const awaitedTask2 = sp2.then(() => Symbol());
 
       // Assert
       let waitForEnded1 = false;
@@ -886,27 +1035,40 @@ describe('SchedulerImplem', () => {
             4: false,
             5: false,
           };
+          const everythingResolved = {
+            1: true,
+            2: true,
+            3: true,
+            4: true,
+            5: true,
+          };
           const resolved = { ...nothingResolved };
           const act = jest.fn().mockImplementation((f) => f());
           const nextTaskIndex = buildSeededNextTaskIndex(seeds);
           const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex };
+          const order: number[] = [];
 
           // Act
           const s = new SchedulerImplem(act, taskSelector);
           s.schedule(Promise.resolve(1)).then(() => {
+            order.push(1);
             resolved[1] = true;
             Promise.all([
               s.schedule(Promise.resolve(2)).then(() => {
+                order.push(2);
                 resolved[2] = true;
               }),
               s.schedule(Promise.resolve(3)).then(() => {
+                order.push(3);
                 resolved[3] = true;
                 s.schedule(Promise.resolve(4)).then(() => {
+                  order.push(4);
                   resolved[4] = true;
                 });
               }),
             ]).then(() => {
               s.schedule(Promise.resolve(5)).then(() => {
+                order.push(5);
                 resolved[5] = true;
                 status.done = true;
               });
@@ -917,14 +1079,29 @@ describe('SchedulerImplem', () => {
           expect(status.done).toBe(false);
           expect(resolved).toEqual(nothingResolved);
           await s.waitAll();
+          if (status.done) {
+            // There are only a few cases that could make 5 resolved via waitAll. Scheduling 5 is the consequence of Promise.all([2, 3]) being resolved.
+            // Promise.all is nasty as it costs an extra await. Meaning that if 3 and 4 (a task scheduled when 3 succeeds) have already been resolved,
+            // resolving 2 would not be enought to schedule 5 in a visible way for waitAll.
+            expect([
+              // The following orders should work to include 5 within the waitAll:
+              [1, 2, 3, 4, 5],
+              [1, 3, 2, 4, 5],
+            ]).toContainEqual(order);
+          } else {
+            expect([
+              // But these ones will not work:
+              [1, 3, 4, 2],
+            ]).toContainEqual(order);
+
+            expect(resolved).toEqual({ ...everythingResolved, 5: false });
+            expect(s.count()).toBe(0); // Well, Promise.all just received the last completion it was waiting for...
+            await 'just awaiting to get the proper count'; // It needs one extra await to move forward and schedule the item 5
+            expect(s.count()).not.toBe(0);
+            await s.waitAll(); // extra waitAll should make it pass
+          }
           expect(status.done).toBe(true);
-          expect(resolved).toEqual({
-            1: true,
-            2: true,
-            3: true,
-            4: true,
-            5: true,
-          });
+          expect(resolved).toEqual(everythingResolved);
         }),
       ));
 
@@ -1564,10 +1741,7 @@ describe('SchedulerImplem', () => {
       task.then((v) => (taskResolvedValue = v));
 
       // Assert
-      while (s.count() !== 0) {
-        expect(taskResolvedValue).toBe(null);
-        await s.waitOne();
-      }
+      await s.waitAll();
       expect(taskResolvedValue).toEqual({ done: true, faulty: false });
     });
 
@@ -1588,10 +1762,7 @@ describe('SchedulerImplem', () => {
       task.then((v) => (taskResolvedValue = v));
 
       // Assert
-      while (s.count() !== 0) {
-        expect(taskResolvedValue).toBe(null);
-        await s.waitOne();
-      }
+      await s.waitAll();
       expect(taskResolvedValue).toEqual({ done: false, faulty: true });
     });
 
@@ -1640,6 +1811,49 @@ describe('SchedulerImplem', () => {
       expect(report).toHaveLength(1); // second task cannot be scheduled as first one is still pending
       expect(report[0].status).toBe('pending');
       expect(report[0].metadata).toBe(expectedMetadataFirst);
+    });
+
+    it('should execute a whole scheduled sequence made of async long steps using a single waitAll', async () => {
+      // Arrange
+      const b1 = jest.fn(async () => {
+        await 1;
+        await 2;
+        await 3;
+      });
+      const b2 = jest.fn(async () => {
+        await 1;
+        await 2;
+        await 3;
+      });
+      const b3 = jest.fn(async () => {
+        await 1;
+        await 2;
+        await 3;
+      });
+      const b4 = jest.fn(async () => {
+        await 1;
+        await 2;
+        await 3;
+      });
+      const act = jest.fn().mockImplementation((f) => f());
+      const taskSelector: TaskSelector<unknown> = { clone: jest.fn(), nextTaskIndex: jest.fn() };
+
+      // Act
+      const s = new SchedulerImplem(act, taskSelector);
+      s.scheduleSequence([
+        { label: 'exec #1', builder: b1 },
+        { label: 'exec #2', builder: b2 },
+        { label: 'exec #3', builder: b3 },
+        { label: 'exec #4', builder: b4 },
+      ]);
+
+      // Assert
+      await s.waitAll();
+      expect(s.report()).toHaveLength(4);
+      expect(b1).toHaveBeenCalled();
+      expect(b2).toHaveBeenCalled();
+      expect(b3).toHaveBeenCalled();
+      expect(b4).toHaveBeenCalled();
     });
   });
 });

--- a/website/docs/tutorials/detect-race-conditions/snippets.spec.mjs
+++ b/website/docs/tutorials/detect-race-conditions/snippets.spec.mjs
@@ -31,7 +31,7 @@ const allQueueSnippets = {
   },
   v1: {
     code: snippets.queueCodeV1,
-    greenTests: ['unit', 'part1', 'part1WaitAll'],
+    greenTests: ['unit', 'part1'],
   },
   v2: {
     code: snippets.queueCodeV2,
@@ -43,7 +43,7 @@ const allQueueSnippets = {
   },
   v4: {
     code: snippets.queueCodeV4,
-    greenTests: ['unit', 'part1', 'part1WaitAll', 'part2', 'part3', 'part3NoBatch', 'part4', 'extendedWaitAll'],
+    greenTests: ['unit', 'part1', 'part1WaitAll', 'part2', 'part3', 'part3NoBatch', 'part4'],
   },
   v5: {
     code: snippets.queueCodeV5,


### PR DESCRIPTION
**💥 Breaking change**

This PR makes schedulers faster. By being faster it means that code that was previously passing may start to fail. Additionally it may predates `waitAll` and makes it not working in some cases that relied on this lucky slow scheduler.

The new scheduler implementation will try to be as fast as possible and skip as few as possible frames. In this change scheduler takes action in places where it used not to because it was waiting for no reasons.

Recreating #3891

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [x] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
