### PR TITLE
✅ Better mock/spy cleaning

### DIFF
--- a/.yarn/versions/2faec736.yml
+++ b/.yarn/versions/2faec736.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: patch
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/SpyCleaner.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/SpyCleaner.ts
@@ -1,0 +1,20 @@
+import fc from 'fast-check';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+
+/**
+ * Connect hooks responsible to clean the spies,
+ * before any other test runs
+ */
+export function declareCleaningHooksForSpies(): void {
+  const currentGlobalConfiguration = fc.readConfigureGlobal();
+  function clean() {
+    vi.restoreAllMocks();
+  }
+  beforeAll(() => {
+    fc.configureGlobal({ ...currentGlobalConfiguration, afterEach: clean });
+  });
+  afterEach(clean);
+  afterAll(() => {
+    fc.configureGlobal(currentGlobalConfiguration);
+  });
+}

--- a/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import prand from 'pure-rand';
 
@@ -16,15 +16,11 @@ import { fakeArbitrary } from '../__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 import { buildShrinkTree, walkTree } from '../__test-helpers__/ShrinkTree';
 import * as DepthContextMock from '../../../../src/arbitrary/_internals/helpers/DepthContext';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from '../__test-helpers__/SpyCleaner';
 
 describe('ArrayArbitrary', () => {
+  declareCleaningHooksForSpies();
+
   describe('generate', () => {
     it('should concat all the generated values together when no set constraints ', () => {
       fc.assert(

--- a/packages/fast-check/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/BigIntArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { BigIntArbitrary } from '../../../../src/arbitrary/_internals/BigIntArbitrary';
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
@@ -15,21 +15,10 @@ import { Stream } from '../../../../src/stream/Stream';
 
 import * as BiasNumericRangeMock from '../../../../src/arbitrary/_internals/helpers/BiasNumericRange';
 import * as ShrinkBigIntMock from '../../../../src/arbitrary/_internals/helpers/ShrinkBigInt';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from '../__test-helpers__/SpyCleaner';
 
 describe('BigIntArbitrary', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+  declareCleaningHooksForSpies();
 
   describe('generate', () => {
     it('should never bias and generate the full range when biasFactor is not specified', () =>

--- a/packages/fast-check/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/IntegerArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import * as fc from 'fast-check';
 import { IntegerArbitrary } from '../../../../src/arbitrary/_internals/IntegerArbitrary';
@@ -16,15 +16,11 @@ import { buildShrinkTree, renderTree, walkTree } from '../__test-helpers__/Shrin
 import * as BiasNumericRangeMock from '../../../../src/arbitrary/_internals/helpers/BiasNumericRange';
 import * as ShrinkIntegerMock from '../../../../src/arbitrary/_internals/helpers/ShrinkInteger';
 import { Stream } from '../../../../src/stream/Stream';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from '../__test-helpers__/SpyCleaner';
 
 describe('IntegerArbitrary', () => {
+  declareCleaningHooksForSpies();
+
   describe('generate', () => {
     it('should never bias and generate the full range when biasFactor is not specified', () =>
       fc.assert(

--- a/packages/fast-check/test/unit/arbitrary/_internals/MixedCaseArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/MixedCaseArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import {
   assertProduceValuesShrinkableWithoutContext,
@@ -14,21 +14,10 @@ import * as BigUintNMock from '../../../../src/arbitrary/bigUintN';
 import { fakeArbitrary } from '../__test-helpers__/ArbitraryHelpers';
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
+import { declareCleaningHooksForSpies } from '../__test-helpers__/SpyCleaner';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
-describe('MixedCaseArbitrary (integration)', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+describe('MixedCaseArbitrary', () => {
+  declareCleaningHooksForSpies();
 
   describe('generate', () => {
     it('should not toggle any character if flags equal zero', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { StreamArbitrary } from '../../../../src/arbitrary/_internals/StreamArbitrary';
 import { Value } from '../../../../src/check/arbitrary/definition/Value';
@@ -12,15 +12,11 @@ import { FakeIntegerArbitrary, fakeArbitrary } from '../__test-helpers__/Arbitra
 import { fakeRandom } from '../__test-helpers__/RandomHelpers';
 
 import * as StringifyMock from '../../../../src/utils/stringify';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from '../__test-helpers__/SpyCleaner';
 
 describe('StreamArbitrary', () => {
+  declareCleaningHooksForSpies();
+
   describe('generate', () => {
     it('should produce a cloneable instance of Stream', () => {
       // Arrange

--- a/packages/fast-check/test/unit/arbitrary/_internals/SubarrayArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/SubarrayArbitrary.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import { SubarrayArbitrary } from '../../../../src/arbitrary/_internals/SubarrayArbitrary';
 
@@ -9,13 +9,6 @@ import {
   assertShrinkProducesSameValueWithoutInitialContext,
   assertShrinkProducesStrictlySmallerValue,
 } from '../__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 describe('SubarrayArbitrary', () => {
   describe('constructor', () => {

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { typedIntArrayArbitraryArbitraryBuilder } from '../../../../../src/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder';
 
@@ -11,15 +11,11 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from '../../__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from '../../__test-helpers__/SpyCleaner';
 
 describe('typedIntArrayArbitraryArbitraryBuilder', () => {
+  declareCleaningHooksForSpies();
+
   it('should default constraints for arbitraryBuilder to defaultMin/Max when not specified', () => {
     fc.assert(
       fc.property(

--- a/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import type {
   ScheduledTask,
@@ -7,13 +7,6 @@ import type {
 import { SchedulerImplem } from '../../../../../src/arbitrary/_internals/implementations/SchedulerImplem';
 import type { Scheduler } from '../../../../../src/arbitrary/_internals/interfaces/Scheduler';
 import { cloneMethod, hasCloneMethod } from '../../../../../src/check/symbols';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 const buildUnresolved = () => {
   let resolved = false;

--- a/packages/fast-check/test/unit/arbitrary/array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/array.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { array } from '../../../src/arbitrary/array';
 
@@ -17,15 +17,11 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { sizeRelatedGlobalConfigArb } from './__test-helpers__/SizeHelpers';
 import { withConfiguredGlobal } from './__test-helpers__/GlobalSettingsHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('array', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate ArrayArbitrary(arb, 0, ?, 0x7fffffff, n.a) for array(arb)', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, (config) => {

--- a/packages/fast-check/test/unit/arbitrary/ascii.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ascii.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { ascii } from '../../../src/arbitrary/ascii';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
@@ -13,14 +14,9 @@ import {
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('ascii', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(ascii);

--- a/packages/fast-check/test/unit/arbitrary/base64.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/base64.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { base64 } from '../../../src/arbitrary/base64';
 
@@ -12,15 +12,11 @@ import {
   assertShrinkProducesStrictlySmallerValue,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('base64', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(base64);

--- a/packages/fast-check/test/unit/arbitrary/base64String.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/base64String.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { base64String } from '../../../src/arbitrary/base64String';
 
@@ -7,6 +7,7 @@ import {
   assertProduceCorrectValues,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as ArrayMock from '../../../src/arbitrary/array';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
@@ -14,14 +15,9 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { sizeForArbitraryArb } from './__test-helpers__/SizeHelpers';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('base64String', () => {
+  declareCleaningHooksForSpies();
+
   it('should accept any constraints accepting at least one length multiple of 4', () =>
     fc.assert(
       fc.property(

--- a/packages/fast-check/test/unit/arbitrary/bigInt.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/bigInt.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { bigInt } from '../../../src/arbitrary/bigInt';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as BigIntArbitraryMock from '../../../src/arbitrary/_internals/BigIntArbitrary';
 
@@ -11,20 +12,8 @@ function fakeBigIntArbitrary() {
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('bigInt', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+  declareCleaningHooksForSpies();
 
   it('should instantiate the same BigIntArbitrary as empty constraints for no arguments', () => {
     // Arrange

--- a/packages/fast-check/test/unit/arbitrary/bigIntN.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/bigIntN.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { bigIntN } from '../../../src/arbitrary/bigIntN';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as BigIntArbitraryMock from '../../../src/arbitrary/_internals/BigIntArbitrary';
 
@@ -11,20 +12,8 @@ function fakeBigIntArbitrary() {
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('bigIntN', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+  declareCleaningHooksForSpies();
 
   it('should instantiate BigIntArbitrary(-2^(n-1), 2^(n-1) -1) for bigIntN(n)', () =>
     fc.assert(

--- a/packages/fast-check/test/unit/arbitrary/bigUint.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/bigUint.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { bigUint } from '../../../src/arbitrary/bigUint';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as BigIntArbitraryMock from '../../../src/arbitrary/_internals/BigIntArbitrary';
 
@@ -11,20 +12,8 @@ function fakeBigIntArbitrary() {
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('bigUint', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+  declareCleaningHooksForSpies();
 
   it('should instantiate the same BigIntArbitrary as empty constraints for no arguments', () => {
     // Arrange

--- a/packages/fast-check/test/unit/arbitrary/bigUintN.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/bigUintN.spec.ts
@@ -1,30 +1,19 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { bigUintN } from '../../../src/arbitrary/bigUintN';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as BigIntArbitraryMock from '../../../src/arbitrary/_internals/BigIntArbitrary';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 function fakeBigIntArbitrary() {
   const instance = fakeArbitrary<bigint>().instance as BigIntArbitraryMock.BigIntArbitrary;
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('bigUintN', () => {
-  if (typeof BigInt === 'undefined') {
-    it('no test', () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+  declareCleaningHooksForSpies();
 
   it('should instantiate BigIntArbitrary(0, 2^n -1) for bigIntN(n)', () =>
     fc.assert(

--- a/packages/fast-check/test/unit/arbitrary/char.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/char.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { char } from '../../../src/arbitrary/char';
 
@@ -12,15 +12,11 @@ import {
   assertShrinkProducesStrictlySmallerValue,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('char', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(char);

--- a/packages/fast-check/test/unit/arbitrary/char16bits.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/char16bits.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { char16bits } from '../../../src/arbitrary/char16bits';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as CharacterArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/CharacterArbitraryBuilder';
 import {
@@ -13,14 +14,9 @@ import {
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('char16bits', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(char16bits);

--- a/packages/fast-check/test/unit/arbitrary/constant.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/constant.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { constant } from '../../../src/arbitrary/constant';
 
@@ -6,15 +6,11 @@ import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import { cloneMethod } from '../../../src/check/symbols';
 
 import * as ConstantArbitraryMock from '../../../src/arbitrary/_internals/ConstantArbitrary';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('constant', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate ConstantArbitrary([c]) for constant(c)', () =>
     fc.assert(
       fc.property(fc.anything(), (c) => {

--- a/packages/fast-check/test/unit/arbitrary/constantFrom.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/constantFrom.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { constantFrom } from '../../../src/arbitrary/constantFrom';
 
@@ -6,15 +6,11 @@ import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import { cloneMethod } from '../../../src/check/symbols';
 
 import * as ConstantArbitraryMock from '../../../src/arbitrary/_internals/ConstantArbitrary';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('constantFrom', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate ConstantArbitrary(csts) for constantFrom(...csts)', () =>
     fc.assert(
       fc.property(fc.array(fc.anything(), { minLength: 1 }), (csts) => {

--- a/packages/fast-check/test/unit/arbitrary/context.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/context.spec.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
-import * as fc from 'fast-check';
+import { describe, it, expect, vi } from 'vitest';
 import type { ContextValue } from '../../../src/arbitrary/context';
 import { context } from '../../../src/arbitrary/context';
 
@@ -8,15 +7,11 @@ import type { WithCloneMethod } from '../../../src/check/symbols';
 import { cloneMethod, hasCloneMethod } from '../../../src/check/symbols';
 
 import * as ConstantMock from '../../../src/arbitrary/constant';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('context', () => {
+  declareCleaningHooksForSpies();
+
   it('should re-use constant to build the context', () => {
     // Arrange
     const { instance } = fakeArbitrary();

--- a/packages/fast-check/test/unit/arbitrary/date.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/date.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import { date } from '../../../src/arbitrary/date';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
@@ -11,15 +11,11 @@ import {
 } from './__test-helpers__/ArbitraryAssertions';
 
 import * as IntegerMock from '../../../src/arbitrary/integer';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('date', () => {
+  declareCleaningHooksForSpies();
+
   it('should map on the output of an integer and specify mapper and unmapper', () =>
     fc.assert(
       fc.property(constraintsArb(), (constraints) => {

--- a/packages/fast-check/test/unit/arbitrary/domain.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/domain.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import type { DomainConstraints } from '../../../src/arbitrary/domain';
 import { domain } from '../../../src/arbitrary/domain';
@@ -13,15 +13,11 @@ import {
 } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('domain (integration)', () => {
+  declareCleaningHooksForSpies();
+
   const isValidDomain = (t: string) => {
     // According to https://www.ietf.org/rfc/rfc1034.txt
     // <domain> ::= <subdomain> | " "

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 
 import type { DoubleConstraints } from '../../../src/arbitrary/double';
@@ -15,6 +15,7 @@ import { doubleToIndex, indexToDouble } from '../../../src/arbitrary/_internals/
 
 import { fakeArbitrary, fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import {
   assertProduceCorrectValues,
@@ -26,17 +27,9 @@ import {
 
 import * as ArrayInt64ArbitraryMock from '../../../src/arbitrary/_internals/ArrayInt64Arbitrary';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-}
-beforeEach(beforeEachHook);
-fc.configureGlobal({
-  ...fc.readConfigureGlobal(),
-  beforeEach: beforeEachHook,
-});
-
 describe('double', () => {
+  declareCleaningHooksForSpies();
+
   it('should accept any valid range of floating point numbers (including infinity)', () => {
     fc.assert(
       fc.property(doubleConstraints(), (ct) => {

--- a/packages/fast-check/test/unit/arbitrary/emailAddress.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/emailAddress.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import type { EmailAddressConstraints } from '../../../src/arbitrary/emailAddress';
 import { emailAddress } from '../../../src/arbitrary/emailAddress';
@@ -12,15 +12,11 @@ import {
 } from './__test-helpers__/ArbitraryAssertions';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('emailAddress (integration)', () => {
+  declareCleaningHooksForSpies();
+
   const expectValidEmailRfc1123 = (t: string) => {
     // Taken from https://www.w3.org/TR/html5/forms.html#valid-e-mail-address
     const rfc1123 =

--- a/packages/fast-check/test/unit/arbitrary/falsy.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/falsy.spec.ts
@@ -1,19 +1,14 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
-import * as fc from 'fast-check';
+import { describe, it, expect, vi } from 'vitest';
 import { falsy } from '../../../src/arbitrary/falsy';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import * as ConstantFromMock from '../../../src/arbitrary/constantFrom';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('falsy', () => {
+  declareCleaningHooksForSpies();
+
   it('should re-use constantFrom to build the falsy', () => {
     // Arrange
     const { instance } = fakeArbitrary();

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 
 import type { FloatConstraints } from '../../../src/arbitrary/float';
@@ -21,6 +21,7 @@ import {
 
 import { fakeArbitrary, fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 import { fakeRandom } from './__test-helpers__/RandomHelpers';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 import {
   assertProduceCorrectValues,
@@ -32,16 +33,6 @@ import {
 
 import * as IntegerMock from '../../../src/arbitrary/integer';
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-}
-beforeEach(beforeEachHook);
-fc.configureGlobal({
-  ...fc.readConfigureGlobal(),
-  beforeEach: beforeEachHook,
-});
-
 function minMaxForConstraints(ct: FloatConstraints) {
   const noDefaultInfinity = ct.noDefaultInfinity;
   const {
@@ -52,6 +43,8 @@ function minMaxForConstraints(ct: FloatConstraints) {
 }
 
 describe('float', () => {
+  declareCleaningHooksForSpies();
+
   it('should accept any valid range of 32-bit floating point numbers (including infinity)', () => {
     fc.assert(
       fc.property(floatConstraints(), (ct) => {

--- a/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import type { Float32ArrayConstraints } from '../../../src/arbitrary/float32Array';
 import { float32Array } from '../../../src/arbitrary/float32Array';
@@ -9,13 +9,6 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 describe('float32Array (integration)', () => {
   type Extra = Float32ArrayConstraints;

--- a/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import type { Float64ArrayConstraints } from '../../../src/arbitrary/float64Array';
 import { float64Array } from '../../../src/arbitrary/float64Array';
@@ -9,13 +9,6 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 describe('float64Array (integration)', () => {
   type Extra = Float64ArrayConstraints;

--- a/packages/fast-check/test/unit/arbitrary/fullUnicode.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/fullUnicode.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { fullUnicode } from '../../../src/arbitrary/fullUnicode';
 
@@ -12,15 +12,11 @@ import {
   assertShrinkProducesStrictlySmallerValue,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('fullUnicode', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(fullUnicode);

--- a/packages/fast-check/test/unit/arbitrary/hexa.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/hexa.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { hexa } from '../../../src/arbitrary/hexa';
 
@@ -12,15 +12,11 @@ import {
   assertShrinkProducesStrictlySmallerValue,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('hexa', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(hexa);

--- a/packages/fast-check/test/unit/arbitrary/integer.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/integer.spec.ts
@@ -1,24 +1,20 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { integer } from '../../../src/arbitrary/integer';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as IntegerArbitraryMock from '../../../src/arbitrary/_internals/IntegerArbitrary';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 function fakeIntegerArbitrary() {
   const instance = fakeArbitrary<number>().instance as IntegerArbitraryMock.IntegerArbitrary;
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('integer', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate IntegerArbitrary(-0x80000000, 0x7fffffff) for integer()', () => {
     // Arrange
     const instance = fakeIntegerArbitrary();

--- a/packages/fast-check/test/unit/arbitrary/nat.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/nat.spec.ts
@@ -1,24 +1,20 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { nat } from '../../../src/arbitrary/nat';
 
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 
 import * as IntegerArbitraryMock from '../../../src/arbitrary/_internals/IntegerArbitrary';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 function fakeIntegerArbitrary() {
   const instance = fakeArbitrary<number>().instance as IntegerArbitraryMock.IntegerArbitrary;
   return instance;
 }
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('nat', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate IntegerArbitrary(0, 0x7fffffff) for nat()', () => {
     // Arrange
     const instance = fakeIntegerArbitrary();

--- a/packages/fast-check/test/unit/arbitrary/oneof.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/oneof.spec.ts
@@ -1,19 +1,15 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import type { OneOfConstraints } from '../../../src/arbitrary/oneof';
 import { oneof } from '../../../src/arbitrary/oneof';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
 import * as FrequencyArbitraryMock from '../../../src/arbitrary/_internals/FrequencyArbitrary';
 import { sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('oneof', () => {
+  declareCleaningHooksForSpies();
+
   it('should adapt received MaybeWeightedArbitrary for FrequencyArbitrary.from when called with constraints', () => {
     fc.assert(
       fc.property(

--- a/packages/fast-check/test/unit/arbitrary/option.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/option.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import type { OptionConstraints } from '../../../src/arbitrary/option';
 import { option } from '../../../src/arbitrary/option';
@@ -12,15 +12,11 @@ import {
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
 import { sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('option', () => {
+  declareCleaningHooksForSpies();
+
   it('should call FrequencyArbitrary.from with the right parameters when called with constraints', () =>
     fc.assert(
       fc.property(

--- a/packages/fast-check/test/unit/arbitrary/record.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/record.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import type { RecordConstraints } from '../../../src/arbitrary/record';
 import { record } from '../../../src/arbitrary/record';
@@ -12,15 +12,11 @@ import {
 } from './__test-helpers__/ArbitraryAssertions';
 
 import * as PartialRecordArbitraryBuilderMock from '../../../src/arbitrary/_internals/builders/PartialRecordArbitraryBuilder';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('record', () => {
+  declareCleaningHooksForSpies();
+
   const keyArb: fc.Arbitrary<any> = fc
     .tuple(fc.string(), fc.boolean())
     .map(([name, symbol]) => (symbol ? Symbol.for(name) : name));

--- a/packages/fast-check/test/unit/arbitrary/sparseArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/sparseArray.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-sparse-arrays */
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import type { SparseArrayConstraints } from '../../../src/arbitrary/sparseArray';
 import { sparseArray } from '../../../src/arbitrary/sparseArray';
@@ -17,18 +17,11 @@ import {
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { MaxLengthUpperBound } from '../../../src/arbitrary/_internals/helpers/MaxLengthFromMinLength';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-}
-beforeEach(beforeEachHook);
-fc.configureGlobal({
-  ...fc.readConfigureGlobal(),
-  beforeEach: beforeEachHook,
-});
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('sparseArray', () => {
+  declareCleaningHooksForSpies();
+
   it('should always specify a minLength and maxLength on the underlying set', () => {
     fc.assert(
       fc.property(fc.option(validSparseArrayConstraints(), { nil: undefined }), (ct) => {

--- a/packages/fast-check/test/unit/arbitrary/ulid.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/ulid.spec.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
-import fc from 'fast-check';
+import { describe, it, expect, vi } from 'vitest';
 import { ulid } from '../../../src/arbitrary/ulid';
 import { fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 
@@ -12,16 +11,12 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('ulid', () => {
+  declareCleaningHooksForSpies();
+
   it('should produce the minimal ulid given all minimal generated values', () => {
     // Arrange
     const { instance: mrng } = fakeRandom();

--- a/packages/fast-check/test/unit/arbitrary/unicode.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/unicode.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { unicode } from '../../../src/arbitrary/unicode';
 
@@ -12,15 +12,11 @@ import {
   assertShrinkProducesStrictlySmallerValue,
   assertProduceSameValueGivenSameSeed,
 } from './__test-helpers__/ArbitraryAssertions';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('unicode', () => {
+  declareCleaningHooksForSpies();
+
   it('should be able to unmap any mapped value', () => {
     // Arrange
     const { min, max, mapToCode, unmapFromCode } = extractArgumentsForBuildCharacter(unicode);

--- a/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import type { UniqueArrayConstraints } from '../../../src/arbitrary/uniqueArray';
 import { uniqueArray } from '../../../src/arbitrary/uniqueArray';
@@ -16,15 +16,11 @@ import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { sizeRelatedGlobalConfigArb } from './__test-helpers__/SizeHelpers';
 import { withConfiguredGlobal } from './__test-helpers__/GlobalSettingsHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('uniqueArray', () => {
+  declareCleaningHooksForSpies();
+
   it('should instantiate ArrayArbitrary(arb, 0, ?, 0x7fffffff, n.a, <default>) for uniqueArray(arb)', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, (config) => {

--- a/packages/fast-check/test/unit/arbitrary/uuid.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uuid.spec.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
-import fc from 'fast-check';
+import { describe, it, expect, vi } from 'vitest';
 import { uuid } from '../../../src/arbitrary/uuid';
 import { fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
 
@@ -12,16 +11,12 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('uuid', () => {
+  declareCleaningHooksForSpies();
+
   it('should produce the minimal uuid (v1-v5) given all minimal generated values', () => {
     // Arrange
     const { instance: mrng } = fakeRandom();

--- a/packages/fast-check/test/unit/arbitrary/uuidV.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uuidV.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import { uuidV } from '../../../src/arbitrary/uuidV';
 import { fakeArbitraryStaticValue } from './__test-helpers__/ArbitraryHelpers';
@@ -12,16 +12,12 @@ import {
   assertProduceValuesShrinkableWithoutContext,
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 const IntegerMock: { integer: (ct: { min: number; max: number }) => Arbitrary<number> } = _IntegerMock;
 
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
-
 describe('uuidV', () => {
+  declareCleaningHooksForSpies();
+
   it.each`
     version | expected
     ${1}    | ${'00000000-0000-1000-8000-000000000000'}

--- a/packages/fast-check/test/unit/arbitrary/webAuthority.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/webAuthority.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import type { WebAuthorityConstraints } from '../../../src/arbitrary/webAuthority';
 import { webAuthority } from '../../../src/arbitrary/webAuthority';
@@ -11,13 +11,6 @@ import {
   assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 describe('webAuthority (integration)', () => {
   type Extra = WebAuthorityConstraints;

--- a/packages/fast-check/test/unit/arbitrary/webPath.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/webPath.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import type { WebPathConstraints } from '../../../src/arbitrary/webPath';
 import { webPath } from '../../../src/arbitrary/webPath';
@@ -13,13 +13,6 @@ import {
 import { Value } from '../../../src/check/arbitrary/definition/Value';
 import { buildShrinkTree, renderTree } from './__test-helpers__/ShrinkTree';
 import { relativeSizeArb, sizeArb } from './__test-helpers__/SizeHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
 
 describe('webPath (integration)', () => {
   type Extra = WebPathConstraints;

--- a/packages/fast-check/test/unit/arbitrary/webUrl.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/webUrl.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fc from 'fast-check';
 import type { WebUrlConstraints } from '../../../src/arbitrary/webUrl';
 import { webUrl } from '../../../src/arbitrary/webUrl';
@@ -20,15 +20,11 @@ import * as WebQueryParametersMock from '../../../src/arbitrary/webQueryParamete
 import * as WebPathMock from '../../../src/arbitrary/webPath';
 import { withConfiguredGlobal } from './__test-helpers__/GlobalSettingsHelpers';
 import { fakeArbitrary } from './__test-helpers__/ArbitraryHelpers';
-
-function beforeEachHook() {
-  vi.resetModules();
-  vi.restoreAllMocks();
-  fc.configureGlobal({ beforeEach: beforeEachHook });
-}
-beforeEach(beforeEachHook);
+import { declareCleaningHooksForSpies } from './__test-helpers__/SpyCleaner';
 
 describe('webUrl', () => {
+  declareCleaningHooksForSpies();
+
   it('should always use the same size value for all its sub-arbitraries (except webAuthority when using its own)', () => {
     fc.assert(
       fc.property(sizeRelatedGlobalConfigArb, webUrlConstraintsBuilder(), (config, constraints) => {


### PR DESCRIPTION
<!-- Context of the PR: short description and potentially linked issues -->

<!-- ...a few words to describe the content of this PR...               -->
<!-- ... -->

Whenever running tests playing with mocks or spies, we have to make sure to properly clean everything. But over cleaning is as bad as no cleaning, more precisely, from a CI point of view, over cleaning tend to make tests slower.

This PR introduce a shared helper responsible to clean anything related to spies. It has to be added on case by case basis to clean describe-blocks using spies between every it and after the block, so that other blocks don't get broken by a previously running describe-block.

<!-- Type of PR: [ ] unchecked / [ ] checked -->

**_Category:_**

- [ ] ✨ Introduce new features
- [ ] 📝 Add or update documentation
- [x] ✅ Add or update tests
- [ ] 🐛 Fix a bug
- [ ] 🏷️ Add or update types
- [ ] ⚡️ Improve performance
- [ ] _Other(s):_ ...
  <!-- Don't forget to add the gitmoji icon in the name of the PR -->
  <!-- See: https://gitmoji.dev/                                  -->

<!-- Fixing bugs, adding features... may impact existing ones           -->
<!-- in order to track potential issues that could be related to your PR -->
<!-- please check the impacts and describe more precisely what to expect -->

**_Potential impacts:_**

<!-- Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- Typings:          Is there a potential performance impact? In which cases? -->

- [ ] Generated values
- [ ] Shrink values
- [ ] Performance
- [ ] Typings
- [ ] _Other(s):_ ...
