### PR TITLE
🔥 Remove `withDeletedKeys` from `record`

### DIFF
--- a/.yarn/versions/784a780f.yml
+++ b/.yarn/versions/784a780f.yml
@@ -1,0 +1,8 @@
+releases:
+  fast-check: major
+
+declined:
+  - "@fast-check/ava"
+  - "@fast-check/jest"
+  - "@fast-check/vitest"
+  - "@fast-check/worker"

--- a/.yarn/versions/784a780f.yml
+++ b/.yarn/versions/784a780f.yml
@@ -1,8 +1,0 @@
-releases:
-  fast-check: major
-
-declined:
-  - "@fast-check/ava"
-  - "@fast-check/jest"
-  - "@fast-check/vitest"
-  - "@fast-check/worker"

--- a/packages/fast-check/src/arbitrary/record.ts
+++ b/packages/fast-check/src/arbitrary/record.ts
@@ -7,35 +7,18 @@ import type { EnumerableKeyOf } from './_internals/helpers/EnumerableKeysExtract
  * @remarks Since 0.0.12
  * @public
  */
-export type RecordConstraints<T = unknown> = (
-  | {
-      /**
-       * List keys that should never be deleted.
-       *
-       * Remark:
-       * You might need to use an explicit typing in case you need to declare symbols as required (not needed when required keys are simple strings).
-       * With something like `{ requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] }` when both `mySymbol1` and `a` are required.
-       *
-       * Warning: Cannot be used in conjunction with withDeletedKeys.
-       *
-       * @defaultValue Array containing all keys of recordModel
-       * @remarks Since 2.11.0
-       */
-      requiredKeys?: T[];
-    }
-  | {
-      /**
-       * Allow to remove keys from the generated record.
-       * Warning: Cannot be used in conjunction with requiredKeys.
-       * Prefer: `requiredKeys: []` over `withDeletedKeys: true`
-       *
-       * @defaultValue false
-       * @remarks Since 1.0.0
-       * @deprecated Prefer using `requiredKeys: []` instead of `withDeletedKeys: true` as the flag will be removed in the next major
-       */
-      withDeletedKeys?: boolean;
-    }
-) & {
+export type RecordConstraints<T = unknown> = {
+  /**
+   * List keys that should never be deleted.
+   *
+   * Remark:
+   * You might need to use an explicit typing in case you need to declare symbols as required (not needed when required keys are simple strings).
+   * With something like `{ requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] }` when both `mySymbol1` and `a` are required.
+   *
+   * @defaultValue Array containing all keys of recordModel
+   * @remarks Since 2.11.0
+   */
+  requiredKeys?: T[];
   /**
    * Do not generate records with null prototype
    * @defaultValue true
@@ -52,13 +35,9 @@ export type RecordConstraints<T = unknown> = (
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type RecordValue<T, TConstraints = {}> = TConstraints extends { withDeletedKeys: boolean; requiredKeys: any[] }
-  ? never
-  : TConstraints extends { withDeletedKeys: true }
-    ? Partial<T>
-    : TConstraints extends { requiredKeys: (infer TKeys)[] }
-      ? Partial<T> & Pick<T, TKeys & keyof T>
-      : T;
+export type RecordValue<T, TConstraints = {}> = TConstraints extends { requiredKeys: (infer TKeys)[] }
+  ? Partial<T> & Pick<T, TKeys & keyof T>
+  : T;
 
 /**
  * For records following the `recordModel` schema
@@ -80,7 +59,7 @@ function record<T>(recordModel: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<
  *
  * @example
  * ```typescript
- * record({ x: someArbitraryInt, y: someArbitraryInt }, {withDeletedKeys: true}): Arbitrary<{x?:number,y?:number}>
+ * record({ x: someArbitraryInt, y: someArbitraryInt }, {requiredKeys: []}): Arbitrary<{x?:number,y?:number}>
  * // merge two integer arbitraries to produce a {x, y}, {x}, {y} or {} record
  * ```
  *
@@ -104,13 +83,7 @@ function record<T>(
     return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }
 
-  if ('withDeletedKeys' in constraints && 'requiredKeys' in constraints) {
-    throw new Error(`requiredKeys and withDeletedKeys cannot be used together in fc.record`);
-  }
-
-  const requireDeletedKeys =
-    ('requiredKeys' in constraints && constraints.requiredKeys !== undefined) ||
-    ('withDeletedKeys' in constraints && !!constraints.withDeletedKeys);
+  const requireDeletedKeys = 'requiredKeys' in constraints && constraints.requiredKeys !== undefined;
   if (!requireDeletedKeys) {
     return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }

--- a/packages/fast-check/test-types/main.ts
+++ b/packages/fast-check/test-types/main.ts
@@ -197,14 +197,6 @@ expectType<fc.Arbitrary<{ a: number; b: string }>>()(
   fc.record({ a: fc.nat(), b: fc.string() }, {}),
   '"record" accepts empty constraints',
 );
-expectType<fc.Arbitrary<{ a: number; b: string }>>()(
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: false }),
-  '"record" understands withDeletedKeys=false',
-);
-expectType<fc.Arbitrary<{ a?: number; b?: string }>>()(
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: true }),
-  '"record" understands withDeletedKeys=true',
-);
 expectType<fc.Arbitrary<{ a?: number; b?: string }>>()(
   fc.record({ a: fc.nat(), b: fc.string() }, { requiredKeys: [] }),
   '"record" only applies optional on keys declared within requiredKeys even when empty',
@@ -240,12 +232,6 @@ expectType<fc.Arbitrary<{ [mySymbol1]: number; [mySymbol2]?: string; a: number; 
     { requiredKeys: [mySymbol1, 'a'] as [typeof mySymbol1, 'a'] },
   ),
   '"record" only applies optional on keys declared within requiredKeys even if it contains symbols and normal keys',
-);
-expectType<fc.Arbitrary<never>>()(
-  // requiredKeys and withDeletedKeys cannot be used together
-  // typings are not perfect but at least they build a value that cannot be used
-  fc.record({ a: fc.nat(), b: fc.string() }, { withDeletedKeys: true, requiredKeys: [] }),
-  '"record" receiving both withDeletedKeys and requiredKeys is invalid',
 );
 type Query = { data: { field: 'X' } };
 expectType<fc.Arbitrary<Query>>()(

--- a/packages/fast-check/test/e2e/NoRegression.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegression.spec.ts
@@ -506,7 +506,7 @@ describe(`NoRegression`, () => {
     expect(
       runWithSanitizedStack(() =>
         fc.assert(
-          fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { withDeletedKeys: true }), (v) => testFunc(v)),
+          fc.property(fc.record({ k1: fc.nat(), k2: fc.nat() }, { requiredKeys: [] }), (v) => testFunc(v)),
           settings,
         ),
       ),

--- a/packages/fast-check/test/e2e/arbitraries/RecordArbitrary.spec.ts
+++ b/packages/fast-check/test/e2e/arbitraries/RecordArbitrary.spec.ts
@@ -24,7 +24,7 @@ describe(`RecordArbitrary (seed: ${seed})`, () => {
         cc: fc.string(),
       };
       const out = fc.check(
-        fc.property(fc.record(recordModel, { withDeletedKeys: true }), (obj) => obj.bb == null),
+        fc.property(fc.record(recordModel, { requiredKeys: [] }), (obj) => obj.bb == null),
         {
           seed: seed,
         },
@@ -42,7 +42,7 @@ describe(`RecordArbitrary (seed: ${seed})`, () => {
         forceNegativeOutput: fc.boolean(),
       };
       const out = fc.check(
-        fc.property(fc.record(recordModel, { withDeletedKeys: true }), (obj) => {
+        fc.property(fc.record(recordModel, { requiredKeys: [] }), (obj) => {
           if (obj.forcePositiveOutput === true && obj.forceNegativeOutput === true) return false;
           return true;
         }),

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/FloatingPointHelpers.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/FloatingPointHelpers.ts
@@ -46,7 +46,7 @@ function constraintsInternal(
   is32Bits: boolean,
 ): fc.Arbitrary<ConstraintsInternalOut> {
   return fc
-    .record(recordConstraints, { withDeletedKeys: true })
+    .record(recordConstraints, { requiredKeys: [] })
     .filter((ct) => {
       // Forbid min and max to be NaN
       return (ct.min === undefined || !Number.isNaN(ct.min)) && (ct.max === undefined || !Number.isNaN(ct.max));

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/TypedIntArrayArbitraryBuilder.spec.ts
@@ -193,7 +193,7 @@ function defaultsMinMaxTypedInt8Arb() {
 }
 
 function validArrayConstraintsArb() {
-  return fc.record({ minLength: fc.nat(), maxLength: fc.nat() }, { withDeletedKeys: true }).map((ct) => {
+  return fc.record({ minLength: fc.nat(), maxLength: fc.nat() }, { requiredKeys: [] }).map((ct) => {
     if (ct.minLength !== undefined && ct.maxLength !== undefined && ct.minLength > ct.maxLength) {
       return { minLength: ct.maxLength, maxLength: ct.minLength };
     }
@@ -202,14 +202,12 @@ function validArrayConstraintsArb() {
 }
 
 function validIntegerConstraintsArb(min: number, max: number) {
-  return fc
-    .record({ min: fc.integer({ min, max }), max: fc.integer({ min, max }) }, { withDeletedKeys: true })
-    .map((ct) => {
-      if (ct.min !== undefined && ct.max !== undefined && ct.min > ct.max) {
-        return { min: ct.max, max: ct.min };
-      }
-      return ct;
-    });
+  return fc.record({ min: fc.integer({ min, max }), max: fc.integer({ min, max }) }, { requiredKeys: [] }).map((ct) => {
+    if (ct.min !== undefined && ct.max !== undefined && ct.min > ct.max) {
+      return { min: ct.max, max: ct.min };
+    }
+    return ct;
+  });
 }
 
 function invalidIntegerConstraintsArb(min: number, max: number) {

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -52,7 +52,7 @@ describe('double', () => {
     fc.assert(
       fc.property(
         float64raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         (f, otherCt) => {
           // Arrange
           fc.pre(!Number.isNaN(f));
@@ -72,7 +72,7 @@ describe('double', () => {
     fc.assert(
       fc.property(
         float64raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         fc.constantFrom('min', 'max', 'both'),
         (f, otherCt, exclusiveMode) => {
           // Arrange

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -67,7 +67,7 @@ describe('float', () => {
     fc.assert(
       fc.property(
         float32raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         (f, otherCt) => {
           // Arrange
           fc.pre(isNotNaN32bits(f));
@@ -87,7 +87,7 @@ describe('float', () => {
     fc.assert(
       fc.property(
         float32raw(),
-        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { withDeletedKeys: true }),
+        fc.record({ noDefaultInfinity: fc.boolean(), noNaN: fc.boolean() }, { requiredKeys: [] }),
         fc.constantFrom('min', 'max', 'both'),
         (f, otherCt, exclusiveMode) => {
           // Arrange

--- a/packages/fast-check/test/unit/arbitrary/record.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/record.spec.ts
@@ -52,36 +52,6 @@ describe('record', () => {
       ),
     ));
 
-  it('should call buildPartialRecordArbitrary with keys=[] when constraints defines withDeletedKeys=true', () =>
-    fc.assert(
-      fc.property(
-        fc.uniqueArray(keyArb, { minLength: 1 }),
-        fc.option(fc.boolean(), { nil: undefined }),
-        (keys, noNullPrototype) => {
-          // Arrange
-          const recordModel: Record<string | symbol, Arbitrary<any>> = {};
-          for (const k of keys) {
-            const { instance } = fakeArbitrary();
-            recordModel[k] = instance;
-          }
-          const { instance } = fakeArbitrary<any>();
-          const buildPartialRecordArbitrary = vi.spyOn(
-            PartialRecordArbitraryBuilderMock,
-            'buildPartialRecordArbitrary',
-          );
-          buildPartialRecordArbitrary.mockReturnValue(instance);
-
-          // Act
-          const arb = record(recordModel, { withDeletedKeys: true, noNullPrototype });
-
-          // Assert
-          expect(arb).toBe(instance);
-          expect(buildPartialRecordArbitrary).toHaveBeenCalledTimes(1);
-          expect(buildPartialRecordArbitrary).toHaveBeenCalledWith(recordModel, [], noNullPrototype !== false);
-        },
-      ),
-    ));
-
   it('should call buildPartialRecordArbitrary with keys=requiredKeys when constraints defines valid requiredKeys', () =>
     fc.assert(
       fc.property(
@@ -146,34 +116,6 @@ describe('record', () => {
       }),
     ));
 
-  it('should reject configurations specifying both requiredKeys and withDeletedKeys (even undefined)', () =>
-    fc.assert(
-      fc.property(
-        fc.uniqueArray(fc.record({ name: keyArb, required: fc.boolean() }), {
-          minLength: 1,
-          selector: (entry) => entry.name,
-        }),
-        fc.option(fc.constant(true), { nil: undefined }),
-        fc.option(fc.boolean(), { nil: undefined }),
-        (keys, withRequiredKeys, withDeletedKeys) => {
-          // Arrange
-          const recordModel: Record<string | symbol, Arbitrary<any>> = {};
-          for (const k of keys) {
-            const { instance } = fakeArbitrary();
-            recordModel[k.name] = instance;
-          }
-
-          // Act / Assert
-          expect(() =>
-            record(recordModel, {
-              requiredKeys: withRequiredKeys ? keys.filter((k) => k.required).map((k) => k.name) : undefined,
-              withDeletedKeys: withDeletedKeys,
-            }),
-          ).toThrowError();
-        },
-      ),
-    ));
-
   it('should accept empty keys configurations with empty requiredKeys', () => {
     // Arrange
     const recordModel: Record<string | symbol, Arbitrary<any>> = {};
@@ -221,13 +163,13 @@ describe('record (integration)', () => {
     }),
     { selector: (entry) => entry.key },
   );
-  const constraintsArbitrary = fc.oneof(
-    fc.record({ withDeletedKeys: fc.boolean(), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
-    fc.record({ withRequiredKeys: fc.constant<true>(true), noNullPrototype: fc.boolean() }, { requiredKeys: [] }),
+  const constraintsArbitrary = fc.record(
+    { withRequiredKeys: fc.constant<true>(true), noNullPrototype: fc.boolean() },
+    { requiredKeys: [] },
   );
   const extraParameters: fc.Arbitrary<Extra> = fc
     .tuple(metaArbitrary, constraintsArbitrary)
-    .map(([metas, constraintsMeta]: [Meta[], { withDeletedKeys?: boolean; withRequiredKeys?: true }]) => {
+    .map(([metas, constraintsMeta]: [Meta[], { withRequiredKeys?: true }]) => {
       if ('withRequiredKeys' in constraintsMeta) {
         return [
           metas,
@@ -249,13 +191,6 @@ describe('record (integration)', () => {
     }
     for (const m of metas) {
       // optional keys can be missing in the generated instance
-      if (
-        'withDeletedKeys' in constraints &&
-        constraints.withDeletedKeys === true &&
-        !Object.prototype.hasOwnProperty.call(value, m.key)
-      ) {
-        continue;
-      }
       if (
         'requiredKeys' in constraints &&
         constraints.requiredKeys !== undefined &&

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -80,13 +80,11 @@ It comes very useful when dealing with settings.
 
 - `fc.record(recordModel)`
 - `fc.record(recordModel, {requiredKeys?, noNullPrototype?})`
-- `fc.record(recordModel, {withDeletedKeys?, noNullPrototype?})`
 
 **with:**
 
 - `recordModel` — _structure of the resulting instance_
-- `requiredKeys?` — default: `[all keys of recordModel]` — _list of keys that should never be deleted, remark: cannot be used with `withDeletedKeys`_
-- `withDeletedKeys?` — default: `false` — _when enabled, record might not generate all keys. `withDeletedKeys: true` is equivalent to `requiredKeys: []`, thus the two options cannot be used at the same time_
+- `requiredKeys?` — default: `[all keys of recordModel]` — _list of keys that should never be deleted_
 - `noNullPrototype?` — default: `true` — _only generate records based on the Object-prototype, do not generate any record with null-prototype_
 
 **Usages:**
@@ -143,15 +141,15 @@ fc.record(
     id: fc.uuidV(4),
     age: fc.nat(99),
   },
-  { withDeletedKeys: true },
+  { requiredKeys: [] },
 );
 // Note: Both id and age will be optional values
 // Examples of generated values:
-// • {"id":"ffffffe1-582d-457d-899e-8084fffffff7","age":97}
-// • {"age":96}
-// • {"id":"00000012-bdc2-4b1c-8a2a-245900000006","age":6}
-// • {"id":"8785297a-e305-43bc-bfff-fff1927a3512","age":30}
-// • {"age":17}
+// • {"id":"00000004-27f6-48bb-8000-000a69064200","age":3}
+// • {"id":"ffffffee-ffef-4fff-8000-0015f69788ee","age":21}
+// • {"age":34}
+// • {"id":"2db92e09-3fdc-49e6-8000-001b00000007","age":5}
+// • {"id":"00000006-0007-4000-8397-86ea00000004"}
 // • …
 ```
 

--- a/website/docs/migration/from-3.x-to-4.x.md
+++ b/website/docs/migration/from-3.x-to-4.x.md
@@ -3,6 +3,9 @@ sidebar_position: 1
 slug: /migration-guide/from-3.x-to-4.x/
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # From 3.x to 4.x
 
 Simple migration guide to fast-check v4 starting from fast-check v3
@@ -14,3 +17,34 @@ Simple migration guide to fast-check v4 starting from fast-check v3
 | TypeScript _(optional)_ | ≥5.0            | ≥4.1                 |
 
 Related pull requests: [#5577](https://github.com/dubzzz/fast-check/pull/5577)
+
+## Update to latest v3.x
+
+Version 4 of fast-check introduces significant changes as part of its major release, including breaking changes. However, many of these changes can be addressed while still using the latest minor release of version 3.
+
+To ensure a smoother migration to version 4, we recommend first upgrading to the latest minor release of version 3. Then, review and address the following deprecation notices to align your codebase with supported patterns.
+
+### Changes on `record`
+
+In earlier versions, the `record` arbitrary included a flag named `withDeletedKeys`. Starting with version 2.11.0, this flag was deprecated and replaced by a new flag called `requiredKeys`. In version 4.0.0, the deprecated `withDeletedKeys` flag has been removed entirely.
+
+To migrate, update your usage of the `record` arbitrary as follows:
+
+<Tabs>
+  <TabItem value="before" label="Before">
+
+```ts
+fc.record(definition, { withDeletedKeys: true });
+fc.record(definition, { withDeletedKeys: false });
+```
+
+  </TabItem>
+  <TabItem value="after" label="After" default>
+
+```ts
+fc.record(definition, { requiredKeys: [] }); // previously: "withDeletedKeys: true"
+fc.record(definition, {}); // equivalent to "requiredKeys: undefined", previously: "withDeletedKeys: false"
+```
+
+  </TabItem>
+</Tabs>

--- a/website/docs/migration/from-3.x-to-4.x.md
+++ b/website/docs/migration/from-3.x-to-4.x.md
@@ -3,9 +3,6 @@ sidebar_position: 1
 slug: /migration-guide/from-3.x-to-4.x/
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # From 3.x to 4.x
 
 Simple migration guide to fast-check v4 starting from fast-check v3
@@ -30,23 +27,14 @@ In earlier versions, the `record` arbitrary included a flag named `withDeletedKe
 
 To migrate, update your usage of the `record` arbitrary as follows:
 
-<Tabs>
-  <TabItem value="before" label="Before">
-
-```ts
-fc.record(definition, { withDeletedKeys: true });
-fc.record(definition, { withDeletedKeys: false });
+```diff
+fc.record(definition, {
+-  withDeletedKeys: true,
++  requiredKeys: [],
+});
+fc.record(definition, {
+-  withDeletedKeys: false,
+});
 ```
-
-  </TabItem>
-  <TabItem value="after" label="After" default>
-
-```ts
-fc.record(definition, { requiredKeys: [] }); // previously: "withDeletedKeys: true"
-fc.record(definition, {}); // equivalent to "requiredKeys: undefined", previously: "withDeletedKeys: false"
-```
-
-  </TabItem>
-</Tabs>
 
 Related pull requests: [#5578](https://github.com/dubzzz/fast-check/pull/5578)

--- a/website/docs/migration/from-3.x-to-4.x.md
+++ b/website/docs/migration/from-3.x-to-4.x.md
@@ -28,11 +28,11 @@ In earlier versions, the `record` arbitrary included a flag named `withDeletedKe
 To migrate, update your usage of the `record` arbitrary as follows:
 
 ```diff
-fc.record(definition, {
+fc.record(recordModel, {
 -  withDeletedKeys: true,
 +  requiredKeys: [],
 });
-fc.record(definition, {
+fc.record(recordModel, {
 -  withDeletedKeys: false,
 });
 ```

--- a/website/docs/migration/from-3.x-to-4.x.md
+++ b/website/docs/migration/from-3.x-to-4.x.md
@@ -48,3 +48,5 @@ fc.record(definition, {}); // equivalent to "requiredKeys: undefined", previousl
 
   </TabItem>
 </Tabs>
+
+Related pull requests: [#5578](https://github.com/dubzzz/fast-check/pull/5578)


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

Initially `record` came with `withDeletedKeys`, but quickly we received the need to have a better granularity level to deal with keys to keep or not and so `requiredKeys` came.

Now, that we have it for some time, we want to drop `withDeletedKeys` as it tends to add complexity to the code and the API.

A migration path and possibly some scripts to help users to run the change might be provided in the future. For now the recommendation would be to replace: `withDeletedKeys: true` by `requiredKeys: []` and `withDeletedKeys: false` by nothing or `requiredKeys: [...here all the keys...]`.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

**:boom: Breaking change**: Drop deprecated flag (replaced by another one)

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
