### PR TITLE
✨ Add back strong unmapping capabilities to `string`

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/helpers/SlicesForStringBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/SlicesForStringBuilder.ts
@@ -2,6 +2,7 @@ import type { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary';
 import { safeGet, safePush, safeSet } from '../../../utils/globals';
 import type { StringSharedConstraints } from '../../_shared/StringSharedConstraints';
 import { patternsToStringUnmapperIsValidLength } from '../mappers/PatternsToString';
+import { MaxLengthUpperBound } from './MaxLengthFromMinLength';
 import { tokenizeString } from './TokenizeString';
 
 const dangerousStrings = [
@@ -77,7 +78,7 @@ const slicesPerArbitrary = new WeakMap<Arbitrary<string>, string[][]>();
 function createSlicesForStringNoConstraints(charArbitrary: Arbitrary<string>): string[][] {
   const slicesForString: string[][] = [];
   for (const dangerous of dangerousStrings) {
-    const candidate = tokenizeString(charArbitrary, dangerous);
+    const candidate = tokenizeString(charArbitrary, dangerous, 0, MaxLengthUpperBound);
     if (candidate !== undefined) {
       safePush(slicesForString, candidate);
     }

--- a/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
@@ -10,10 +10,18 @@ export function patternsToStringMapper(tab: string[]): string {
 }
 
 /** @internal */
+function minLengthFrom(constraints: StringSharedConstraints): number {
+  return constraints.minLength !== undefined ? constraints.minLength : 0;
+}
+
+/** @internal */
+function maxLengthFrom(constraints: StringSharedConstraints): number {
+  return constraints.maxLength !== undefined ? constraints.maxLength : MaxLengthUpperBound;
+}
+
+/** @internal */
 export function patternsToStringUnmapperIsValidLength(tokens: string[], constraints: StringSharedConstraints): boolean {
-  const minLength = constraints.minLength !== undefined ? constraints.minLength : 0;
-  const maxLength = constraints.maxLength !== undefined ? constraints.maxLength : MaxLengthUpperBound;
-  return minLength <= tokens.length && tokens.length <= maxLength;
+  return minLengthFrom(constraints) <= tokens.length && tokens.length <= maxLengthFrom(constraints);
 }
 
 /** @internal */
@@ -26,10 +34,10 @@ export function patternsToStringUnmapperFor(
       throw new Error('Unsupported value');
     }
 
-    const tokens = tokenizeString(patternsArb, value);
-    if (tokens !== undefined && patternsToStringUnmapperIsValidLength(tokens, constraints)) {
-      return tokens;
+    const tokens = tokenizeString(patternsArb, value, minLengthFrom(constraints), maxLengthFrom(constraints));
+    if (tokens === undefined) {
+      throw new Error('Unable to unmap received string');
     }
-    throw new Error('Unable to unmap received string');
+    return tokens;
   };
 }


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

Reverting part of the capability-drop introduced by #5387.

When working on #5387, we dropped some unmapping capabilities on `string`. In the past `string` arbitrary used to be able to shrink even custom values and that even if it uses a pretty uncommon dictionary of units. With #5387 we restricted the unmapping capabilities a bit by dropping some of these very advanced supports.

Now that we know that we can add this support back while preserving our performance uplift we add part of them back.

In other words, before #5387 the following arbitrary could have shrunk `...___...`:

```ts
fc.string({ maxLength: 3, unit: fc.constantFrom('._', '_...', '_._.', '_..', '.', '.._.', '__.', '....', '..', '.___', '._..', '__', '_.', '___', '.__.', '__._', '._.', '...', '_', '.._', '..._', '.__', '_.._', '_.__', '__..') })
```

After the PR #5387, he was not able anymore.

But we are adding back such support! Which will be mostly invisible for all our users :joy:

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ✨ Introduce new features
- [x] Impacts: New and not new at the same time, it never disappeared from officially published versions

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
