### PR TITLE
:sparkles: Initial implementation of observability feature

### DIFF
--- a/.changeset/shaky-stars-joke.md
+++ b/.changeset/shaky-stars-joke.md
@@ -1,0 +1,5 @@
+---
+'fast-check': minor
+---
+
+Add observability logging feature

--- a/packages/fast-check/src/check/runner/RunnerIterator.ts
+++ b/packages/fast-check/src/check/runner/RunnerIterator.ts
@@ -25,8 +25,9 @@ export class RunnerIterator<Ts> implements IterableIterator<Ts> {
     readonly shrink: (value: Value<Ts>) => IterableIterator<Value<Ts>>,
     verbose: VerbosityLevel,
     interruptedAsFailure: boolean,
+    observabilityEnabled: boolean = false,
   ) {
-    this.runExecution = new RunExecution<Ts>(verbose, interruptedAsFailure);
+    this.runExecution = new RunExecution<Ts>(verbose, interruptedAsFailure, observabilityEnabled);
     this.currentIdx = -1;
     this.nextValues = sourceValues;
   }

--- a/packages/fast-check/src/check/runner/configuration/GlobalParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/GlobalParameters.ts
@@ -85,6 +85,19 @@ export type GlobalParameters = Pick<Parameters<unknown>, Exclude<keyof Parameter
    * @remarks Since 2.22.0
    */
   defaultSizeToMaxWhenMaxSpecified?: boolean;
+  /**
+   * Enable observability reporting to collect test execution data.
+   *
+   * When enabled, fast-check will automatically collect and export test execution data
+   * including test cases, their status, and execution details to `.fast-check/observer/` directory.
+   * This data can be used for analysis, debugging, and observability purposes.
+   *
+   * The observability reporter works independently of regular error reporters and does not
+   * affect test execution or failure reporting behavior.
+   *
+   * @defaultValue `false`
+   */
+  observabilityEnabled?: boolean;
 };
 /**
  * Define global parameters that will be used by all the runners

--- a/packages/fast-check/src/check/runner/configuration/Parameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/Parameters.ts
@@ -203,4 +203,35 @@ export interface Parameters<T = void> {
    * as part of the message and not as a cause.
    */
   includeErrorInReport?: boolean;
