### PR TITLE
🐛 Resist even more to external poisoning for `string`

### DIFF
--- a/.changeset/mighty-teachers-listen.md
+++ b/.changeset/mighty-teachers-listen.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+🐛 Resist even more to external poisoning for `string`

--- a/packages/fast-check/src/arbitrary/_internals/StringUnitArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/StringUnitArbitrary.ts
@@ -1,4 +1,5 @@
 import type { Arbitrary } from '../../check/arbitrary/definition/Arbitrary';
+import { safeNormalize, safePush } from '../../utils/globals';
 import { mapToConstant } from '../mapToConstant';
 import type { GraphemeRange } from './data/GraphemeRanges';
 import {
@@ -44,15 +45,15 @@ function getOrCreateStringUnitInstance(type: StringUnitType, alphabet: StringUni
   const ranges = type === 'binary' ? alphabetRanges : intersectGraphemeRanges(alphabetRanges, autonomousGraphemeRanges);
   const entries: GraphemeRangeEntry[] = [];
   for (const range of ranges) {
-    entries.push(convertGraphemeRangeToMapToConstantEntry(range));
+    safePush(entries, convertGraphemeRangeToMapToConstantEntry(range));
   }
   if (type === 'grapheme') {
     const decomposedRanges = intersectGraphemeRanges(alphabetRanges, autonomousDecomposableGraphemeRanges);
     for (const range of decomposedRanges) {
       const rawEntry = convertGraphemeRangeToMapToConstantEntry(range);
-      entries.push({
+      safePush(entries, {
         num: rawEntry.num,
-        build: (idInGroup) => rawEntry.build(idInGroup).normalize('NFD'),
+        build: (idInGroup) => safeNormalize(rawEntry.build(idInGroup), 'NFD'),
       });
     }
   }

--- a/packages/fast-check/src/arbitrary/_internals/helpers/GraphemeRangesHelpers.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/GraphemeRangesHelpers.ts
@@ -1,3 +1,4 @@
+import { safePop, safePush } from '../../../utils/globals';
 import type { GraphemeRange } from '../data/GraphemeRanges';
 
 /** @internal */
@@ -62,10 +63,10 @@ export function intersectGraphemeRanges(rangesA: GraphemeRange[], rangesB: Graph
         const lastMergedRangeMax = lastMergedRange.length === 1 ? lastMergedRange[0] : lastMergedRange[1];
         if (lastMergedRangeMax + 1 === min) {
           min = lastMergedRange[0];
-          mergedRanges.pop();
+          safePop(mergedRanges);
         }
       }
-      mergedRanges.push(min === max ? [min] : [min, max]);
+      safePush(mergedRanges, min === max ? [min] : [min, max]);
       if (rangeAMax <= max) {
         cursorA += 1;
       }

--- a/packages/fast-check/src/arbitrary/_internals/mappers/IndexToMappedConstant.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/IndexToMappedConstant.ts
@@ -1,3 +1,8 @@
+import { Error } from '../../../utils/globals';
+
+/** @internal */
+const safeObjectIs = Object.is;
+
 /** @internal */
 export function indexToMappedConstantMapperFor<T>(
   entries: { num: number; build: (idInGroup: number) => T }[],
@@ -51,7 +56,7 @@ export function indexToMappedConstantUnmapperFor<T>(
     if (reverseMapping === null) {
       reverseMapping = buildReverseMapping(entries);
     }
-    const choiceIndex = Object.is(value, -0) ? reverseMapping.negativeZeroIndex : reverseMapping.mapping.get(value);
+    const choiceIndex = safeObjectIs(value, -0) ? reverseMapping.negativeZeroIndex : reverseMapping.mapping.get(value);
     if (choiceIndex === undefined) {
       throw new Error('Unknown value encountered cannot be built using this mapToConstant');
     }

--- a/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
@@ -1,7 +1,7 @@
 import type { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary';
 import { MaxLengthUpperBound } from '../helpers/MaxLengthFromMinLength';
 import type { StringSharedConstraints } from '../../_shared/StringSharedConstraints';
-import { safeJoin, safePop, safePush, safeSubstring } from '../../../utils/globals';
+import { safeJoin, safePop, safePush, safeSubstring, Error } from '../../../utils/globals';
 
 /** @internal - tab is supposed to be composed of valid entries extracted from the source arbitrary */
 export function patternsToStringMapper(tab: string[]): string {

--- a/packages/fast-check/src/arbitrary/mapToConstant.ts
+++ b/packages/fast-check/src/arbitrary/mapToConstant.ts
@@ -4,6 +4,7 @@ import {
   indexToMappedConstantMapperFor,
   indexToMappedConstantUnmapperFor,
 } from './_internals/mappers/IndexToMappedConstant';
+import { Error } from '../utils/globals';
 
 /** @internal */
 function computeNumChoices<T>(options: { num: number; build: (idInGroup: number) => T }[]): number {

--- a/packages/fast-check/src/utils/globals.ts
+++ b/packages/fast-check/src/utils/globals.ts
@@ -292,6 +292,7 @@ const untouchedToLowerCase = String.prototype.toLowerCase;
 const untouchedToUpperCase = String.prototype.toUpperCase;
 const untouchedPadStart = String.prototype.padStart;
 const untouchedCharCodeAt = String.prototype.charCodeAt;
+const untouchedNormalize = String.prototype.normalize;
 const untouchedReplace: (pattern: RegExp | string, replacement: string) => string = String.prototype.replace;
 function extractSplit(instance: string) {
   try {
@@ -345,6 +346,13 @@ function extractPadStart(instance: string) {
 function extractCharCodeAt(instance: string) {
   try {
     return instance.charCodeAt;
+  } catch (err) {
+    return undefined;
+  }
+}
+function extractNormalize(instance: string) {
+  try {
+    return instance.normalize;
   } catch (err) {
     return undefined;
   }
@@ -412,6 +420,12 @@ export function safeCharCodeAt(instance: string, index: number): number {
     return instance.charCodeAt(index);
   }
   return safeApply(untouchedCharCodeAt, instance, [index]);
+}
+export function safeNormalize(instance: string, form: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): string {
+  if (extractNormalize(instance) === untouchedNormalize) {
+    return instance.normalize(form);
+  }
+  return safeApply(untouchedNormalize, instance, [form]);
 }
 export function safeReplace(instance: string, pattern: RegExp | string, replacement: string): string {
   if (extractReplace(instance) === untouchedReplace) {


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

`string` used to be pretty reliable against poisoning and still is. But when used in some context such as the result of another generated value (in the case of `.chain` or `fc.gen`) it can expose users to unability to compute itself if a poisoning occured in-between.

As such this PR makes it even more reliable.

Thanks to that PR, `string` arbitrary should be able to better support an ustable environment with some globals being altered or dropped.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: 🐛 Fix a bug
- [x] Impacts: Making fast-check more reliable

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
