### PR TITLE
✅(vitest) Add retry for Node 23

### DIFF
--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
+const major = Number(process.versions.node.split('.')[0]);
+
 export default defineConfig({
   test: {
     testTimeout: 60000, // 60s
     include: ['**/test/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    retry: major === 23 ? 5 : undefined,
   },
 });


### PR DESCRIPTION
Retries are needed for now against Node 23. There is an open ticket on V8 side (see https://issues.chromium.org/issues/374285493) and one on Node side (see https://github.com/nodejs/node/issues/54918) regarding hanging issues of Node 23.