### PR TITLE
📝 Add examples for: `fc.string()`,  `fc.integer()`,  `fc.nat()`, `fc.dictionary()` and `fc.array()`

### DIFF
--- a/packages/fast-check/src/arbitrary/array.ts
+++ b/packages/fast-check/src/arbitrary/array.ts
@@ -71,7 +71,25 @@ export interface ArrayConstraintsInternal<T> extends ArrayConstraints {
  *
  * @param arb - Arbitrary used to generate the values inside the array
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
+ * 
+ * @example
+ * ```typescript
+ * fc.array(fc.nat());
+ * // Examples of generated values:
+ * // • [1811605556]
+ * // • [773390791,2091685325,1242440672]
+ * // • []
+ * ```
  *
+ * @example
+ * ```typescript
+ * fc.array(fc.string());
+ * // Examples of generated values:
+ * // • ["key"]
+ * // • ["JT>\"C9k", "h]iD\"27;", "S", "n\\Ye", ""]
+ * // • []
+ * ```
+ * 
  * @remarks Since 0.0.1
  * @public
  */

--- a/packages/fast-check/src/arbitrary/dictionary.ts
+++ b/packages/fast-check/src/arbitrary/dictionary.ts
@@ -57,6 +57,43 @@ export interface DictionaryConstraints {
  *
  * @param keyArb - Arbitrary used to generate the keys of the object
  * @param valueArb - Arbitrary used to generate the values of the object
+ * 
+ * @example
+ * ```typescript
+ * fc.dictionary(fc.string(), fc.string());
+ * // Examples of generated values:
+ * // • {"<H":"`D? &7A","T>X0Aa]tp>":":5+|","8{0.mI>8R,":"j._[Xi&.[","!83F]'E1_":"y[bB,G$_S}","NnY,!{":"6NZ4,G'}","Y&>Uj":"gg@eTi","e>QDNvD/gz":"Bt0&oV;","ULLW1":"F6i_","?&I":"lPd7}"}
+ * // • {"_":" y|","Yo+\"O@q+j":"cI{H","":"3#$}9{5!z","?^~k ":"w$defipro","[fa4c":"J"}
+ * // • {"~":""}
+ * // • {"lzproperty":"?"}
+ * // • {"hOIY\"R q}":"W","l__defineG":"8x`:H0?T"}
+ * // • …
+ * ```
+ *
+ * @example
+ * ```typescript
+ * fc.dictionary(fc.string(), fc.nat());
+ * // Examples of generated values:
+ * // • {"":11,".[hM+$+:?N":30,"%{":59342696,"|_":29,"E":670852246,"pl_":2147483639,">":2147483630,"M7cU?#9":1072636200,"ot":1627183273}
+ * // • {"_G@>x":461241683,"@9c=&6H:c0":105089967,"c_)r66nwK":1355210745}
+ * // • {"#1O;mZ1":1005073225}
+ * // • {}
+ * // • {"6":144134225,".9":437743867,"tR?j$Hat3X":1920000943,"DQTd":324814916}
+ * // • …
+ * ```
+ *
+ * @example
+ * ```typescript
+ * fc.dictionary(fc.string(), fc.nat(), { minKeys: 2 });
+ * // Note: Generate instances with at least 2 keys
+ * // Examples of generated values:
+ * // • {"%{":11,"4cH":12,"ke":2147483622,"rqM~i'":485910780}
+ * // • {"K":1498847755,"&cP<5:e(y\"":1430281549,"!\"2a":1631161561,"dY+g":1880545446,"M2+^,Yq7~t":1437539188}
+ * // • {"NfXclS":815533370,"?":2060844890,"":1862140278,"R":618808229,"N|":25902062,"DGw00u?brK":348863633}
+ * // • {" R~Own":2147483645,"~":16,"i$#D":1037390287}
+ * // • {">YTN<Tt":1950414260,"I6":1505301756,"2;]'dH.i!":815067799,":kmC'":1948205418,"g|GTLPe-":2101264769}
+ * // • …
+ * ```
  *
  * @remarks Since 1.0.0
  * @public

--- a/packages/fast-check/src/arbitrary/integer.ts
+++ b/packages/fast-check/src/arbitrary/integer.ts
@@ -37,6 +37,27 @@ function buildCompleteIntegerConstraints(constraints: IntegerConstraints): Requi
  * For integers between min (included) and max (included)
  *
  * @param constraints - Constraints to apply when building instances (since 2.6.0)
+ * 
+ * @example
+ * ```typescript
+ * fc.integer();
+ * // Note: All possible integers between `-2147483648` (included) and `2147483647` (included)
+ * // Examples of generated values: -1064811759, -2147483638, 2032841726, 930965475, -1…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.integer({ min: -99, max: 99 });
+ * // Note: All possible integers between `-99` (included) and `99` (included)
+ * // Examples of generated values: 33, -94, 5, -2, 97…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.integer({ min: 65536 });
+ * // Note: All possible integers between `65536` (included) and `2147483647` (included)
+ * // Examples of generated values: 487771549, 1460850457, 1601368274, 1623935346, 65541…
+ * ```
  *
  * @remarks Since 0.0.1
  * @public

--- a/packages/fast-check/src/arbitrary/nat.ts
+++ b/packages/fast-check/src/arbitrary/nat.ts
@@ -37,6 +37,27 @@ function nat(max: number): Arbitrary<number>;
  * For positive integers between 0 (included) and max (included)
  *
  * @param constraints - Constraints to apply when building instances
+ * 
+ * @example
+ * ```typescript
+ * fc.nat();
+ * // Note: All possible integers between `0` (included) and `2147483647` (included)
+ * // Examples of generated values: 2, 5, 2147483618, 225111650, 1108701149…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.nat(1000);
+ * // Note: All possible integers between `0` (included) and `1000` (included)
+ * // Examples of generated values: 2, 8, 4, 270, 0…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.nat({ max: 1000 });
+ * // Note: All possible integers between `0` (included) and `1000` (included)
+ * // Examples of generated values: 917, 60, 599, 696, 7…
+ * ```
  *
  * @remarks Since 2.6.0
  * @public

--- a/packages/fast-check/src/arbitrary/string.ts
+++ b/packages/fast-check/src/arbitrary/string.ts
@@ -61,6 +61,27 @@ function extractUnitArbitrary(constraints: Pick<StringConstraints, 'unit'>): Arb
  * For strings of {@link char}
  *
  * @param constraints - Constraints to apply when building instances (since 2.4.0)
+ * 
+ * @example
+ * ```typescript
+ * fc.string();
+ * // Examples of generated values: "JT>\"C9k", "h]iD\"27;", "S", "n\\Ye", ""…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.string({ minLength: 4, maxLength: 6 });
+ * // Note: Any string containing between 4 (included) and 6 (included) characters
+ * // Examples of generated values: "Trxlyb", "&&@%4", "s@IO", "0\"zM", "}#\"$"…
+ * ```
+ * 
+ * @example
+ * ```typescript
+ * fc.string({ unit: fc.constantFrom('Hello', 'World') });
+ * // Note: With a custom arbitrary passed as unit, minLength (resp. maxLength) refers to length in terms of unit values.
+ * // As an example, "HelloWorldHello" has a length of 3 in this context.
+ * // Examples of generated values: "", "Hello", "HelloWorld", "HelloWorldHello", "WorldWorldHelloWorldHelloWorld"…
+ * ```
  *
  * @remarks Since 0.0.1
  * @public


### PR DESCRIPTION
**Description**

This PR adds a few examples for  `fc.string()`,  `fc.integer()`,  `fc.nat()`, `fc.dictionary()` and `fc.array()`. Extracted from the [Fast-Check documentation](https://fast-check.dev/docs/introduction/) page. The goal is to improve developer understanding by embedding usage examples directly into the codebase.

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [ ] My PR references one of several related issues (if any)
  - [ ] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [ ] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [ ] My PR adds relevant tests and they would have failed without my PR (when applicable)

**Advanced**

- [x] Category: 📝 Add or update documentation
- [x] Impacts: N/A
