### PR TITLE
🗑️ Mark as deprecated most of char and string arbitraries

### DIFF
--- a/.yarn/versions/2d16b9e2.yml
+++ b/.yarn/versions/2d16b9e2.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: minor
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/ascii.ts
+++ b/packages/fast-check/src/arbitrary/ascii.ts
@@ -4,6 +4,7 @@ import { indexToPrintableIndexMapper, indexToPrintableIndexUnmapper } from './_i
 
 /**
  * For single ascii characters - char code between 0x00 (included) and 0x7f (included)
+ * @deprecated Please use ${@link string} with `fc.string({ unit: 'binary-ascii', minLength: 1, maxLength: 1 })` instead
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/asciiString.ts
+++ b/packages/fast-check/src/arbitrary/asciiString.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit: 'binary-ascii', ...constraints })` instead
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/base64.ts
+++ b/packages/fast-check/src/arbitrary/base64.ts
@@ -19,6 +19,7 @@ function base64Unmapper(v: number) {
 
 /**
  * For single base64 characters - A-Z, a-z, 0-9, + or /
+ * @deprecated Prefer using `fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/')`
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/char.ts
+++ b/packages/fast-check/src/arbitrary/char.ts
@@ -11,6 +11,7 @@ function identity(v: number) {
  *
  * {@link https://www.ascii-code.com/}
  *
+ * @deprecated Please use ${@link string} with `fc.string({ minLength: 1, maxLength: 1 })` instead
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/char16bits.ts
+++ b/packages/fast-check/src/arbitrary/char16bits.ts
@@ -10,6 +10,7 @@ import { indexToPrintableIndexMapper, indexToPrintableIndexUnmapper } from './_i
  * Some generated characters might appear invalid regarding UCS-2 and UTF-16 encoding.
  * Indeed values within 0xd800 and 0xdfff constitute surrogate pair characters and are illegal without their paired character.
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit, minLength: 1, maxLength: 1 })`, utilizing one of its unit variants instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/packages/fast-check/src/arbitrary/fullUnicode.ts
+++ b/packages/fast-check/src/arbitrary/fullUnicode.ts
@@ -30,6 +30,7 @@ function unicodeUnmapper(v: number) {
  *
  * {@link https://tc39.github.io/ecma262/#sec-utf16encoding}
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit: 'grapheme', minLength: 1, maxLength: 1 })` or `fc.string({ unit: 'binary', minLength: 1, maxLength: 1 })` instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/packages/fast-check/src/arbitrary/fullUnicodeString.ts
+++ b/packages/fast-check/src/arbitrary/fullUnicodeString.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit: 'grapheme', ...constraints })` or `fc.string({ unit: 'binary', ...constraints })` instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/packages/fast-check/src/arbitrary/hexa.ts
+++ b/packages/fast-check/src/arbitrary/hexa.ts
@@ -19,6 +19,7 @@ function hexaUnmapper(v: number): number {
 
 /**
  * For single hexadecimal characters - 0-9 or a-f
+ * @deprecated Prefer using `fc.constantFrom(...'0123456789abcdef')`
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/hexaString.ts
+++ b/packages/fast-check/src/arbitrary/hexaString.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit: fc.constantFrom(...'0123456789abcdef'), ...constraints })` instead
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/string16bits.ts
+++ b/packages/fast-check/src/arbitrary/string16bits.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit, ...constraints })`, utilizing one of its unit variants instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/packages/fast-check/src/arbitrary/stringOf.ts
+++ b/packages/fast-check/src/arbitrary/stringOf.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  * @param charArb - Arbitrary able to generate random strings (possibly multiple characters)
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit: charArb, ...constraints })` instead
  * @remarks Since 1.1.3
  * @public
  */

