### PR TITLE
✨ Better capture scheduled tasks before running scheduling

### DIFF
--- a/.changeset/tough-cameras-brush.md
+++ b/.changeset/tough-cameras-brush.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Better capture scheduled tasks before running scheduling

--- a/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
@@ -828,7 +828,7 @@ describe('SchedulerImplem', () => {
       await process;
     });
 
-    it('should schedule known Promises as quickly as possible when depending on promise ticks', async () => {
+    it('should try to wait enough ticks for all Promises to be registered before scheduling any', async () => {
       // Arrange
       const awaitedTask = buildUnresolved();
       const seenTasks: unknown[][] = [];
@@ -862,8 +862,6 @@ describe('SchedulerImplem', () => {
 
       // Assert
       expect(processFlags).toEqual(expectedFlags);
-      const batchSize = numTicksBeforeScheduling;
-      let expectedCount = batchSize + 1;
       for (let i = 0; i !== expectedFlags.length; ++i) {
         // Scheduled promises will be partially grouped into common batches, the process we play with does fire in parallel:
         // - s.schedule(promise[0])
@@ -871,13 +869,120 @@ describe('SchedulerImplem', () => {
         // - Promise.resolve().then(() => {}).then(() => s.schedule(promise[2]))
         // - Promise.resolve().then(() => {}).then(() => {}).then(() => s.schedule(promise[3]))...
         // In other words, promise[3] gets scheduled 3 ticks after promise[0].
-        expect(seenTasks[i]).toEqual(
-          promises.slice(i, i + expectedCount).map((p) => expect.objectContaining({ original: p })),
-        );
-        expectedCount += batchSize;
+        expect(seenTasks[i]).toEqual(promises.slice(i).map((p) => expect.objectContaining({ original: p })));
       }
-      expect(seenTasks).toHaveLength(expectedFlags.length); // all promises took part in the first scheduling
     });
+
+    it.each([
+      { gap: numTicksBeforeScheduling, success: true, label: 'and could wait long' },
+      { gap: numTicksBeforeScheduling + 1, success: false, label: 'but may miss some' },
+    ])(
+      'should try to wait enough ticks for all Promises to be registered before scheduling any $label',
+      async ({ gap, success }) => {
+        // Arrange
+        const awaitedTask = buildUnresolved();
+        const seenTasks: unknown[][] = [];
+        const nextTaskIndex = vi.fn().mockImplementation((tasks) => {
+          seenTasks.push([...tasks]); // cloning as the tasks will be edited in-place
+          return 0; // automatically releasing first available promise
+        });
+        const taskSelector: TaskSelector<unknown> = { clone: vi.fn(), nextTaskIndex };
+
+        // Act
+        const s = new SchedulerImplem((f) => f(), taskSelector);
+        let processFlags: number[] = [];
+        function wrapPromise(promise: Promise<number>, extraTicks: number): Promise<number> {
+          if (extraTicks === 0) {
+            return s.schedule(promise);
+          }
+          let p = Promise.resolve();
+          for (let i = 1; i !== extraTicks; ++i) {
+            p = p.then(() => {});
+          }
+          return p.then(() => s.schedule(promise));
+        }
+        const p1 = Promise.resolve(1);
+        const p2 = Promise.resolve(2);
+        async function startProcess() {
+          processFlags = await Promise.all([wrapPromise(p1, 0), wrapPromise(p2, gap)]);
+          awaitedTask.resolve();
+        }
+        startProcess();
+        await s.waitFor(awaitedTask.p);
+
+        // Assert
+        expect(processFlags).toEqual([1, 2]);
+        expect(seenTasks[0]).toEqual(
+          success
+            ? [expect.objectContaining({ original: p1 }), expect.objectContaining({ original: p2 })]
+            : [expect.objectContaining({ original: p1 })],
+        );
+        expect(seenTasks[1]).toEqual([expect.objectContaining({ original: p2 })]);
+      },
+    );
+
+    it.each([
+      { gap: numTicksBeforeScheduling, success: true, label: 'and could wait long' },
+      { gap: numTicksBeforeScheduling + 1, success: false, label: 'but may miss some' },
+    ])(
+      'should try to wait enough ticks for all Promises to be registered before scheduling and reset on new scheduling any $label',
+      async ({ gap, success }) => {
+        // Arrange
+        const awaitedTask = buildUnresolved();
+        const seenTasks: unknown[][] = [];
+        const nextTaskIndex = vi.fn().mockImplementation((tasks) => {
+          seenTasks.push([...tasks]); // cloning as the tasks will be edited in-place
+          return 0; // automatically releasing first available promise
+        });
+        const taskSelector: TaskSelector<unknown> = { clone: vi.fn(), nextTaskIndex };
+
+        // Act
+        const s = new SchedulerImplem((f) => f(), taskSelector);
+        let processFlags: number[] = [];
+        function wrapPromise(promise: Promise<number>, extraTicks: number): Promise<number> {
+          if (extraTicks === 0) {
+            return s.schedule(promise);
+          }
+          let p = Promise.resolve();
+          for (let i = 1; i !== extraTicks; ++i) {
+            p = p.then(() => {});
+          }
+          return p.then(() => s.schedule(promise));
+        }
+        const belowBatchSize = 10;
+        expect(belowBatchSize).toBeLessThan(numTicksBeforeScheduling);
+        const p1 = Promise.resolve(1);
+        const p2 = Promise.resolve(2);
+        const p3 = Promise.resolve(3);
+        async function startProcess() {
+          processFlags = await Promise.all([
+            wrapPromise(p1, 0),
+            wrapPromise(p2, belowBatchSize),
+            wrapPromise(p3, belowBatchSize + gap),
+          ]);
+          awaitedTask.resolve();
+        }
+        startProcess();
+        await s.waitFor(awaitedTask.p);
+
+        // Assert
+        expect(processFlags).toEqual([1, 2, 3]);
+        expect(seenTasks[0]).toEqual(
+          success
+            ? [
+                expect.objectContaining({ original: p1 }),
+                expect.objectContaining({ original: p2 }),
+                expect.objectContaining({ original: p3 }),
+              ]
+            : [expect.objectContaining({ original: p1 }), expect.objectContaining({ original: p2 })],
+        );
+        expect(seenTasks[1]).toEqual([
+          expect.objectContaining({ original: p2 }),
+          expect.objectContaining({ original: p3 }),
+        ]);
+        expect(seenTasks[2]).toEqual([expect.objectContaining({ original: p3 })]);
+      },
+    );
 
     it('should schedule known Promises without any timeout delay', async () => {
       // Arrange

--- a/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/implementations/SchedulerImplem.spec.ts
@@ -863,7 +863,7 @@ describe('SchedulerImplem', () => {
       // Assert
       expect(processFlags).toEqual(expectedFlags);
       for (let i = 0; i !== expectedFlags.length; ++i) {
-        // Scheduled promises will be partially grouped into common batches, the process we play with does fire in parallel:
+        // Scheduled promises will be grouped into common batches, the process we play with does fire in parallel:
         // - s.schedule(promise[0])
         // - Promise.resolve().then(() => s.schedule(promise[1]))
         // - Promise.resolve().then(() => {}).then(() => s.schedule(promise[2]))


### PR DESCRIPTION
**Description**

<!-- Please provide a short description and potentially linked issues justifying the need for this PR -->

We want our users never to worry about how we internally deal with waiting for promises to be scheduled. Given the fact there is no API (in JS) available to know if they are pending promises awaiting, we are empirically letting a few ticks running before closing the set of promises that we consider for a batch.

This PR makes sure that anytime a new promise gets added for a batch, we reset our window to wait a bit longer. It makes us safer on the fast that we are gonna catch them all.

<!-- * Your PR is fixing a bug or regression? Check for existing issues related to this bug and link them -->
<!-- * Your PR is adding a new feature? Make sure there is a related issue or discussion attached to it -->

<!-- You can provide any additional context to help into understanding what's this PR is attempting to solve: reproduction of a bug, code snippets... -->

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
  - [x] My PR does not add any new dependency without an associated Issue or Discussion
- [x] My PR includes bumps details, please run `pnpm run bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ✨ Introduce new features
- [x] Impacts: Scheduler can schedule more tasks within the same batch, it implies that we may eventually find way more race conditions than what we used to detect. In practice this case will probably never be triggered but we prefer having it covered.

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
