### PR TITLE
👷 Downgrade node in tests

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -205,7 +205,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x, latest]
+        node-version: [20.x, 22.x, 24.x, 25.1]
         os: ['ubuntu-latest']
         shard-id: ['1']
         shard-count: ['1']


### PR DESCRIPTION
Version 25.2 seems to trigger unwanted errors with Jest.