--- a/packages/fast-check/src/arbitrary/unicode.ts
+++ b/packages/fast-check/src/arbitrary/unicode.ts
@@ -25,6 +25,7 @@ function unicodeUnmapper(v: number) {
 
 /**
  * For single unicode characters defined in the BMP plan - char code between 0x0000 (included) and 0xffff (included) and without the range 0xd800 to 0xdfff (surrogate pair characters)
+ * @deprecated Please use ${@link string} with `fc.string({ unit, minLength: 1, maxLength: 1 })`, utilizing one of its unit variants instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/packages/fast-check/src/arbitrary/unicodeString.ts
+++ b/packages/fast-check/src/arbitrary/unicodeString.ts
@@ -14,6 +14,7 @@ const safeObjectAssign = Object.assign;
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
  *
+ * @deprecated Please use ${@link string} with `fc.string({ unit, ...constraints })`, utilizing one of its unit variants instead
  * @remarks Since 0.0.11
  * @public
  */

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -12,8 +12,8 @@ String containing characters produced by the passed character generator.
 
 **Signatures:**
 
-- `fc.stringOf(charArb)` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.stringOf(charArb, {minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.stringOf(charArb)` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.stringOf(charArb, {minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -12,8 +12,8 @@ String containing characters produced by the passed character generator.
 
 **Signatures:**
 
-- `fc.stringOf(charArb)`
-- `fc.stringOf(charArb, {minLength?, maxLength?, size?})`
+- `fc.stringOf(charArb)` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.stringOf(charArb, {minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 

--- a/website/docs/core-blocks/arbitraries/primitives/char.md
+++ b/website/docs/core-blocks/arbitraries/primitives/char.md
@@ -12,7 +12,7 @@ One lowercase hexadecimal character — ie.: _one character in `0123456789abcdef
 
 **Signatures:**
 
-- `fc.hexa()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.hexa()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -30,7 +30,7 @@ One base64 character — _ie.: one character in `A-Z`, `a-z`, `0-9`, `+` or `/`_
 
 **Signatures:**
 
-- `fc.base64()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.base64()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -48,7 +48,7 @@ One printable character — _ie.: one character between `0x20` (included) and `0
 
 **Signatures:**
 
-- `fc.char()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.char()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -66,7 +66,7 @@ One ascii character — _ie.: one character between `0x00` (included) and `0x7f`
 
 **Signatures:**
 
-- `fc.ascii()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.ascii()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -86,7 +86,7 @@ Generate any character of UCS-2 which is a subset of UTF-16 (restricted to BMP p
 
 **Signatures:**
 
-- `fc.unicode()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.unicode()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -106,7 +106,7 @@ Generate any 16 bits character. Be aware the values within `0xd800` and `0xdfff`
 
 **Signatures:**
 
-- `fc.char16bits()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.char16bits()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 
@@ -126,7 +126,7 @@ Its length can be greater than one as it potentially contains multiple UTF-16 ch
 
 **Signatures:**
 
-- `fc.fullUnicode()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.fullUnicode()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **Usages:**
 

--- a/website/docs/core-blocks/arbitraries/primitives/char.md
+++ b/website/docs/core-blocks/arbitraries/primitives/char.md
@@ -12,7 +12,7 @@ One lowercase hexadecimal character — ie.: _one character in `0123456789abcdef
 
 **Signatures:**
 
-- `fc.hexa()`
+- `fc.hexa()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -30,7 +30,7 @@ One base64 character — _ie.: one character in `A-Z`, `a-z`, `0-9`, `+` or `/`_
 
 **Signatures:**
 
-- `fc.base64()`
+- `fc.base64()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -48,7 +48,7 @@ One printable character — _ie.: one character between `0x20` (included) and `0
 
 **Signatures:**
 
-- `fc.char()`
+- `fc.char()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -66,7 +66,7 @@ One ascii character — _ie.: one character between `0x00` (included) and `0x7f`
 
 **Signatures:**
 
-- `fc.ascii()`
+- `fc.ascii()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -86,7 +86,7 @@ Generate any character of UCS-2 which is a subset of UTF-16 (restricted to BMP p
 
 **Signatures:**
 
-- `fc.unicode()`
+- `fc.unicode()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -106,7 +106,7 @@ Generate any 16 bits character. Be aware the values within `0xd800` and `0xdfff`
 
 **Signatures:**
 
-- `fc.char16bits()`
+- `fc.char16bits()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 
@@ -126,7 +126,7 @@ Its length can be greater than one as it potentially contains multiple UTF-16 ch
 
 **Signatures:**
 
-- `fc.fullUnicode()`
+- `fc.fullUnicode()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **Usages:**
 

--- a/website/docs/core-blocks/arbitraries/primitives/string.md
+++ b/website/docs/core-blocks/arbitraries/primitives/string.md
@@ -16,8 +16,8 @@ Hexadecimal string containing characters produced by `fc.hexa()`.
 
 **Signatures:**
 
-- `fc.hexaString()`
-- `fc.hexaString({minLength?, maxLength?, size?})`
+- `fc.hexaString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.hexaString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 
@@ -123,8 +123,8 @@ ASCII string containing characters produced by `fc.ascii()`.
 
 **Signatures:**
 
-- `fc.asciiString()`
-- `fc.asciiString({minLength?, maxLength?, size?})`
+- `fc.asciiString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.asciiString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 
@@ -160,8 +160,8 @@ Unicode string containing characters produced by `fc.unicode()`.
 
 **Signatures:**
 
-- `fc.unicodeString()`
-- `fc.unicodeString({minLength?, maxLength?, size?})`
+- `fc.unicodeString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.unicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 
@@ -199,8 +199,8 @@ Be aware that the generated string might appear invalid regarding the unicode st
 
 **Signatures:**
 
-- `fc.string16bits()`
-- `fc.string16bits({minLength?, maxLength?, size?})`
+- `fc.string16bits()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.string16bits({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 
@@ -236,8 +236,8 @@ Unicode string containing characters produced by `fc.fullUnicode()`.
 
 **Signatures:**
 
-- `fc.fullUnicodeString()`
-- `fc.fullUnicodeString({minLength?, maxLength?, size?})`
+- `fc.fullUnicodeString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.fullUnicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
 
 **with:**
 

--- a/website/docs/core-blocks/arbitraries/primitives/string.md
+++ b/website/docs/core-blocks/arbitraries/primitives/string.md
@@ -16,8 +16,8 @@ Hexadecimal string containing characters produced by `fc.hexa()`.
 
 **Signatures:**
 
-- `fc.hexaString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.hexaString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.hexaString()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.hexaString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 
@@ -123,8 +123,8 @@ ASCII string containing characters produced by `fc.ascii()`.
 
 **Signatures:**
 
-- `fc.asciiString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.asciiString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.asciiString()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.asciiString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 
@@ -160,8 +160,8 @@ Unicode string containing characters produced by `fc.unicode()`.
 
 **Signatures:**
 
-- `fc.unicodeString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.unicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.unicodeString()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.unicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 
@@ -199,8 +199,8 @@ Be aware that the generated string might appear invalid regarding the unicode st
 
 **Signatures:**
 
-- `fc.string16bits()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.string16bits({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.string16bits()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.string16bits({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 
@@ -236,8 +236,8 @@ Unicode string containing characters produced by `fc.fullUnicode()`.
 
 **Signatures:**
 
-- `fc.fullUnicodeString()` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
-- `fc.fullUnicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#xyza](https://github.com/dubzzz/fast-check/pull/xyza))_
+- `fc.fullUnicodeString()` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
+- `fc.fullUnicodeString({minLength?, maxLength?, size?})` — _deprecated since v3.22.0 ([#5233](https://github.com/dubzzz/fast-check/pull/5233))_
 
 **with:**
 


### PR DESCRIPTION
**Description**

This PR deprecates all our past arbitraries of single characters. We recommend to replace them by arbitraries on strings with `minLength` and `maxLength` both set to `1`.

This PR also deprecates all string arbitraries except `string`, `base64String`, `stringMatching` and `mixedCase`. All the deprecated arbitraries could now be expressed using `fc.string` with a specific `unit`. Here are our recommended migration paths:

- `asciiString` can be replaced by `fc.string({ unit: 'binary-ascii' })` (identical behavior).
- `unicodeString` does not have direct equivalent in the recommended world, we either recommend you to build a custom unit arbitrary (see 1 below) or to rely on existing units provided by `fc.string`. Depending on what you wanted to achieve when selecting `fc.unicode` you may go for either `'grapheme'` and related or `'binary'` and related. On our side, we rather recommend to rely on `'grapheme'` and related builders as they better fit with the definition of what is a grapheme from an Unicode point of view.
- `string16bits` does not have direct equivalent in the recommended world (you may read the text written above for `unicodeString` for more recommendations). See 2 below for an exact conversion.
- `fullUnicodeString` can be replaced by `fc.string({ unit: 'binary' })` (identical behavior), that said we rather recommend you to go for `fc.string({ unit: 'grapheme' })` or `fc.string({ unit: 'grapheme-composite' })`.
- `hexaString` does not have direct equivalent in the recommended world. See 3 below for an exact conversion.

**(1) Converting `unicodeString` to `string`:**

```ts
const gapSize = 0xdfff + 1 - 0xd800;
function unicodeMapper(v: number) {
  if (v < 0xd800) return v;
  return v + gapSize;
}
function unicode(): fc.Arbitrary<string> {
  return fc.integer({ min: 0x00, max: 0xff }).map(n => String.fromCodePoint(unicodeMapper(n)));
}
function unicodeString(constraints: fc.StringConstraints = {}): fc.Arbitrary<string> {
  return fc.string({ ...constraints, unit: unicode() });
}
```

**(2) Converting `string16bits` to `string`:**

```ts
function char16bits(): fc.Arbitrary<string> {
  return fc.integer({ min: 0x0000, max: 0xffff }).map(n => String.fromCodePoint(n));
}
function string16bits(constraints: fc.StringConstraints = {}): fc.Arbitrary<string> {
  return fc.string({ ...constraints, unit: char16bits() });
}
```

**(3) Converting `hexaString` to `string`:**

```ts
const items = '0123456789abcdef';
function hexa(): fc.Arbitrary<string> {
  return fc.integer({ min: 0, max: 15 }).map(n => items[n]);
}
function hexaString(constraints: fc.StringConstraints = {}): fc.Arbitrary<string> {
  return fc.string({ ...constraints, unit: hexa() });
}
```

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: 🗑️ Deprecating
- [x] Impacts: API reduction

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
