### PR TITLE
🔥 Drop unneeded catch param

### DIFF
--- a/.changeset/lazy-sloths-turn.md
+++ b/.changeset/lazy-sloths-turn.md
@@ -1,0 +1,5 @@
+---
+"fast-check": major
+---
+
+🔥 Drop unneeded catch param

--- a/packages/fast-check/src/arbitrary/_internals/helpers/SlicesForStringBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/SlicesForStringBuilder.ts
@@ -42,7 +42,7 @@ function computeCandidateStringLegacy(
   let candidate: string[];
   try {
     candidate = stringSplitter(dangerous);
-  } catch (err) {
+  } catch {
     // No split found for `dangerous`, `dangerous` cannot be shrunk by arrays made of `charArbitrary`
     return undefined;
   }

--- a/packages/fast-check/src/check/arbitrary/definition/Arbitrary.ts
+++ b/packages/fast-check/src/check/arbitrary/definition/Arbitrary.ts
@@ -273,7 +273,7 @@ class MapArbitrary<T, U> extends Arbitrary<U> {
       try {
         const unmapped = this.unmapper(value);
         return this.arb.canShrinkWithoutContext(unmapped);
-      } catch (_err) {
+      } catch {
         return false;
       }
     }

--- a/packages/fast-check/src/utils/apply.ts
+++ b/packages/fast-check/src/utils/apply.ts
@@ -11,7 +11,7 @@ function safeExtractApply<T, TArgs extends unknown[], TReturn>(
 ): ((thisArg: T) => TReturn) | undefined {
   try {
     return f.apply;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/fast-check/src/utils/globals.ts
+++ b/packages/fast-check/src/utils/globals.ts
@@ -69,77 +69,77 @@ const untouchedEvery = Array.prototype.every;
 function extractForEach(instance: unknown[]) {
   try {
     return instance.forEach;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractIndexOf(instance: readonly unknown[]) {
   try {
     return instance.indexOf;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractJoin(instance: unknown[]) {
   try {
     return instance.join;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractMap(instance: unknown[]) {
   try {
     return instance.map;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractFilter(instance: unknown[]) {
   try {
     return instance.filter;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractPush(instance: unknown[]) {
   try {
     return instance.push;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractPop(instance: unknown[]) {
   try {
     return instance.pop;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractSplice(instance: unknown[]) {
   try {
     return instance.splice;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractSlice(instance: unknown[]) {
   try {
     return instance.slice;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractSort(instance: unknown[]) {
   try {
     return instance.sort;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractEvery(instance: unknown[]) {
   try {
     return instance.every;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -223,14 +223,14 @@ const untouchedToISOString = Date.prototype.toISOString;
 function extractGetTime(instance: Date) {
   try {
     return instance.getTime;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractToISOString(instance: Date) {
   try {
     return instance.toISOString;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -254,7 +254,7 @@ const untouchedHas = Set.prototype.has;
 function extractAdd(instance: Set<unknown>) {
   try {
     return instance.add;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -355,56 +355,56 @@ const untouchedReplace: (pattern: RegExp | string, replacement: string) => strin
 function extractSplit(instance: string) {
   try {
     return instance.split;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractStartsWith(instance: string) {
   try {
     return instance.startsWith;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractEndsWith(instance: string) {
   try {
     return instance.endsWith;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractSubstring(instance: string) {
   try {
     return instance.substring;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractToLowerCase(instance: string) {
   try {
     return instance.toLowerCase;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractToUpperCase(instance: string) {
   try {
     return instance.toUpperCase;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractPadStart(instance: string) {
   try {
     return instance.padStart;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 function extractCharCodeAt(instance: string) {
   try {
     return instance.charCodeAt;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -418,7 +418,7 @@ function extractNormalize(instance: string) {
 function extractReplace(instance: string) {
   try {
     return instance.replace;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -498,7 +498,7 @@ const untouchedNumberToString = Number.prototype.toString;
 function extractNumberToString(instance: number) {
   try {
     return instance.toString;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/fast-check/src/utils/stringify.ts
+++ b/packages/fast-check/src/utils/stringify.ts
@@ -159,7 +159,7 @@ export function stringifyInternal<Ts>(
     // if user defined custom sync serialization function, we use it before next ones
     try {
       return value[toStringMethod]();
-    } catch (err) {
+    } catch {
       // fallback to defaults...
     }
   }
@@ -214,7 +214,7 @@ export function stringifyInternal<Ts>(
           // Instance (or one of its parent prototypes) overrides the default toString of Object
           return (value as any).toString(); // <-- Can throw
         }
-      } catch (err) {
+      } catch {
         // Only return what would have been the default toString on Object
         return '[object Object]';
       }

--- a/packages/fast-check/test/e2e/NoRegression.spec.ts
+++ b/packages/fast-check/test/e2e/NoRegression.spec.ts
@@ -818,7 +818,7 @@ describe(`NoRegression`, () => {
               try {
                 fc.modelRun(setup, cmds);
                 return true;
-              } catch (err) {
+              } catch {
                 return false;
               }
             },

--- a/packages/fast-check/test/e2e/NoStackOverflowOnShrink.spec.ts
+++ b/packages/fast-check/test/e2e/NoStackOverflowOnShrink.spec.ts
@@ -12,7 +12,7 @@ const computeMaximalStackSize = () => {
   };
   try {
     f();
-  } catch (_err) {
+  } catch {
     // throws 'RangeError: Maximum call stack size exceeded'
   }
   return depth;

--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -180,7 +180,7 @@ function dropAllFromObj(obj: unknown): (() => void)[] {
       const descriptor = safeObjectGetOwnPropertyDescriptor(obj, k)!;
       delete (obj as any)[k];
       restores.push(() => safeObjectDefineProperty(obj, k, descriptor));
-    } catch (err) {
+    } catch {
       // Object.prototype cannot be deleted, and others might too
     }
   }

--- a/packages/fast-check/test/e2e/ReplayFailures.spec.ts
+++ b/packages/fast-check/test/e2e/ReplayFailures.spec.ts
@@ -60,7 +60,7 @@ describe(`ReplayFailures (seed: ${seed})`, () => {
             expect(data).toEqual(out.counterexample![0]);
             validCallIndex = numCalls;
             ++numValidCalls;
-          } catch (err) {
+          } catch {
             // noop
           }
           ++numCalls;

--- a/packages/fast-check/test/e2e/arbitraries/ObjectArbitrary.spec.ts
+++ b/packages/fast-check/test/e2e/arbitraries/ObjectArbitrary.spec.ts
@@ -30,7 +30,7 @@ describe(`ObjectArbitrary (seed: ${seed})`, () => {
           try {
             JSON.parse(revJson(json));
             return false;
-          } catch (err) {
+          } catch {
             return true;
           }
         }),

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/ArbitraryAssertions.ts
@@ -234,7 +234,7 @@ export function assertProduceSomeSpecificValues<T, U = never>(
       // We default numRuns to 1000, but let user override it whenever needed
       assertParameters: { numRuns: 1000, ...options.assertParameters, endOnFailure: true },
     });
-  } catch (err) {
+  } catch {
     // no-op
   }
   expect(foundOne).toBe(true);

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
@@ -231,7 +231,7 @@ function isStringified(v: unknown): boolean {
   try {
     eval(v);
     return true; // the string was correctly parsed
-  } catch (err) {
+  } catch {
     return false; // not a valid representation
   }
 }
@@ -244,7 +244,7 @@ function isStringifiedAsKeys(v: unknown): boolean {
     try {
       eval(key);
       return true; // the string used as key the string representation of a JavaScript instance
-    } catch (err) {
+    } catch {
       // not a valid representation
     }
   }

--- a/packages/fast-check/test/unit/arbitrary/commands.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/commands.spec.ts
@@ -25,7 +25,7 @@ describe('commands (integration)', () => {
       if (!c.check(model)) continue;
       try {
         c.run(model, real);
-      } catch (err) {
+      } catch {
         return;
       }
     }

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -77,7 +77,7 @@ function regexBasedOnChunks(): fc.Arbitrary<Extra> {
     try {
       new RegExp('.', 'd'); // Not supported in Node 14
       return true;
-    } catch (err) {
+    } catch {
       return false;
     }
   })();

--- a/packages/fast-check/test/unit/utils/stringify.spec.ts
+++ b/packages/fast-check/test/unit/utils/stringify.spec.ts
@@ -19,7 +19,7 @@ const checkEqual = (a: any, b: any): boolean => {
   try {
     expect(a).toEqual(b);
     return true;
-  } catch (err) {
+  } catch {
     return false;
   }
 };

--- a/packages/poisoning/test/main.spec.ts
+++ b/packages/poisoning/test/main.spec.ts
@@ -121,7 +121,7 @@ describe('assertNoPoisoning', () => {
           // @ts-ignore
           delete obj[k];
           ++numDeleted;
-        } catch (err) {
+        } catch {
           // Object.prototype cannot be deleted, and others might too
         }
       }

--- a/website/docs/migration/from-3.x-to-4.x.md
+++ b/website/docs/migration/from-3.x-to-4.x.md
@@ -15,7 +15,7 @@ Simple migration guide to fast-check v4 starting from fast-check v3
 | ECMAScript specification | ES2020          | ES2017               |
 | TypeScript _(optional)_  | ≥5.0            | ≥4.1                 |
 
-Related pull requests: [#5577](https://github.com/dubzzz/fast-check/pull/5577), [#5605](https://github.com/dubzzz/fast-check/pull/5605), [#5617](https://github.com/dubzzz/fast-check/pull/5617)
+Related pull requests: [#5577](https://github.com/dubzzz/fast-check/pull/5577), [#5605](https://github.com/dubzzz/fast-check/pull/5605), [#5617](https://github.com/dubzzz/fast-check/pull/5617), [#5634](https://github.com/dubzzz/fast-check/pull/5634)
 
 ## Update to latest v3.x
 


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

There is no more need to specify anything when catching an error without treating it.

Let's adopt "Optional catch binding" in our codebase! Available since Node 10 and ES2019.

Related to #5282

**Important** - Once reaching next-3.23.0, we should add back the eslint configuration: `'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', caughtErrors: 'none' }],`.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at
https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: Shorter code/readability
- [x] Impacts: Require node >=10

