### PR TITLE
:sparkles: Add 'history' parameter to infiniteStream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Any change in the code may have impact in the next release. In order to ease our
 - minor: new features
 - major: breaking changes
 
-In order to ease this work, before opening the PR (or after if you forgot to do it), you should run the script `pnpm bump` to underline which packages have been impacted. Please note that our internals and private packages must always be toggled to 'decline' as we don't plan to bump their versions.
+In order to ease this work, before opening the PR (or after if you forgot to do it), you should run the script `pnpm -w run bump` to underline which packages have been impacted. Please note that our internals and private packages must always be toggled to 'decline' as we don't plan to bump their versions.
 
 #### Update your PR
 

--- a/packages/fast-check/src/arbitrary/infiniteStream.ts
+++ b/packages/fast-check/src/arbitrary/infiniteStream.ts
@@ -5,15 +5,20 @@ import { StreamArbitrary } from './_internals/StreamArbitrary';
 /**
  * Produce an infinite stream of values
  *
+ * WARNING: By default, infiniteStream remembers all values it has ever
+ * generated. This causes unbounded memory growth during large tests.
+ * Set history=false to disable.
+ *
  * WARNING: Requires Object.assign
  *
  * @param arb - Arbitrary used to generate the values
+ * @param history - Whether to remember generated values (since 4.3.0)
  *
  * @remarks Since 1.8.0
  * @public
  */
