### PR TITLE
⚡️ Drop unneeded `BigInt` check in `mixedCase`

### DIFF
--- a/.changeset/lazy-cherries-grin.md
+++ b/.changeset/lazy-cherries-grin.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+⚡️ Drop unneeded `BigInt` check in `mixedCase` (#5211)

--- a/packages/fast-check/src/arbitrary/mixedCase.ts
+++ b/packages/fast-check/src/arbitrary/mixedCase.ts
@@ -1,5 +1,5 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary';
-import { safeToUpperCase, safeToLowerCase, BigInt, Error } from '../utils/globals';
+import { safeToUpperCase, safeToLowerCase } from '../utils/globals';
 import { MixedCaseArbitrary } from './_internals/MixedCaseArbitrary';
 
 /**
@@ -43,9 +43,6 @@ function defaultToggleCase(rawChar: string) {
  * @public
  */
 export function mixedCase(stringArb: Arbitrary<string>, constraints?: MixedCaseConstraints): Arbitrary<string> {
-  if (typeof BigInt === 'undefined') {
-    throw new Error(`mixedCase requires BigInt support`);
-  }
   const toggleCase = (constraints && constraints.toggleCase) || defaultToggleCase;
   const untoggleAll = constraints && constraints.untoggleAll;
   return new MixedCaseArbitrary(stringArb, toggleCase, untoggleAll);


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

While not being really expensive to compute it's yet another check and dropping it could be useful if we want to go faster. Indeed with `BigInt` being a thing in Node since 10.5.0, we probably don't want to pay for checking it all the time.

We will probably have to bump our minimal requirement to 10.5.0+ for the version 4 of fast-check so that we can expect it to always be a thing no matter the runtime being used as long as it fits our requirements.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at
https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ⚡️ Improve performance
- [x] Impacts: No