+  /**
+   * Explicit test case identifier for observability and reporting features.
+   *
+   * When provided, this value will be used for test identification instead of
+   * relying on automatic stack trace parsing. Recommended for consistent and
+   * reliable test case naming across different environments.
+   *
+   * @remarks If not specified, fast-check will attempt to derive the test name
+   * from the stack trace, which may be unreliable in certain runtime environments.
+   *
+   * @example
+   * ```typescript
+   * fc.assert(fc.property(fc.integer(), (n) => n === n), {
+   *   testCaseName: "integer_identity_test"
+   * });
+   * ```
+   */
+  testCaseName?: string;
+  /**
+   * Enable observability reporting to collect test execution data.
+   *
+   * When enabled, fast-check will automatically collect and export test execution data
+   * including test cases, their status, and execution details to `.fast-check/observer/` directory.
+   * This data can be used for analysis, debugging, and observability purposes.
+   *
+   * The observability reporter works independently of regular error reporters and does not
+   * affect test execution or failure reporting behavior.
+   *
+   * @defaultValue `false` (or inherited from global configuration)
+   */
+  observabilityEnabled?: boolean;
 }

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -38,6 +38,8 @@ export class QualifiedParameters<T> {
   reporter: ((runDetails: RunDetails<T>) => void) | undefined;
   asyncReporter: ((runDetails: RunDetails<T>) => Promise<void>) | undefined;
   includeErrorInReport: boolean;
+  testCaseName: string | undefined;
+  observabilityEnabled: boolean | undefined;
 
   constructor(op?: Parameters<T>) {
     const p = op || {};
@@ -66,6 +68,8 @@ export class QualifiedParameters<T> {
     this.reporter = p.reporter;
     this.asyncReporter = p.asyncReporter;
     this.includeErrorInReport = p.includeErrorInReport === true;
+    this.testCaseName = p.testCaseName;
+    this.observabilityEnabled = p.observabilityEnabled;
   }
 
   toParameters(): Parameters<T> {
@@ -89,6 +93,8 @@ export class QualifiedParameters<T> {
       reporter: this.reporter,
       asyncReporter: this.asyncReporter,
       includeErrorInReport: this.includeErrorInReport,
+      testCaseName: this.testCaseName,
+      observabilityEnabled: this.observabilityEnabled,
     };
     return parameters;
   }

--- a/packages/fast-check/src/check/runner/reporter/ObservabilityReporter.ts
+++ b/packages/fast-check/src/check/runner/reporter/ObservabilityReporter.ts
@@ -1,0 +1,182 @@
+import { ExecutionStatus } from './ExecutionStatus';
+import type { ExecutionTree } from './ExecutionTree';
+import type { RunDetails } from './RunDetails';
+import { stringify } from '../../../utils/stringify';
+import { getTestNameFromStackTrace } from '../utils/TestNameDetector';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ObservedTestCase {
+  type: 'test_case';
+  run_start: number;
+  property: string;
+  status: 'passed' | 'failed' | 'gave_up';
+  status_reason: string;
+  representation: string;
+  coverage: 'no_coverage_info'; // not supported yet
+  features: Record<string, any>;
+  how_generated: string;
+  timing?: Record<string, number>;
+}
+
+/**
+ * Convert ExecutionStatus to ObservedTestCase status
+ */
+function mapExecutionStatusToObservedStatus(status: ExecutionStatus): 'passed' | 'failed' | 'gave_up' {
+  switch (status) {
+    case ExecutionStatus.Success:
+      return 'passed';
+    case ExecutionStatus.Failure:
+      return 'failed';
+    case ExecutionStatus.Skipped:
+      return 'gave_up';
+    default:
+      return 'failed';
+  }
+}
+
+/**
+ * Get status reason based on execution status and run details
+ */
+function getStatusReason<Ts>(status: ExecutionStatus, runDetails: RunDetails<Ts>): string {
+  switch (status) {
+    case ExecutionStatus.Success:
+      return '';
+    case ExecutionStatus.Failure:
+      if (runDetails.failed && runDetails.counterexample !== null) {
+        return 'Property failed with counterexample';
+      }
+      return 'Property failed';
+    case ExecutionStatus.Skipped:
+      return 'Pre-condition failed';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Convert a single ExecutionTree to ObservedTestCase
+ */
+function executionTreeToObservedTestCase<Ts>(
+  tree: ExecutionTree<Ts>,
+  runDetails: RunDetails<Ts>,
+  propertyName: string,
+): ObservedTestCase {
+  const status = mapExecutionStatusToObservedStatus(tree.status);
+  const statusReason = getStatusReason(tree.status, runDetails);
+  const representation = stringify(tree.value);
+
+  return {
+    type: 'test_case',
+    run_start: runDetails.runStart,
+    property: propertyName,
+    status,
+    status_reason: statusReason,
+    representation,
+    features: {},
+    coverage: 'no_coverage_info',
+    how_generated: 'fast-check',
+  };
+}
+
+/**
+ * Convert all ExecutionTrees from RunDetails to ObservedTestCases
+ */
+export function convertExecutionTreesToObservedTestCases<Ts>(
+  runDetails: RunDetails<Ts>,
+  propertyName: string,
+): ObservedTestCase[] {
+  const observedTestCases: ObservedTestCase[] = [];
+
+  // Convert each execution tree to an observed test case
+  for (const tree of runDetails.executionSummary) {
+    const observedTestCase = executionTreeToObservedTestCase(tree, runDetails, propertyName);
+    observedTestCases.push(observedTestCase);
+
+    // Recursively convert children if needed
+    function convertChildren(parentTree: ExecutionTree<Ts>) {
+      for (const childTree of parentTree.children) {
+        const childObservedTestCase = executionTreeToObservedTestCase(childTree, runDetails, propertyName);
+        observedTestCases.push(childObservedTestCase);
+
+        // Recursively process grandchildren
+        if (childTree.children.length > 0) {
+          convertChildren(childTree);
+        }
+      }
+    }
+
+    convertChildren(tree);
+  }
+
+  return observedTestCases;
+}
+
+/**
+ * Convert all ExecutionTrees from RunDetails to ObservedTestCases with automatic test name detection
+ */
+export function convertExecutionTreesToObservedTestCasesWithTestName<Ts>(
+  runDetails: RunDetails<Ts>,
+): ObservedTestCase[] {
+  const testName = runDetails.runConfiguration.testCaseName || getTestNameFromStackTrace();
+  return convertExecutionTreesToObservedTestCases(runDetails, testName);
+}
+
+/**
+ * Get the date string in YYYY-MM-DD format from a timestamp
+ */
+function getDateStringFromTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Ensure the observer directory exists
+ */
+function ensureObserverDirectory(): string {
+  const cwd = process.cwd();
+  const observerDir = path.join(cwd, '.fast-check', 'observer');
+
+  if (!fs.existsSync(observerDir)) {
+    fs.mkdirSync(observerDir, { recursive: true });
+  }
+
+  return observerDir;
+}
+
+/**
+ * Write test cases to JSONL file
+ */
+function writeTestCasesToFile(observedTestCases: ObservedTestCase[], runStart: number): void {
+  try {
+    const observerDir = ensureObserverDirectory();
+    const dateString = getDateStringFromTimestamp(runStart);
+    const filename = `${dateString}_test_cases.jsonl`;
+    const filepath = path.join(observerDir, filename);
+
+    // Convert each test case to a JSON line
+    const jsonLines = observedTestCases.map((testCase) => JSON.stringify(testCase)).join('\n');
+
+    // Append to file (create if doesn't exist)
+    if (jsonLines.length > 0) {
+      const content = fs.existsSync(filepath) ? '\n' + jsonLines : jsonLines;
+      fs.appendFileSync(filepath, content, 'utf8');
+    }
+  } catch (error) {
+    // Silently fail to avoid breaking tests if file writing fails
+    console.warn('Failed to write test cases to file:', error);
+  }
+}
+
+export function observe<Ts>(out: RunDetails<Ts>): RunDetails<Ts> {
+  if (out.runConfiguration.observabilityEnabled) {
+    const observedTestCases = convertExecutionTreesToObservedTestCasesWithTestName(out);
+
+    // Write test cases to JSONL file using the run start timestamp
+    writeTestCasesToFile(observedTestCases, out.runStart);
+  }
+  return out;
+}

--- a/packages/fast-check/src/check/runner/reporter/RunDetails.ts
+++ b/packages/fast-check/src/check/runner/reporter/RunDetails.ts
@@ -184,4 +184,11 @@ export interface RunDetailsCommon<Ts> {
    * @remarks Since 1.25.0
    */
   runConfiguration: Parameters<Ts>;
+  /**
+   * Timestamp (in milliseconds since Unix epoch) when the property run was started
+   *
+   * This timestamp is captured at the beginning of the test execution and represents
+   * the exact moment when the runner began generating and testing values for the property.
+   */
+  runStart: number;
 }

--- a/packages/fast-check/src/check/runner/utils/TestNameDetector.ts
+++ b/packages/fast-check/src/check/runner/utils/TestNameDetector.ts
@@ -1,0 +1,41 @@
+/**
+ * Extract filename from the first line after the last Runner line in stack trace
+ *
+ * HACK: This is a brittle approach that relies on stack trace parsing to determine
+ * the test file name. This exists because fast-check is test framework agnostic
+ * and does not have context of property names or test case identifiers.
+ *
+ * PREFERRED ALTERNATIVE: Use parameters.testCaseName to explicitly specify the test name
+ * instead of relying on this stack trace parsing hack.
+ */
+export function getTestNameFromStackTrace(): string {
+  try {
+    const stack = new Error().stack;
+    if (!stack) {
+      return 'unknown_test';
+    }
+
+    const lines = stack.split('\n');
+    let lastRunnerIndex = -1;
+
+    // HACK: Find the last Runner line by string matching (ts or js)
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes('fast-check') && lines[i].includes('check/runner/Runner.')) {
+        lastRunnerIndex = i;
+      }
+    }
+
+    // HACK: Assume the next line contains the test file information
+    if (lastRunnerIndex >= 0 && lastRunnerIndex + 1 < lines.length) {
+      const nextLine = lines[lastRunnerIndex + 1];
+      const match = nextLine.match(/([^/\\]+\.[jt]sx?):(\d+)/);
+      if (match) {
+        return `${match[1]}:${match[2]}`;
+      }
+    }
+
+    return 'unknown';
+  } catch (err) {
+    return 'unknown';
+  }
+}

--- a/packages/fast-check/test/e2e/ObservabilityReporter.spec.ts
+++ b/packages/fast-check/test/e2e/ObservabilityReporter.spec.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fc from '../../src/fast-check';
+import { seed } from './seed';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe(`ObservabilityReporter (seed: ${seed})`, () => {
+  const observerDir = path.join(process.cwd(), '.fast-check', 'observer');
+
+  beforeEach(() => {
+    // Clean up any existing observer files
+    if (fs.existsSync(observerDir)) {
+      const files = fs.readdirSync(observerDir);
+      files.forEach((file) => {
+        if (file.endsWith('_test_cases.jsonl')) {
+          fs.unlinkSync(path.join(observerDir, file));
+        }
+      });
+    }
+    fc.resetConfigureGlobal();
+  });
+
+  afterEach(() => {
+    fc.resetConfigureGlobal();
+    // Clean up observer files after each test
+    if (fs.existsSync(observerDir)) {
+      const files = fs.readdirSync(observerDir);
+      files.forEach((file) => {
+        if (file.endsWith('_test_cases.jsonl')) {
+          fs.unlinkSync(path.join(observerDir, file));
+        }
+      });
+    }
+  });
+
+  it('should generate observability data for successful property tests', () => {
+    fc.configureGlobal({ observabilityEnabled: true });
+
+    fc.assert(
+      fc.property(fc.integer(), fc.integer(), (a, b) => {
+        // Commutative property of addition
+        return a + b === b + a;
+      }),
+      {
+        numRuns: 10,
+        seed,
+        testCaseName: 'commutative_addition_test',
+      },
+    );
+
+    // Check that observability data was generated
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    // Read and validate the content
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Validate each line is valid JSON with expected structure
+    lines.forEach((line) => {
+      const testCase = JSON.parse(line);
+      expect(testCase).toMatchObject({
+        type: 'test_case',
+        run_start: expect.any(Number),
+        property: 'commutative_addition_test',
+        status: 'passed',
+        status_reason: '',
+        representation: expect.any(String),
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+  });
+
+  it('should generate observability data for failing property tests with shrinking', () => {
+    fc.configureGlobal({ observabilityEnabled: true });
+
+    const result = fc.check(
+      fc.property(fc.array(fc.integer({ min: 1, max: 100 })), (arr) => {
+        fc.pre(arr.length > 0); // Ensure non-empty array
+        return arr[0] > 50; // This will fail for values <= 50
+      }),
+      {
+        numRuns: 100,
+        seed,
+        testCaseName: 'array_first_element_test',
+      },
+    );
+
+    expect(result.failed).toBe(true);
+
+    // Check that observability data was generated
+    console.log(observerDir);
+
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    console.log(files);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    // Read and validate the content
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Should have both passed and failed test cases
+    const testCases = lines.map((line) => JSON.parse(line));
+    const passedCases = testCases.filter((tc) => tc.status === 'passed');
+    const failedCases = testCases.filter((tc) => tc.status === 'failed');
+    const skippedCases = testCases.filter((tc) => tc.status === 'gave_up');
+
+    expect(passedCases.length + failedCases.length + skippedCases.length).toBe(testCases.length);
+    expect(failedCases.length).toBeGreaterThan(0); // Should have at least one failure
+
+    // Validate structure of failed cases
+    failedCases.forEach((testCase) => {
+      expect(testCase).toMatchObject({
+        type: 'test_case',
+        run_start: expect.any(Number),
+        property: 'array_first_element_test',
+        status: 'failed',
+        status_reason: expect.any(String),
+        representation: expect.any(String),
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+  });
+
+  it('should generate observability data for tests with pre-conditions', () => {
+    fc.configureGlobal({ observabilityEnabled: true });
+
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 100 }), fc.integer({ min: 1, max: 100 }), (a, b) => {
+        fc.pre(a > 50 && b > 50); // Only test with values > 50
+        return a * b > 2500; // Should always be true given the pre-condition
+      }),
+      {
+        numRuns: 50,
+        seed,
+        testCaseName: 'multiplication_with_precondition_test',
+      },
+    );
+
+    // Check that observability data was generated
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    // Read and validate the content
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    const testCases = lines.map((line) => JSON.parse(line));
+    const passedCases = testCases.filter((tc) => tc.status === 'passed');
+    const skippedCases = testCases.filter((tc) => tc.status === 'gave_up');
+
+    // Should have both passed and skipped cases due to pre-conditions
+    expect(passedCases.length).toBeGreaterThan(0);
+    expect(skippedCases.length).toBeGreaterThan(0);
+
+    // Validate skipped cases have correct status reason
+    skippedCases.forEach((testCase) => {
+      expect(testCase).toMatchObject({
+        type: 'test_case',
+        run_start: expect.any(Number),
+        property: 'multiplication_with_precondition_test',
+        status: 'gave_up',
+        status_reason: 'Pre-condition failed',
+        representation: expect.any(String),
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+  });
+
+  it('should generate observability data for complex object properties', () => {
+    fc.configureGlobal({ observabilityEnabled: true });
+
+    fc.assert(
+      fc.property(
+        fc.record({
+          name: fc.string({ minLength: 1, maxLength: 20 }),
+          age: fc.integer({ min: 0, max: 120 }),
+          active: fc.boolean(),
+          scores: fc.array(fc.float({ min: 0, max: 100 }), { maxLength: 5 }),
+        }),
+        (person) => {
+          return (
+            typeof person.name === 'string' &&
+            person.name.length > 0 &&
+            typeof person.age === 'number' &&
+            person.age >= 0 &&
+            person.age <= 120 &&
+            typeof person.active === 'boolean' &&
+            Array.isArray(person.scores) &&
+            person.scores.every((score) => score >= 0 && score <= 100)
+          );
+        },
+      ),
+      {
+        numRuns: 20,
+        seed,
+        testCaseName: 'complex_object_validation_test',
+      },
+    );
+
+    // Check that observability data was generated
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    // Read and validate the content
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBe(20); // Should have exactly 20 test cases
+
+    // All should be passed for this property
+    lines.forEach((line) => {
+      const testCase = JSON.parse(line);
+      expect(testCase).toMatchObject({
+        type: 'test_case',
+        run_start: expect.any(Number),
+        property: 'complex_object_validation_test',
+        status: 'passed',
+        status_reason: '',
+        representation: expect.any(String),
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+
+      // Validate that representation contains object structure
+      expect(testCase.representation).toMatch(/\{.*name.*age.*active.*scores.*\}/);
+    });
+  });
+
+  it('should handle per-test observability configuration', () => {
+    // Don't enable globally
+    fc.configureGlobal({ observabilityEnabled: false });
+
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (a, b) => {
+        return (a + b).length === a.length + b.length;
+      }),
+      {
+        numRuns: 5,
+        seed,
+        observabilityEnabled: true, // Enable per-test
+        testCaseName: 'per_test_observability_test',
+      },
+    );
+
+    // Check that observability data was generated despite global setting
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBe(5);
+
+    lines.forEach((line) => {
+      const testCase = JSON.parse(line);
+      expect(testCase.property).toBe('per_test_observability_test');
+      expect(testCase.status).toBe('passed');
+    });
+  });
+
+  it('should not generate observability data when disabled', () => {
+    // Ensure observability is disabled
+    fc.configureGlobal({ observabilityEnabled: false });
+
+    fc.assert(
+      fc.property(fc.integer(), (n) => {
+        return typeof n === 'number';
+      }),
+      {
+        numRuns: 10,
+        seed,
+        testCaseName: 'disabled_observability_test',
+      },
+    );
+
+    // Check that no observability data was generated
+    if (fs.existsSync(observerDir)) {
+      const files = fs.readdirSync(observerDir);
+      const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+      expect(jsonlFiles.length).toBe(0);
+    }
+  });
+
+  it('should handle async properties with observability', async () => {
+    fc.configureGlobal({ observabilityEnabled: true });
+
+    await fc.assert(
+      fc.asyncProperty(fc.integer(), fc.string(), async (n, s) => {
+        // Simulate async operation
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return typeof n === 'number' && typeof s === 'string';
+      }),
+      {
+        numRuns: 8,
+        seed,
+        testCaseName: 'async_property_test',
+      },
+    );
+
+    // Check that observability data was generated
+    expect(fs.existsSync(observerDir)).toBe(true);
+    const files = fs.readdirSync(observerDir);
+    const jsonlFiles = files.filter((f) => f.endsWith('_test_cases.jsonl'));
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+
+    const content = fs.readFileSync(path.join(observerDir, jsonlFiles[0]), 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBe(8);
+
+    lines.forEach((line) => {
+      const testCase = JSON.parse(line);
+      expect(testCase).toMatchObject({
+        type: 'test_case',
+        run_start: expect.any(Number),
+        property: 'async_property_test',
+        status: 'passed',
+        status_reason: '',
+        representation: expect.any(String),
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+  });
+});

--- a/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
@@ -27,6 +27,7 @@ const parametersArbitrary = fc.record(
     reporter: fc.func(fc.constant(undefined)),
     asyncReporter: fc.func(fc.constant(Promise.resolve(undefined))),
     includeErrorInReport: fc.boolean(),
+    observabilityEnabled: fc.option(fc.boolean()),
   },
   { requiredKeys: [] },
 );

--- a/packages/fast-check/test/unit/check/runner/reporter/ObservabilityReporter.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/reporter/ObservabilityReporter.spec.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  convertExecutionTreesToObservedTestCases,
+  convertExecutionTreesToObservedTestCasesWithTestName,
+  observe,
+} from '../../../../../src/check/runner/reporter/ObservabilityReporter';
+import type { RunDetails } from '../../../../../src/check/runner/reporter/RunDetails';
+import { ExecutionStatus } from '../../../../../src/check/runner/reporter/ExecutionStatus';
+import type { ExecutionTree } from '../../../../../src/check/runner/reporter/ExecutionTree';
+
+vi.mock('fs');
+const mockedFs = vi.mocked(fs);
+
+describe('ObservabilityReporter', () => {
+  const mockObserverDir = '/test/.fast-check/observer';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock process.cwd()
+    vi.spyOn(process, 'cwd').mockReturnValue('/test');
+    // Mock Date constructor for getCurrentDateString
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2022-01-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('convertExecutionTreesToObservedTestCases', () => {
+    it('should convert successful execution tree to observed test case', () => {
+      const executionTree: ExecutionTree<number> = {
+        status: ExecutionStatus.Success,
+        value: 42,
+        children: [],
+      };
+
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [executionTree],
+        failed: false,
+        runStart: 1641038400000,
+      };
+
+      const result = convertExecutionTreesToObservedTestCases(runDetails as RunDetails<number>, 'test_property');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'test_case',
+        run_start: 1641038400000,
+        property: 'test_property',
+        status: 'passed',
+        status_reason: '',
+        representation: '42',
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+
+    it('should convert failed execution tree to observed test case', () => {
+      const executionTree: ExecutionTree<string> = {
+        status: ExecutionStatus.Failure,
+        value: 'test-value',
+        children: [],
+      };
+
+      const runDetails: Partial<RunDetails<string>> = {
+        executionSummary: [executionTree],
+        failed: true,
+        counterexample: 'test-value',
+        runStart: 1641038400000,
+      };
+
+      const result = convertExecutionTreesToObservedTestCases(runDetails as RunDetails<string>, 'failing_property');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'test_case',
+        run_start: 1641038400000,
+        property: 'failing_property',
+        status: 'failed',
+        status_reason: 'Property failed with counterexample',
+        representation: '"test-value"',
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+
+    it('should convert skipped execution tree to observed test case', () => {
+      const executionTree: ExecutionTree<boolean> = {
+        status: ExecutionStatus.Skipped,
+        value: true,
+        children: [],
+      };
+
+      const runDetails: Partial<RunDetails<boolean>> = {
+        executionSummary: [executionTree],
+        failed: false,
+        runStart: 1641038400000,
+      };
+
+      const result = convertExecutionTreesToObservedTestCases(runDetails as RunDetails<boolean>, 'skipped_property');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'test_case',
+        run_start: 1641038400000,
+        property: 'skipped_property',
+        status: 'gave_up',
+        status_reason: 'Pre-condition failed',
+        representation: 'true',
+        features: {},
+        coverage: 'no_coverage_info',
+        how_generated: 'fast-check',
+      });
+    });
+
+    it('should handle execution trees with children', () => {
+      const childTree: ExecutionTree<number> = {
+        status: ExecutionStatus.Success,
+        value: 10,
+        children: [],
+      };
+
+      const parentTree: ExecutionTree<number> = {
+        status: ExecutionStatus.Failure,
+        value: 5,
+        children: [childTree],
+      };
+
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [parentTree],
+        failed: true,
+        runStart: 1641038400000,
+      };
+
+      const result = convertExecutionTreesToObservedTestCases(runDetails as RunDetails<number>, 'nested_property');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].representation).toBe('5');
+      expect(result[0].status).toBe('failed');
+      expect(result[1].representation).toBe('10');
+      expect(result[1].status).toBe('passed');
+    });
+  });
+
+  describe('convertExecutionTreesToObservedTestCasesWithTestName', () => {
+    it('should use testCaseName from runConfiguration when available', () => {
+      const executionTree: ExecutionTree<number> = {
+        status: ExecutionStatus.Success,
+        value: 123,
+        children: [],
+      };
+
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [executionTree],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'explicit_test_name',
+        },
+      };
+
+      const result = convertExecutionTreesToObservedTestCasesWithTestName(runDetails as RunDetails<number>);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].property).toBe('explicit_test_name');
+    });
+  });
+
+  describe('observe', () => {
+    beforeEach(() => {
+      // Mock fs methods
+      mockedFs.existsSync.mockReturnValue(false);
+      mockedFs.mkdirSync.mockImplementation(() => undefined);
+      mockedFs.appendFileSync.mockImplementation(() => undefined);
+    });
+
+    it('should create observer directory if it does not exist', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_create_directory',
+          observabilityEnabled: true,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(false);
+
+      observe(runDetails as RunDetails<number>);
+
+      expect(mockedFs.mkdirSync).toHaveBeenCalledWith(mockObserverDir, { recursive: true });
+    });
+
+    it('should not create directory if it already exists', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_existing_directory',
+          observabilityEnabled: true,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(true);
+
+      observe(runDetails as RunDetails<number>);
+
+      expect(mockedFs.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('should write test cases to JSONL file', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_write_jsonl',
+          observabilityEnabled: true,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(true);
+
+      observe(runDetails as RunDetails<number>);
+
+      expect(mockedFs.appendFileSync).toHaveBeenCalledWith(
+        path.join(mockObserverDir, '2022-01-01_test_cases.jsonl'),
+        expect.stringContaining('"property":"test_write_jsonl"'),
+        'utf8',
+      );
+    });
+
+    it('should handle file writing errors gracefully', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_error_handling',
+          observabilityEnabled: true,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.appendFileSync.mockImplementation(() => {
+        throw new Error('File write error');
+      });
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Should not throw
+      expect(() => observe(runDetails as RunDetails<number>)).not.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to write test cases to file:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should append to existing file with newline', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_append_existing',
+          observabilityEnabled: true,
+        },
+      };
+
+      // Mock directory exists, and file exists
+      mockedFs.existsSync.mockImplementation((filePath) => {
+        if (typeof filePath === 'string') {
+          if (filePath.includes('observer') && filePath.endsWith('observer')) {
+            return true; // Directory exists
+          }
+          if (filePath.includes('.jsonl')) {
+            return true; // File exists
+          }
+        }
+        return false;
+      });
+
+      observe(runDetails as RunDetails<number>);
+
+      expect(mockedFs.appendFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('2022-01-01_test_cases.jsonl'),
+        expect.stringMatching(/^\n.*"property":"test_append_existing"/),
+        'utf8',
+      );
+    });
+
+    it('should handle empty execution summary', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_empty_summary',
+          observabilityEnabled: true,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(true);
+
+      observe(runDetails as RunDetails<number>);
+
+      // Should not call appendFileSync for empty content
+      expect(mockedFs.appendFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should not write anything when observabilityEnabled is false', () => {
+      const runDetails: Partial<RunDetails<number>> = {
+        executionSummary: [
+          {
+            status: ExecutionStatus.Success,
+            value: 42,
+            children: [],
+          },
+        ],
+        failed: false,
+        runStart: 1641038400000,
+        runConfiguration: {
+          testCaseName: 'test_disabled',
+          observabilityEnabled: false,
+        },
+      };
+
+      mockedFs.existsSync.mockReturnValue(true);
+
+      observe(runDetails as RunDetails<number>);
+
+      // Should not call any fs methods when disabled
+      expect(mockedFs.mkdirSync).not.toHaveBeenCalled();
+      expect(mockedFs.appendFileSync).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Description**

**Feature**: #6190 Tyche/OpenPBTStats support for better observability

This PR introduces a new observability feature that collects detailed test execution data for analysis. The feature is disabled by default to maintain backwards compatibility. It adds an ``ObservabilityReporter`` that captures test execution data and writes it to JSONL files when ``observabilityEnabled`` is set in the configuration.

---
**Example Usage:**

```typescript
import * as fc from 'fast-check';

// Enable observability for all property tests
fc.configureGlobal({ observabilityEnabled: true });

// Your property tests will now generate observability data
fc.assert(
  fc.property(fc.integer(), fc.integer(), (a, b) => {
    return a + b === b + a; // Commutative property
  }),
  {
    testCaseName: 'commutative_addition',
    numRuns: 100
  }
);
```
The observability data is saved to .fast-check/observer/YYYY-MM-DD_test_cases.jsonl with the following structure (compact single line json entries separated by new line):

```json
{
  "type": "test_case",
  "run_start": 1641038400000,
  "property": "commutative_addition",
  "status": "passed",
  "status_reason": "",
  "representation": "[42, 17]",
  "features": {},
  "coverage": "no_coverage_info",
  "how_generated": "fast-check"
}
```
The files can be opened and visualized using with Tyche plugin.

**Checklist** — _Don't delete this checklist and make sure you do the following before opening the PR_

- [X] The name of my PR follows [gitmoji](https://gitmoji.dev/) specification
- [X] My PR references one of several related issues (if any)
  - [X] New features or breaking changes must come with an associated Issue or Discussion
  - [X] My PR does not add any new dependency without an associated Issue or Discussion
- [X] My PR includes bumps details, please run `pnpm run bump` and flag the impacts properly
- [X] My PR adds relevant tests and they would have failed without my PR (when applicable)