-function infiniteStream<T>(arb: Arbitrary<T>): Arbitrary<Stream<T>> {
-  return new StreamArbitrary(arb);
+function infiniteStream<T>(arb: Arbitrary<T>, history: boolean = true): Arbitrary<Stream<T>> {
+  return new StreamArbitrary(arb, history);
 }
 
 export { infiniteStream };

--- a/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -647,11 +647,11 @@ Execution summary:
 exports[`NoRegression (async) > infiniteStream (to Promise) 1`] = `
 [Error: Property failed after 1 tests
 { seed: 42, path: "0", endOnFailure: true }
-Counterexample: [Stream(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]
+Counterexample: [Stream(10 emitted)(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]
 Shrunk 0 time(s)
 
 Execution summary:
-[31m×[0m [Stream(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]]
+[31m×[0m [Stream(10 emitted)(Promise.resolve(-2),Promise.resolve(-22),Promise.resolve(24),Promise.resolve(8),Promise.resolve(9975393),Promise.resolve(25),Promise.resolve(-757343395),Promise.resolve(-1407968202),Promise.resolve(6),Promise.resolve(2147483645)…)]]
 `;
 
 exports[`NoRegression (async) > number 1`] = `
@@ -3237,11 +3237,11 @@ Execution summary:
 exports[`NoRegression > infiniteStream 1`] = `
 [Error: Property failed after 1 tests
 { seed: 42, path: "0", endOnFailure: true }
-Counterexample: [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]
+Counterexample: [Stream(10 emitted)(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]
 Shrunk 0 time(s)
 
 Execution summary:
-[31m×[0m [Stream(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]]
+[31m×[0m [Stream(10 emitted)(2147483646,9,24,8,9975393,2147483642,1390140253,739515446,6,28…)]]
 `;
 
 exports[`NoRegression > int8Array 1`] = `

--- a/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/StreamArbitrary.spec.ts
@@ -18,132 +18,147 @@ describe('StreamArbitrary', () => {
   declareCleaningHooksForSpies();
 
   describe('generate', () => {
-    it('should produce a cloneable instance of Stream', () => {
-      // Arrange
-      const biasFactor = 48;
-      const { instance: sourceArb } = fakeArbitrary();
-      const { instance: mrng } = fakeRandom();
+    it('should produce a cloneable instance of Stream', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const biasFactor = 48;
+          const { instance: sourceArb } = fakeArbitrary();
+          const { instance: mrng } = fakeRandom();
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const out = arb.generate(mrng, biasFactor);
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const out = arb.generate(mrng, biasFactor);
 
-      // Assert
-      expect(out.value).toBeInstanceOf(Stream);
-      expect(out.hasToBeCloned).toBe(true);
-      expect(hasCloneMethod(out.value)).toBe(true);
-    });
+          // Assert
+          expect(out.value).toBeInstanceOf(Stream);
+          expect(out.hasToBeCloned).toBe(true);
+          expect(hasCloneMethod(out.value)).toBe(true);
+        }),
+      ));
 
-    it('should not call generate before we pull from the Stream but decide bias', () => {
-      // Arrange
-      const biasFactor = 48;
-      const { instance: sourceArb, generate } = fakeArbitrary();
-      const { instance: mrng, nextInt } = fakeRandom();
+    it('should not call generate before we pull from the Stream but decide bias', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const biasFactor = 48;
+          const { instance: sourceArb, generate } = fakeArbitrary();
+          const { instance: mrng, nextInt } = fakeRandom();
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      arb.generate(mrng, biasFactor).value;
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          arb.generate(mrng, biasFactor).value;
 
-      // Assert
-      expect(nextInt).toHaveBeenCalledTimes(1);
-      expect(nextInt).toHaveBeenCalledWith(1, biasFactor);
-      expect(generate).not.toHaveBeenCalled();
-    });
+          // Assert
+          expect(nextInt).toHaveBeenCalledTimes(1);
+          expect(nextInt).toHaveBeenCalledWith(1, biasFactor);
+          expect(generate).not.toHaveBeenCalled();
+        }),
+      ));
 
-    it('should not check bias again for cloned instances', () => {
-      // Arrange
-      const biasFactor = 48;
-      const { instance: sourceArb, generate } = fakeArbitrary();
-      const internalValue = { [cloneMethod]: () => internalValue };
-      generate.mockReturnValue(new Value(internalValue, undefined));
-      const { instance: mrng, nextInt } = fakeRandom();
+    it('should not check bias again for cloned instances', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const biasFactor = 48;
+          const { instance: sourceArb, generate } = fakeArbitrary();
+          const internalValue = { [cloneMethod]: () => internalValue };
+          generate.mockReturnValue(new Value(internalValue, undefined));
+          const { instance: mrng, nextInt } = fakeRandom();
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const out = arb.generate(mrng, biasFactor);
-      const s1 = out.value;
-      const s2 = out.value;
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const out = arb.generate(mrng, biasFactor);
+          const s1 = out.value;
+          const s2 = out.value;
 
-      // Assert
-      expect(nextInt).toHaveBeenCalledTimes(1);
-      expect(nextInt).toHaveBeenCalledWith(1, biasFactor);
-      if (Object.is(s1, s2)) {
-        throw new Error(`We do not expect s1 to be identical to s2`);
-      }
-    });
+          // Assert
+          expect(nextInt).toHaveBeenCalledTimes(1);
+          expect(nextInt).toHaveBeenCalledWith(1, biasFactor);
+          if (Object.is(s1, s2)) {
+            throw new Error(`We do not expect s1 to be identical to s2`);
+          }
+        }),
+      ));
 
-    it('should call generate with cloned instance of Random as we pull from the Stream', () => {
-      // Arrange
-      const numValuesToPull = 5;
-      const biasFactor = 48;
-      let index = 0;
-      const expectedValues = [...Array(numValuesToPull)].map(() => Symbol());
-      const { instance: sourceArb, generate } = fakeArbitrary();
-      generate.mockImplementation(() => new Value(expectedValues[index++], undefined));
-      const { instance: mrng, clone, nextInt } = fakeRandom();
-      nextInt.mockReturnValueOnce(1); // for bias
-      const { instance: mrngCloned } = fakeRandom();
-      clone.mockReturnValueOnce(mrngCloned);
+    it('should call generate with cloned instance of Random as we pull from the Stream', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const numValuesToPull = 5;
+          const biasFactor = 48;
+          let index = 0;
+          const expectedValues = [...Array(numValuesToPull)].map(() => Symbol());
+          const { instance: sourceArb, generate } = fakeArbitrary();
+          generate.mockImplementation(() => new Value(expectedValues[index++], undefined));
+          const { instance: mrng, clone, nextInt } = fakeRandom();
+          nextInt.mockReturnValueOnce(1); // for bias
+          const { instance: mrngCloned } = fakeRandom();
+          clone.mockReturnValueOnce(mrngCloned);
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const stream = arb.generate(mrng, biasFactor).value;
-      const values = [...stream.take(numValuesToPull)];
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const stream = arb.generate(mrng, biasFactor).value;
+          const values = [...stream.take(numValuesToPull)];
 
-      // Assert
-      expect(generate).toHaveBeenCalledTimes(numValuesToPull);
-      for (const call of generate.mock.calls) {
-        expect(call).toEqual([mrngCloned, biasFactor]);
-      }
-      expect(values).toEqual(expectedValues);
-    });
+          // Assert
+          expect(generate).toHaveBeenCalledTimes(numValuesToPull);
+          for (const call of generate.mock.calls) {
+            expect(call).toEqual([mrngCloned, biasFactor]);
+          }
+          expect(values).toEqual(expectedValues);
+        }),
+      ));
 
