### PR TITLE
👷 Measure coverage on Mac OS

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -219,7 +219,7 @@ jobs:
             os: 'windows-latest'
             shard: '2/2'
     env:
-      ENABLE_COVERAGE: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x' }}
+      ENABLE_COVERAGE: ${{ matrix.os == 'macos-latest' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install pnpm


### PR DESCRIPTION
Measuring coverage on Linux makes the CI unhappy as Vitest suddenly started to crash on the spec responsible to generate our documentation. Switching to Mac OS fixed the issue for now.