### PR TITLE
✨ Wait longer before scheduling anything with `waitFor`

### DIFF
--- a/.changeset/eleven-rice-matter.md
+++ b/.changeset/eleven-rice-matter.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Wait longer before scheduling anything with `waitFor`


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

Our scheduler API provides multiple ways to wait for scheduled tasks. One of them is `waitFor`.

The `waitFor` awaiter is currently waiting for 1 tick before starting to schedule anything. The "1 tick" sounds both high and low at the same time. Our target is to bump to something more realistic to avoid our users from running into strange issues where fast-check is just stupidly scheduling tasks one after the others without changing the ordering just because our users has to deal with extra ticks between tasks (user awaits things before scheduling something in one code path and not the other).

This PR bumps this 1 tick to 50. Normally most users will be safe. 

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `pnpm run bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ✨ Introduce new features
- [x] Impacts: Better scheduling with `waitFor`, does not change the contract of `waitFor`. The end-user was already expecting that behavior to occur. We just makes it possible on more cases.

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