-    it('should call generate with cloned instance of Random specific for each Stream', () => {
-      // Arrange
-      const numValuesToPullS1 = 5;
-      const numValuesToPullS2 = 3;
-      const biasFactor = 48;
-      const { instance: sourceArb, generate } = fakeArbitrary();
-      generate.mockImplementation(() => new Value(Symbol(), undefined));
-      const { instance: mrng, clone, nextInt } = fakeRandom();
-      nextInt.mockReturnValueOnce(1); // for bias
-      const { instance: mrngClonedA } = fakeRandom();
-      const { instance: mrngClonedB } = fakeRandom();
-      clone.mockReturnValueOnce(mrngClonedA).mockReturnValueOnce(mrngClonedB);
+    it('should call generate with cloned instance of Random specific for each Stream', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const numValuesToPullS1 = 5;
+          const numValuesToPullS2 = 3;
+          const biasFactor = 48;
+          const { instance: sourceArb, generate } = fakeArbitrary();
+          generate.mockImplementation(() => new Value(Symbol(), undefined));
+          const { instance: mrng, clone, nextInt } = fakeRandom();
+          nextInt.mockReturnValueOnce(1); // for bias
+          const { instance: mrngClonedA } = fakeRandom();
+          const { instance: mrngClonedB } = fakeRandom();
+          clone.mockReturnValueOnce(mrngClonedA).mockReturnValueOnce(mrngClonedB);
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const out = arb.generate(mrng, biasFactor);
-      const s1 = out.value;
-      const c1 = s1[Symbol.iterator]();
-      for (let i = 0; i !== numValuesToPullS1; ++i) {
-        const next = c1.next();
-        expect(next.done).toBe(false);
-      }
-      const s2 = out.value;
-      const c2 = s2[Symbol.iterator]();
-      for (let i = 0; i !== numValuesToPullS2; ++i) {
-        const next = c2.next();
-        expect(next.done).toBe(false);
-      }
-      c1.next();
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const out = arb.generate(mrng, biasFactor);
+          const s1 = out.value;
+          const c1 = s1[Symbol.iterator]();
+          for (let i = 0; i !== numValuesToPullS1; ++i) {
+            const next = c1.next();
+            expect(next.done).toBe(false);
+          }
+          const s2 = out.value;
+          const c2 = s2[Symbol.iterator]();
+          for (let i = 0; i !== numValuesToPullS2; ++i) {
+            const next = c2.next();
+            expect(next.done).toBe(false);
+          }
+          c1.next();
 
-      // Assert
-      expect(generate).toHaveBeenCalledTimes(numValuesToPullS1 + numValuesToPullS2 + 1);
-      const calls = generate.mock.calls;
-      for (let i = 0; i !== numValuesToPullS1; ++i) {
-        const call = calls[i];
-        expect(call).toEqual([mrngClonedA, biasFactor]);
-      }
-      for (let i = 0; i !== numValuesToPullS2; ++i) {
-        const call = calls[numValuesToPullS1 + i];
-        expect(call).toEqual([mrngClonedB, biasFactor]);
-      }
-      expect(calls[numValuesToPullS1 + numValuesToPullS2]).toEqual([mrngClonedA, biasFactor]);
-    });
+          // Assert
+          expect(generate).toHaveBeenCalledTimes(numValuesToPullS1 + numValuesToPullS2 + 1);
+          const calls = generate.mock.calls;
+          for (let i = 0; i !== numValuesToPullS1; ++i) {
+            const call = calls[i];
+            expect(call).toEqual([mrngClonedA, biasFactor]);
+          }
+          for (let i = 0; i !== numValuesToPullS2; ++i) {
+            const call = calls[numValuesToPullS1 + i];
+            expect(call).toEqual([mrngClonedB, biasFactor]);
+          }
+          expect(calls[numValuesToPullS1 + numValuesToPullS2]).toEqual([mrngClonedA, biasFactor]);
+        }),
+      ));
 
