### PR TITLE
⚡️ Faster ipV6 generation with cached string builders

### DIFF
--- a/.changeset/swift-buckets-perform.md
+++ b/.changeset/swift-buckets-perform.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+⚡️ Faster ipV6 generation with cached string builders

--- a/packages/fast-check/src/arbitrary/ipV6.ts
+++ b/packages/fast-check/src/arbitrary/ipV6.ts
@@ -34,27 +34,31 @@ function h16sTol32Unmapper(value: unknown): [string, string] {
 }
 
 const items = '0123456789abcdef';
+let cachedHexa: Arbitrary<string> | undefined = undefined;
 /** @internal */
 function hexa(): Arbitrary<string> {
-  return integer({ min: 0, max: 15 }).map(
-    (n) => items[n],
-    (c) => {
-      if (typeof c !== 'string') {
-        throw new Error('Not a string');
-      }
-      if (c.length !== 1) {
-        throw new Error('Invalid length');
-      }
-      const code = safeCharCodeAt(c, 0); // 0=48,..,9=57,a=97,..,f=102
-      if (code <= 57) {
-        return code - 48; // any char before '0' will lead to <0 (rejected by integer)
-      }
-      if (code < 97) {
-        throw new Error('Invalid character');
-      }
-      return code - 87; // -87=-97+10, any char after 'f' will lead to >15 (rejected by integer)
-    },
-  );
+  if (cachedHexa === undefined) {
+    cachedHexa = integer({ min: 0, max: 15 }).map(
+      (n) => items[n],
+      (c) => {
+        if (typeof c !== 'string') {
+          throw new Error('Not a string');
+        }
+        if (c.length !== 1) {
+          throw new Error('Invalid length');
+        }
+        const code = safeCharCodeAt(c, 0); // 0=48,..,9=57,a=97,..,f=102
+        if (code <= 57) {
+          return code - 48; // any char before '0' will lead to <0 (rejected by integer)
+        }
+        if (code < 97) {
+          throw new Error('Invalid character');
+        }
+        return code - 87; // -87=-97+10, any char after 'f' will lead to >15 (rejected by integer)
+      },
+    );
+  }
+  return cachedHexa;
 }
 
 /**


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

While we moved away from `hexa` and `hexaString` we somehow killed the performance of `ipV6`. Indeed it used to rely on `hexaString` which was extremely fast to be instantiated. By switching to `string` we forgot about stabilizing the `unit`. As such each call to create a string of hexa characters will pay an extra cost.

This PR is supposed to address this regression.

```txt
│ (index) │ Task Name                                                        │ ops/sec     │ Average Time (ns)  │ Margin     │ Samples │
├─────────┼──────────────────────────────────────────────────────────────────┼─────────────┼────────────────────┼────────────┼─────────┤
│ 164     │ 'ipV6 [property] on fast-check@3.23.0'                           │ '1,759'     │ 568265.730002895   │ '±4.34%'   │ 100     │
│ 165     │ 'ipV6 [property] on fast-check@main'                             │ '481'       │ 2078033.290001331  │ '±1.76%'   │ 100     │
│ 166     │ 'ipV6 [property] on fast-check@extra'                            │ '1,827'     │ 547190.2500046417  │ '±4.20%'   │ 100     │
│ 384     │ 'ipV6 [init] on fast-check@3.23.0'                               │ '125,684'   │ 7956.439999397845  │ '±22.05%'  │ 100     │
│ 385     │ 'ipV6 [init] on fast-check@main'                                 │ '608'       │ 1642458.1099988427 │ '±2.46%'   │ 100     │
│ 386     │ 'ipV6 [init] on fast-check@extra'                                │ '261,875'   │ 3818.6100008897483 │ '±32.17%'  │ 100     │
```

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ⚡️ Improve performance
- [x] Impacts: None expected

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
