### PR TITLE
🐛 Fix object unmapper and depth computation for special keys

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/mappers/KeyValuePairsToObject.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/KeyValuePairsToObject.ts
@@ -7,6 +7,7 @@ const safeObjectCreate = Object.create;
 const safeObjectDefineProperty = Object.defineProperty;
 const safeObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const safeObjectGetPrototypeOf = Object.getPrototypeOf;
+const safeObjectPrototype = Object.prototype;
 const safeReflectOwnKeys = Reflect.ownKeys;
 
 /** @internal */
@@ -44,7 +45,7 @@ export function keyValuePairsToObjectUnmapper<K extends PropertyKey, V>(value: u
     throw new Error('Incompatible instance received: should be a non-null object');
   }
   const hasNullPrototype = safeObjectGetPrototypeOf(value) === null;
-  const hasObjectPrototype = 'constructor' in value && value.constructor === Object;
+  const hasObjectPrototype = safeObjectGetPrototypeOf(value) === safeObjectPrototype;
   if (!hasNullPrototype && !hasObjectPrototype) {
     throw new Error('Incompatible instance received: should be of exact type Object');
   }

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/ComputeObjectDepth.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/ComputeObjectDepth.ts
@@ -6,7 +6,7 @@ export function computeObjectDepth(o: unknown): number {
   // .keys and .values are defined on normal arrays but will be problematic for arrays containing holes
   // as they also take holes into account
   const values =
-    !Array.isArray(o!) && 'values' in o!
+    !Array.isArray(o!) && typeof (o! as Record<string, unknown>).values === 'function'
       ? [...(o! as { values: () => Iterable<unknown> }).values()]
       : Object.values(o!);
   return 1 + Math.max(...values.map((v) => computeObjectDepth(v)));


### PR DESCRIPTION
Fix two bugs triggered when string arbitraries can generate special property names like "constructor" or "values":

1. keyValuePairsToObjectUnmapper: Use prototype chain check instead of constructor property check. When an object has an own "constructor" property shadowing Object.prototype.constructor, the previous check `value.constructor === Object` would fail incorrectly.

2. ComputeObjectDepth (test helper): Use typeof check before calling o.values() to avoid TypeError when a plain object has an own "values" property with a non-function value.

Both issues are triggered by jsonValue with stringUnit: 'binary-ascii' which can generate any ASCII string as object keys.

Fixes #6663

## Description

<!-- Describe your change and explain what this PR is trying to solve -->

Fixes #issue-number

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