-    it('should only print pulled values on print', () =>
+    it('should print pulled values if history is available', () =>
       fc.assert(
         fc.property(fc.array(fc.integer()), (expectedValues) => {
           // Arrange
@@ -160,13 +175,13 @@ describe('StreamArbitrary', () => {
           stringify.mockImplementation(fakeStringify);
 
           // Act
-          const arb = new StreamArbitrary(sourceArb);
+          const arb = new StreamArbitrary(sourceArb, true);
           const stream = arb.generate(mrng, biasFactor).value;
           const values = [...stream.take(expectedValues.length)];
 
           // Assert
           expect(values).toEqual(expectedValues);
-          expect(String(stream)).toEqual(`Stream(${expectedValues.map(fakeStringify).join(',')}…)`);
+          expect(String(stream).includes(`(${expectedValues.map(fakeStringify).join(',')}…)`)).toBe(true);
           expect(stringify).toHaveBeenCalledTimes(expectedValues.length);
           expect(generate).toHaveBeenCalledTimes(expectedValues.length);
           if (expectedValues.length > 0) {
@@ -175,37 +190,72 @@ describe('StreamArbitrary', () => {
         }),
       ));
 
-    it('should create independant Stream even in terms of toString', () => {
-      // Arrange
-      const biasFactor = 48;
-      let index = 0;
-      const { instance: sourceArb, generate } = fakeArbitrary<number>();
-      generate.mockImplementation(() => new Value(index++, undefined));
-      const { instance: mrng, clone, nextInt } = fakeRandom();
-      nextInt.mockReturnValueOnce(2); // for no bias
-      const { instance: mrngCloned } = fakeRandom();
-      clone.mockReturnValueOnce(mrngCloned);
-      const stringify = vi.spyOn(StringifyMock, 'stringify');
-      stringify.mockImplementation((v) => '<' + String(v) + '>');
+    it('should print count of pulled values', () =>
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.boolean(), (expectedValues, history) => {
+          // Arrange
+          const biasFactor = 48;
+          let index = 0;
+          const { instance: sourceArb, generate } = fakeArbitrary<number>();
+          generate.mockImplementation(() => new Value(expectedValues[index++], undefined));
+          const { instance: mrng, clone, nextInt } = fakeRandom();
+          nextInt.mockReturnValueOnce(2); // for no bias
+          const { instance: mrngCloned } = fakeRandom();
+          clone.mockReturnValueOnce(mrngCloned);
+          const fakeStringify = (v: unknown) => '<' + String(v) + '>';
+          const stringify = vi.spyOn(StringifyMock, 'stringify');
+          stringify.mockImplementation(fakeStringify);
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const out = arb.generate(mrng, biasFactor);
-      const stream1 = out.value;
-      const stream2 = out.value;
-      const values1 = [...stream1.take(2)];
-      const values2 = [...stream2.take(3)];
-      const values1Bis = [...stream1.take(2)];
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const stream = arb.generate(mrng, biasFactor).value;
+          void [...stream.take(expectedValues.length)];
 
-      // Assert
-      expect(values1).toEqual([0, 1]);
-      expect(values2).toEqual([2, 3, 4]);
-      expect(values1Bis).toEqual([5, 6]);
-      expect(String(stream1)).toEqual(`Stream(<0>,<1>,<5>,<6>…)`);
-      expect(String(stream2)).toEqual(`Stream(<2>,<3>,<4>…)`);
-      expect(stringify).toHaveBeenCalledTimes(7);
-      expect(generate).toHaveBeenCalledTimes(7);
-    });
+          // Assert
+          expect(String(stream)).toMatch(`(${expectedValues.length} emitted)`);
+          expect(generate).toHaveBeenCalledTimes(expectedValues.length);
+        }),
+      ));
+
+    it('should create independent Stream even in terms of toString', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const biasFactor = 48;
+          let index = 0;
+          const { instance: sourceArb, generate } = fakeArbitrary<number>();
+          generate.mockImplementation(() => new Value(index++, undefined));
+          const { instance: mrng, clone, nextInt } = fakeRandom();
+          nextInt.mockReturnValueOnce(2); // for no bias
+          const { instance: mrngCloned } = fakeRandom();
+          clone.mockReturnValueOnce(mrngCloned);
+          const stringify = vi.spyOn(StringifyMock, 'stringify');
+          stringify.mockImplementation((v) => '<' + String(v) + '>');
+
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const out = arb.generate(mrng, biasFactor);
+          const stream1 = out.value;
+          const stream2 = out.value;
+          const values1 = [...stream1.take(2)];
+          const values2 = [...stream2.take(3)];
+          const values1Bis = [...stream1.take(2)];
+
+          // Assert
+          expect(values1).toEqual([0, 1]);
+          expect(values2).toEqual([2, 3, 4]);
+          expect(values1Bis).toEqual([5, 6]);
+          const stream1String = String(stream1);
+          const stream2String = String(stream2);
+          [0, 1, 5, 6].forEach((v) => {
+            expect(stream2String).not.toMatch(`\\<${v}\\>`);
+          });
+          [2, 3, 4].forEach((v) => {
+            expect(stream1String).not.toMatch(`\\<${v}\\>`);
+          });
+          expect(generate).toHaveBeenCalledTimes(7);
+        }),
+      ));
   });
 
   describe('canShrinkWithoutContext', () => {
@@ -222,7 +272,7 @@ describe('StreamArbitrary', () => {
       const { instance: sourceArb, canShrinkWithoutContext } = fakeArbitrary();
 
       // Act
-      const arb = new StreamArbitrary(sourceArb);
+      const arb = new StreamArbitrary(sourceArb, true);
       const out = arb.canShrinkWithoutContext(data);
 
       // Assert
@@ -230,40 +280,46 @@ describe('StreamArbitrary', () => {
       expect(canShrinkWithoutContext).not.toHaveBeenCalled();
     });
 
-    it('should return false even for its own values', () => {
-      // Arrange
-      const { instance: sourceArb, canShrinkWithoutContext } = fakeArbitrary();
-      const { instance: mrng } = fakeRandom();
+    it('should return false even for its own values', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const { instance: sourceArb, canShrinkWithoutContext } = fakeArbitrary();
+          const { instance: mrng } = fakeRandom();
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const g = arb.generate(mrng, undefined);
-      const out = arb.canShrinkWithoutContext(g.value);
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const g = arb.generate(mrng, undefined);
+          const out = arb.canShrinkWithoutContext(g.value);
 
-      // Assert
-      expect(out).toBe(false);
-      expect(canShrinkWithoutContext).not.toHaveBeenCalled();
-    });
+          // Assert
+          expect(out).toBe(false);
+          expect(canShrinkWithoutContext).not.toHaveBeenCalled();
+        }),
+      ));
   });
 
   describe('shrink', () => {
-    it('should always shrink to nil', () => {
-      // Arrange
-      const { instance: sourceArb, generate, shrink } = fakeArbitrary<number>();
-      generate.mockReturnValue(new Value(0, undefined));
-      const { instance: mrng } = fakeRandom();
+    it('should always shrink to nil', () =>
+      fc.assert(
+        fc.property(fc.boolean(), (history) => {
+          // Arrange
+          const { instance: sourceArb, generate, shrink } = fakeArbitrary<number>();
+          generate.mockReturnValue(new Value(0, undefined));
+          const { instance: mrng } = fakeRandom();
 
-      // Act
-      const arb = new StreamArbitrary(sourceArb);
-      const { value, context } = arb.generate(mrng, undefined);
-      const pullValues = [...value.take(50)];
-      const shrinks = [...arb.shrink(value, context)];
+          // Act
+          const arb = new StreamArbitrary(sourceArb, history);
+          const { value, context } = arb.generate(mrng, undefined);
+          const pullValues = [...value.take(50)];
+          const shrinks = [...arb.shrink(value, context)];
 
-      // Assert
-      expect(pullValues).toBeDefined();
-      expect(shrinks).toHaveLength(0);
-      expect(shrink).not.toHaveBeenCalled();
-    });
+          // Assert
+          expect(pullValues).toBeDefined();
+          expect(shrinks).toHaveLength(0);
+          expect(shrink).not.toHaveBeenCalled();
+        }),
+      ));
   });
 });
 
