### PR TITLE
🐛 Stricter checks for consecutive `noBias`

### DIFF
--- a/.changeset/ten-wolves-jam.md
+++ b/.changeset/ten-wolves-jam.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+🐛 Stricter checks for consecutive `noBias`

--- a/packages/fast-check/src/arbitrary/noBias.ts
+++ b/packages/fast-check/src/arbitrary/noBias.ts
@@ -5,30 +5,6 @@ import type { Stream } from '../stream/Stream';
 
 const stableObjectGetPrototypeOf = Object.getPrototypeOf;
 
-/**
- * Build an arbitrary without any bias.
- *
- * The produced instance wraps the source one and ensures the bias factor will always be passed to undefined meaning bias will be deactivated.
- * All the rest stays unchanged.
- *
- * @param arb - The original arbitrary used for generating values. This arbitrary remains unchanged.
- *
- * @remarks Since 3.20.0
- * @public
- */
-export function noBias<T>(arb: Arbitrary<T>): Arbitrary<T> {
-  if (
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    stableObjectGetPrototypeOf(arb) === NoBiasArbitrary.prototype &&
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    arb.generate === NoBiasArbitrary.prototype.generate
-  ) {
-    return arb;
-  }
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  return new NoBiasArbitrary(arb);
-}
-
 /** @internal */
 class NoBiasArbitrary<T> extends Arbitrary<T> {
   constructor(readonly arb: Arbitrary<T>) {
@@ -43,4 +19,27 @@ class NoBiasArbitrary<T> extends Arbitrary<T> {
   shrink(value: T, context?: unknown): Stream<Value<T>> {
     return this.arb.shrink(value, context);
   }
+}
+
+/**
+ * Build an arbitrary without any bias.
+ *
+ * The produced instance wraps the source one and ensures the bias factor will always be passed to undefined meaning bias will be deactivated.
+ * All the rest stays unchanged.
+ *
+ * @param arb - The original arbitrary used for generating values. This arbitrary remains unchanged.
+ *
+ * @remarks Since 3.20.0
+ * @public
+ */
+export function noBias<T>(arb: Arbitrary<T>): Arbitrary<T> {
+  if (
+    stableObjectGetPrototypeOf(arb) === NoBiasArbitrary.prototype &&
+    arb.generate === NoBiasArbitrary.prototype.generate &&
+    arb.canShrinkWithoutContext === NoBiasArbitrary.prototype.canShrinkWithoutContext &&
+    arb.shrink === NoBiasArbitrary.prototype.shrink
+  ) {
+    return arb;
+  }
+  return new NoBiasArbitrary(arb);
 }

--- a/packages/fast-check/test/unit/arbitrary/noBias.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/noBias.spec.ts
@@ -54,28 +54,31 @@ describe('noBias', () => {
     expect(secondNoBias).toBe(firstNoBias);
   });
 
-  it('should return itself when called twice except when altered on generate', () => {
-    // Arrange
-    class MyNextArbitrary extends Arbitrary<any> {
-      generate(): Value<any> {
-        throw new Error('Not implemented.');
+  it.each([{ method: 'generate' }, { method: 'canShrinkWithoutContext' }, { method: 'shrink' }])(
+    'should return itself when called twice except when altered on $method',
+    ({ method }) => {
+      // Arrange
+      class MyNextArbitrary extends Arbitrary<any> {
+        generate(): Value<any> {
+          throw new Error('Not implemented.');
+        }
+        canShrinkWithoutContext(value: unknown): value is any {
+          throw new Error('Not implemented.');
+        }
+        shrink(): Stream<Value<any>> {
+          throw new Error('Not implemented.');
+        }
       }
-      canShrinkWithoutContext(value: unknown): value is any {
-        throw new Error('Not implemented.');
-      }
-      shrink(): Stream<Value<any>> {
-        throw new Error('Not implemented.');
-      }
-    }
-    const fakeArbitrary: Arbitrary<any> = new MyNextArbitrary();
+      const fakeArbitrary: Arbitrary<any> = new MyNextArbitrary();
 
-    // Act
-    const firstNoBias = noBias(fakeArbitrary);
-    // @ts-expect-error - Evil inplace override of a method
-    firstNoBias.generate = () => {};
-    const secondNoBias = noBias(firstNoBias);
+      // Act
+      const firstNoBias = noBias(fakeArbitrary);
+      // @ts-expect-error - Evil inplace override of a method
+      firstNoBias[method] = () => {};
+      const secondNoBias = noBias(firstNoBias);
 
-    // Assert
-    expect(secondNoBias).not.toBe(firstNoBias);
-  });
+      // Assert
+      expect(secondNoBias).not.toBe(firstNoBias);
+    },
+  );
 });


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

When wrapping twice in a row an arbitrary using `noBias`, the helper function responsible to add `noBias` to your arbitrary may decide not to do so if the provided arbitrary is already the result of `noBias`.

Previously the check was limited to prototype and generate method. We extended it to all methods of our arbitraries.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `yarn bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: 🐛 Fix a bug 
- [x] Impacts: None expected
<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
