### PR TITLE
✨ Expose internal state of the PRNG from `Random`

### DIFF
--- a/.yarn/versions/a6ab7de6.yml
+++ b/.yarn/versions/a6ab7de6.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/package.json
+++ b/packages/fast-check/package.json
@@ -60,7 +60,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "pure-rand": "^6.0.0"
+    "pure-rand": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/packages/fast-check/src/random/generator/Random.ts
+++ b/packages/fast-check/src/random/generator/Random.ts
@@ -98,4 +98,14 @@ export class Random {
     const b = this.next(27);
     return (a * Random.DBL_FACTOR + b) * Random.DBL_DIVISOR;
   }
+
+  /**
+   * Extract the internal state of the internal RandomGenerator backing the current instance of Random
+   */
+  getState(): readonly number[] | undefined {
+    if ('getState' in this.internalRng && typeof this.internalRng.getState === 'function') {
+      return this.internalRng.getState();
+    }
+    return undefined;
+  }
 }

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
@@ -9,6 +9,7 @@ export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, '
   const nextBigInt = jest.fn();
   const nextArrayInt = jest.fn();
   const nextDouble = jest.fn();
+  const getState = jest.fn();
   class MyRandom extends Random {
     clone = clone;
     next = next;
@@ -16,11 +17,11 @@ export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, '
     nextInt = nextInt;
     nextBigInt = nextBigInt;
     nextArrayInt = nextArrayInt;
-    nextDouble = nextDouble;
+    getState = getState;
   }
 
   // Calling `new MyRandom` triggers a call to the default ctor of `Random`.
   // As we don't use anything from this base class, we just pass the ctor with a value that looks ok for it.
   const instance = new MyRandom({ clone: () => null } as any);
-  return { instance, clone, next, nextBoolean, nextInt, nextBigInt, nextArrayInt, nextDouble };
+  return { instance, clone, next, nextBoolean, nextInt, nextBigInt, nextArrayInt, nextDouble, getState };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9381,7 +9381,7 @@ __metadata:
     glob: "npm:^10.3.10"
     jest: "npm:^29.7.0"
     not-node-buffer: "npm:buffer@^6.0.3"
-    pure-rand: "npm:^6.0.0"
+    pure-rand: "npm:^6.1.0"
     regexp-tree: "npm:^0.1.27"
     replace-in-file: "npm:^7.1.0"
     typedoc: "npm:^0.25.10"
@@ -15886,10 +15886,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^6.0.0, pure-rand@npm:^6.0.4":
-  version: 6.0.4
-  resolution: "pure-rand@npm:6.0.4"
-  checksum: 10c0/0fe7b12f25b10ea5b804598a6f37e4bcf645d2be6d44fe963741f014bf0095bdb6ff525106d6da6e76addc8142358fd380f1a9b8c62ea4d5516bf26a96a37c95
+"pure-rand@npm:^6.0.0, pure-rand@npm:^6.0.4, pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In the context of https://github.com/dubzzz/fast-check/pull/4063, we need to have an access onto the internal state of the PRNG backing the instance of `Random` in order to be able to serialize it and recreate the "exact" same instance of `Random` on destination (another worker thread).

The current PR adds a `getState` method on `Random`.

Adding it should be enough to fulfill the needs of https://github.com/dubzzz/fast-check/pull/4063. But we will wait for it to be confirmed before releasing any minor version including that change.

<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [x] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [ ] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