@@ -277,7 +333,7 @@ describe('StreamArbitrary (integration)', () => {
   const isCorrect = (value: Stream<number>) =>
     value instanceof Stream && [...value.take(10)].every((v) => sourceArb.canShrinkWithoutContext(v));
 
-  const streamBuilder = () => new StreamArbitrary(sourceArb);
+  const streamBuilder = () => new StreamArbitrary(sourceArb, true);
 
   it('should produce the same values given the same seed', () => {
     assertProduceSameValueGivenSameSeed(streamBuilder, { isEqual });

--- a/packages/fast-check/test/unit/arbitrary/infiniteStream.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/infiniteStream.spec.ts
@@ -1,3 +1,4 @@
+import * as fc from 'fast-check';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { infiniteStream } from '../../../src/arbitrary/infiniteStream';
 
@@ -12,7 +13,7 @@ function beforeEachHook() {
 beforeEach(beforeEachHook);
 
 describe('infiniteStream', () => {
-  it('should instantiate StreamArbitrary(arb, numValues) for infiniteStream(arb)', () => {
+  it('should instantiate StreamArbitrary(arb, true) for infiniteStream(arb)', () => {
     // Arrange
     const { instance: sourceArbitrary } = fakeArbitrary();
     const { instance } = fakeArbitrary();
@@ -23,7 +24,26 @@ describe('infiniteStream', () => {
     const arb = infiniteStream(sourceArbitrary);
 
     // Assert
-    expect(StreamArbitrary).toHaveBeenCalledWith(sourceArbitrary);
+    expect(StreamArbitrary).toHaveBeenCalledWith(sourceArbitrary, true);
     expect(arb).toBe(instance);
+  });
+
+  it('should instantiate StreamArbitrary(arb, history) for infiniteStream(arb, history)', () => {
+    fc.assert(
+      fc.property(fc.boolean(), (history) => {
+        // Arrange
+        const { instance: sourceArbitrary } = fakeArbitrary();
+        const { instance } = fakeArbitrary();
+        const StreamArbitrary = vi.spyOn(StreamArbitraryMock, 'StreamArbitrary');
+        StreamArbitrary.mockImplementation(() => instance as StreamArbitraryMock.StreamArbitrary<unknown>);
+
+        // Act
+        const arb = infiniteStream(sourceArbitrary, history);
+
+        // Assert
+        expect(StreamArbitrary).toHaveBeenCalledWith(sourceArbitrary, history);
+        expect(arb).toBe(instance);
+      }),
+    );
   });
 });

--- a/website/docs/core-blocks/arbitraries/composites/iterable.md
+++ b/website/docs/core-blocks/arbitraries/composites/iterable.md
@@ -15,16 +15,21 @@ The `Stream` structure provided by fast-check implements `IterableIterator<T>` a
 **Signatures:**
 
 - `fc.infiniteStream(arb)`
+- `fc.infiniteStream(arb, history)` (since 4.3.0)
 
 **with:**
 
 - `arb` — _arbitrary instance responsible to generate values_
+- `history` — default: `true` — whether to include generated values in the string representation. _(caution: unbounded memory growth)_
 
 **Usages:**
 
 ```js
 fc.infiniteStream(fc.nat(9));
-// Examples of generated values: Stream(…)…
+// Examples of generated values: Stream(0 emitted)(…)…
+
+fc.infiniteStream(fc.nat(9), false);
+// Examples of generated values: Stream(0 emitted)…
 ```
 
 Resources: [API reference](https://fast-check.dev/api-reference/functions/infiniteStream.html).  


### PR DESCRIPTION
**Description**
The new `history` parameter allows users to set an upper bound on infiniteStream's memory usage by giving up visibility into the items it emitted. In the future, it would be possible to enrich this parameter to create a bounded memory window at the beginning and/or end of the stream, but for now the option is just a boolean to toggle history on and off.

To still present some useful information, the stream now prints the count of the number of emitted items. The count shows even when the history is present, to save the user from manually counting. I assume the exact string representation of the arbitrary is not part of fast-check's semver guarantees and so this would be a minor bump. Let me know if I'm mistaken.

Fixes #6106.

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [x] My PR references one of several related issues (if any)
  - [x] New features or breaking changes must come with an associated Issue or Discussion
- [x] My PR includes bumps details, please run `pnpm run bump` and flag the impacts properly
- [x] My PR adds relevant tests and they would have failed without my PR (when applicable)

<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

**Advanced**

<!-- How to fill the advanced section is detailed below! -->

- [x] Category: ...🐛✨
- [x] Impacts: ... should be ok.

<!-- [Category] Please use one of the categories below, it will help us into better understanding the urgency of the PR -->
<!-- * ✨ Introduce new features -->
<!-- * 📝 Add or update documentation -->
<!-- * ✅ Add or update tests -->
<!-- * 🐛 Fix a bug -->
<!-- * 🏷️ Add or update types -->
<!-- * ⚡️ Improve performance -->
<!-- * _Other(s):_ ... -->

<!-- [Impacts] Please provide a comma separated list of the potential impacts that might be introduced by this change -->
<!-- * Generated values: Can your change impact any of the existing generators in terms of generated values, if so which ones? when? -->
<!-- * Shrink values:    Can your change impact any of the existing generators in terms of shrink values, if so which ones? when? -->
<!-- * Performance:      Can it require some typings changes on user side? Please give more details -->
<!-- * Typings:          Is there a potential performance impact? In which cases? -->
