### PR TITLE
feat: support depth on array and anything derived from them

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/ArrayArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/ArrayArbitrary.ts
@@ -9,12 +9,17 @@ import type { CustomSetBuilder } from './interfaces/CustomSet.js';
 import type { DepthContext, DepthIdentifier } from './helpers/DepthContext.js';
 import { getDepthContextFor } from './helpers/DepthContext.js';
 import { buildSlicedGenerator } from './helpers/BuildSlicedGenerator.js';
+import type { DepthSize } from './helpers/MaxLengthFromMinLength.js';
+import { depthBiasFromSizeForArbitrary } from './helpers/MaxLengthFromMinLength.js';
 import { safeMap, safePush, safeSlice } from '../../utils/globals.js';
 
 const safeMathFloor = Math.floor;
 const safeMathLog = Math.log;
 const safeMathMax = Math.max;
+const safeMathMin = Math.min;
+const safeMathPow = Math.pow;
 const safeArrayIsArray = Array.isArray;
+const safePositiveInfinity = Number.POSITIVE_INFINITY;
 
 /** @internal */
 type ArrayArbitraryContext = {
@@ -36,6 +41,9 @@ function biasedMaxLength(minLength: number, maxLength: number): number {
 export class ArrayArbitrary<T> extends Arbitrary<T[]> {
   readonly lengthArb: Arbitrary<number>;
   readonly depthContext: DepthContext;
+  readonly depthBias: number;
+  readonly maxDepth: number;
+  readonly hasDepthConstraints: boolean;
 
   constructor(
     readonly arb: Arbitrary<T>,
@@ -47,10 +55,15 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
     // it's output just in case produced values are too small (below minLength)
     readonly setBuilder: CustomSetBuilder<Value<T>> | undefined,
     readonly customSlices: T[][],
+    depthSize?: DepthSize,
+    maxDepth?: number,
   ) {
     super();
     this.lengthArb = integer({ min: minLength, max: maxGeneratedLength });
     this.depthContext = getDepthContextFor(depthIdentifier);
+    this.hasDepthConstraints = depthSize !== undefined || maxDepth !== undefined;
+    this.depthBias = depthBiasFromSizeForArbitrary(depthSize, maxDepth !== undefined);
+    this.maxDepth = maxDepth !== undefined ? maxDepth : safePositiveInfinity;
   }
 
   private preFilter(tab: Value<T>[]): Value<T>[] {
@@ -170,9 +183,26 @@ export class ArrayArbitrary<T> extends Arbitrary<T[]> {
     return new Value(vs, context);
   }
 
+  private computeDepthAdjustedMaxGeneratedLength(): number {
+    if (!this.hasDepthConstraints || this.minLength === this.maxGeneratedLength) {
+      return this.maxGeneratedLength;
+    }
+    if (this.maxDepth <= this.depthContext.depth) {
+      return this.minLength;
+    }
+    if (this.depthBias <= 0) {
+      return this.maxGeneratedLength;
+    }
+    const scaleFactor = safeMathPow(1 + this.depthBias, this.depthContext.depth);
+    return safeMathMax(
+      this.minLength,
+      this.minLength + safeMathFloor((this.maxGeneratedLength - this.minLength) / scaleFactor),
+    );
+  }
+
   generate(mrng: Random, biasFactor: number | undefined): Value<T[]> {
     const biasMeta = this.applyBias(mrng, biasFactor);
-    const targetSize = biasMeta.size;
+    const targetSize = safeMathMin(biasMeta.size, this.computeDepthAdjustedMaxGeneratedLength());
     const items =
       this.setBuilder !== undefined
         ? this.safeGenerateNItemsNoDuplicates(this.setBuilder, targetSize, mrng, biasMeta.biasFactorItems)

--- a/packages/fast-check/src/arbitrary/array.ts
+++ b/packages/fast-check/src/arbitrary/array.ts
@@ -1,6 +1,6 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
 import { ArrayArbitrary } from './_internals/ArrayArbitrary.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import {
   MaxLengthUpperBound,
   maxGeneratedLengthFromSizeForArbitrary,
@@ -43,12 +43,25 @@ export interface ArrayConstraints {
    * then the generated items will tend to be less deep to avoid creating structures a lot
    * larger than expected.
    *
-   * For the moment, the depth is not taken into account to compute the number of items to
-   * define for a precise generate call of the array. Just applied onto eligible items.
-   *
    * @remarks Since 2.25.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller arrays.
+   *
+   * @remarks Since 3.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only arrays of {@link ArrayConstraints.minLength | minLength}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 3.x.0
+   */
+  maxDepth?: number;
 }
 
 /**
@@ -84,6 +97,18 @@ function array<T>(arb: Arbitrary<T>, constraints: ArrayConstraints = {}): Arbitr
   const specifiedMaxLength = maxLengthOrUnset !== undefined;
   const maxGeneratedLength = maxGeneratedLengthFromSizeForArbitrary(size, minLength, maxLength, specifiedMaxLength);
   const customSlices = (constraints as ArrayConstraintsInternal<T>).experimentalCustomSlices || [];
-  return new ArrayArbitrary<T>(arb, minLength, maxGeneratedLength, maxLength, depthIdentifier, undefined, customSlices);
+  const depthSize = constraints.depthSize;
+  const maxDepth = constraints.maxDepth;
+  return new ArrayArbitrary<T>(
+    arb,
+    minLength,
+    maxGeneratedLength,
+    maxLength,
+    depthIdentifier,
+    undefined,
+    customSlices,
+    depthSize,
+    maxDepth,
+  );
 }
 export { array };

--- a/packages/fast-check/src/arbitrary/dictionary.ts
+++ b/packages/fast-check/src/arbitrary/dictionary.ts
@@ -1,7 +1,7 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
 import { tuple } from './tuple.js';
 import { uniqueArray } from './uniqueArray.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import {
   keyValuePairsToObjectMapper,
   keyValuePairsToObjectUnmapper,
@@ -47,6 +47,22 @@ export interface DictionaryConstraints {
    * @remarks Since 3.15.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller dictionaries.
+   *
+   * @remarks Since 3.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only dictionaries of {@link DictionaryConstraints.minKeys | minKeys}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 3.x.0
+   */
+  maxDepth?: number;
   /**
    * Do not generate objects with null prototype
    * @defaultValue false
@@ -96,6 +112,8 @@ export function dictionary<K extends PropertyKey, V>(
       size: constraints.size,
       selector: dictionaryKeyExtractor,
       depthIdentifier: constraints.depthIdentifier,
+      depthSize: constraints.depthSize,
+      maxDepth: constraints.maxDepth,
     }),
     noNullPrototype ? constant(false) : boolean(),
   ).map(keyValuePairsToObjectMapper, keyValuePairsToObjectUnmapper);

--- a/packages/fast-check/src/arbitrary/map.ts
+++ b/packages/fast-check/src/arbitrary/map.ts
@@ -1,7 +1,7 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
 import { tuple } from './tuple.js';
 import { uniqueArray } from './uniqueArray.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import { arrayToMapMapper, arrayToMapUnmapper } from './_internals/mappers/ArrayToMap.js';
 import type { DepthIdentifier } from './_internals/helpers/DepthContext.js';
 
@@ -42,6 +42,22 @@ export interface MapConstraints {
    * @remarks Since 4.4.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller maps.
+   *
+   * @remarks Since 4.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only maps of {@link MapConstraints.minKeys | minKeys}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 4.x.0
+   */
+  maxDepth?: number;
 }
 
 /**
@@ -65,6 +81,8 @@ export function map<K, V>(
     size: constraints.size,
     selector: mapKeyExtractor,
     depthIdentifier: constraints.depthIdentifier,
+    depthSize: constraints.depthSize,
+    maxDepth: constraints.maxDepth,
     comparator: 'SameValueZero',
   }).map(arrayToMapMapper, arrayToMapUnmapper);
 }

--- a/packages/fast-check/src/arbitrary/set.ts
+++ b/packages/fast-check/src/arbitrary/set.ts
@@ -1,6 +1,6 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
 import { uniqueArray } from './uniqueArray.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import type { DepthIdentifier } from './_internals/helpers/DepthContext.js';
 import { arrayToSetMapper, arrayToSetUnmapper } from './_internals/mappers/ArrayToSet.js';
 
@@ -35,12 +35,25 @@ export type SetConstraints = {
    * then the generated items will tend to be less deep to avoid creating structures a lot
    * larger than expected.
    *
-   * For the moment, the depth is not taken into account to compute the number of items to
-   * define for a precise generate call of the set. Just applied onto eligible items.
-   *
    * @remarks Since 4.4.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller sets.
+   *
+   * @remarks Since 4.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only sets of {@link SetConstraints.minLength | minLength}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 4.x.0
+   */
+  maxDepth?: number;
 };
 
 /**
@@ -61,6 +74,8 @@ export function set<T>(arb: Arbitrary<T>, constraints: SetConstraints = {}): Arb
     maxLength: constraints.maxLength,
     size: constraints.size,
     depthIdentifier: constraints.depthIdentifier,
+    depthSize: constraints.depthSize,
+    maxDepth: constraints.maxDepth,
     comparator: 'SameValueZero',
   }).map(arrayToSetMapper, arrayToSetUnmapper);
 }

--- a/packages/fast-check/src/arbitrary/sparseArray.ts
+++ b/packages/fast-check/src/arbitrary/sparseArray.ts
@@ -4,7 +4,7 @@ import { tuple } from './tuple.js';
 import { uniqueArray } from './uniqueArray.js';
 import { restrictedIntegerArbitraryBuilder } from './_internals/builders/RestrictedIntegerArbitraryBuilder.js';
 import type { DepthIdentifier } from './_internals/helpers/DepthContext.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import {
   maxGeneratedLengthFromSizeForArbitrary,
   MaxLengthUpperBound,
@@ -58,12 +58,25 @@ export interface SparseArrayConstraints {
    * then the generated items will tend to be less deep to avoid creating structures a lot
    * larger than expected.
    *
-   * For the moment, the depth is not taken into account to compute the number of items to
-   * define for a precise generate call of the array. Just applied onto eligible items.
-   *
    * @remarks Since 2.25.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller arrays.
+   *
+   * @remarks Since 3.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only arrays of {@link SparseArrayConstraints.minNumElements | minNumElements}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 3.x.0
+   */
+  maxDepth?: number;
 }
 
 /** @internal */
@@ -135,6 +148,8 @@ export function sparseArray<T>(arb: Arbitrary<T>, constraints: SparseArrayConstr
       maxLength: resultedMaxNumElements,
       selector: (item) => item[0],
       depthIdentifier,
+      depthSize: constraints.depthSize,
+      maxDepth: constraints.maxDepth,
     },
   ).map(
     (items) => {

--- a/packages/fast-check/src/arbitrary/uniqueArray.ts
+++ b/packages/fast-check/src/arbitrary/uniqueArray.ts
@@ -1,6 +1,6 @@
 import { ArrayArbitrary } from './_internals/ArrayArbitrary.js';
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
-import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
+import type { DepthSize, SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
 import {
   maxGeneratedLengthFromSizeForArbitrary,
   MaxLengthUpperBound,
@@ -74,12 +74,25 @@ export type UniqueArraySharedConstraints = {
    * then the generated items will tend to be less deep to avoid creating structures a lot
    * larger than expected.
    *
-   * For the moment, the depth is not taken into account to compute the number of items to
-   * define for a precise generate call of the array. Just applied onto eligible items.
-   *
    * @remarks Since 2.25.0
    */
   depthIdentifier?: DepthIdentifier | string;
+  /**
+   * While going deeper and deeper within a recursive structure (see {@link letrec}),
+   * this factor will be used to increase the probability to generate smaller arrays.
+   *
+   * @remarks Since 3.x.0
+   */
+  depthSize?: DepthSize;
+  /**
+   * Maximal authorized depth.
+   * Once this depth has been reached only arrays of {@link UniqueArraySharedConstraints.minLength | minLength}
+   * will be generated.
+   *
+   * @defaultValue Number.POSITIVE_INFINITY — _defaulting seen as "max non specified" when `defaultSizeToMaxWhenMaxSpecified=true`_
+   * @remarks Since 3.x.0
+   */
+  maxDepth?: number;
 };
 
 /**
@@ -233,6 +246,8 @@ export function uniqueArray<T, U>(arb: Arbitrary<T>, constraints: UniqueArrayCon
     depthIdentifier,
     setBuilder,
     [],
+    constraints.depthSize,
+    constraints.maxDepth,
   );
   if (minLength === 0) return arrayArb;
   return arrayArb.filter((tab) => tab.length >= minLength);

--- a/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/ArrayArbitrary.spec.ts
@@ -230,6 +230,70 @@ describe('ArrayArbitrary', () => {
       );
     });
 
+    it('should cap generated length based on current depth when maxDepth is set', () => {
+      // Arrange
+      const depthContext = { depth: 3 };
+      const getDepthContextFor = vi.spyOn(DepthContextMock, 'getDepthContextFor');
+      getDepthContextFor.mockReturnValue(depthContext);
+      const { instance, generate } = fakeArbitrary();
+      generate.mockReturnValue(new Value(42, undefined));
+      const { instance: integerInstance, generate: generateInteger } = fakeArbitrary();
+      generateInteger.mockReturnValue(new Value(0, undefined)); // generate 0-length arrays at maxDepth
+      const integer = vi.spyOn(IntegerMock, 'integer');
+      integer.mockReturnValue(integerInstance);
+      const { instance: mrng } = fakeRandom();
+
+      // Act
+      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined, undefined, [], undefined, 3);
+      const g = arb.generate(mrng, undefined);
+
+      // Assert - at depth 3 with maxDepth 3, should generate minLength (0) items
+      expect(g.value).toEqual([]);
+    });
+
+    it('should reduce generated length based on depth when depthSize is set', () => {
+      // Arrange
+      const depthContext = { depth: 2 };
+      const getDepthContextFor = vi.spyOn(DepthContextMock, 'getDepthContextFor');
+      getDepthContextFor.mockReturnValue(depthContext);
+      const { instance, generate } = fakeArbitrary();
+      generate.mockReturnValue(new Value(42, undefined));
+      const { instance: integerInstance, generate: generateInteger } = fakeArbitrary();
+      generateInteger.mockReturnValue(new Value(10, undefined)); // would generate 10 items without depth
+      const integer = vi.spyOn(IntegerMock, 'integer');
+      integer.mockReturnValue(integerInstance);
+      const { instance: mrng } = fakeRandom();
+
+      // Act
+      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined, undefined, [], 'xsmall', undefined);
+      const g = arb.generate(mrng, undefined);
+
+      // Assert - at depth 2 with depthBias=1 (xsmall), adjustedMax = floor(10 / pow(2,2)) = floor(2.5) = 2
+      // so the generated 10 should be capped to 2
+      expect(g.value.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should not adjust generated length when depthSize and maxDepth are not set', () => {
+      // Arrange
+      const depthContext = { depth: 5 };
+      const getDepthContextFor = vi.spyOn(DepthContextMock, 'getDepthContextFor');
+      getDepthContextFor.mockReturnValue(depthContext);
+      const { instance, generate } = fakeArbitrary();
+      generate.mockReturnValue(new Value(42, undefined));
+      const { instance: integerInstance, generate: generateInteger } = fakeArbitrary();
+      generateInteger.mockReturnValue(new Value(10, undefined));
+      const integer = vi.spyOn(IntegerMock, 'integer');
+      integer.mockReturnValue(integerInstance);
+      const { instance: mrng } = fakeRandom();
+
+      // Act
+      const arb = new ArrayArbitrary(instance, 0, 10, 100, undefined, undefined, []);
+      const g = arb.generate(mrng, undefined);
+
+      // Assert - without depth constraints, should generate 10 items even at depth 5
+      expect(g.value.length).toBe(10);
+    });
+
     it('should produce a cloneable instance if provided one cloneable underlying', () => {
       // Arrange
       const { instance, generate } = fakeArbitrary<string[]>();

--- a/packages/fast-check/test/unit/arbitrary/array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/array.spec.ts
@@ -45,6 +45,8 @@ describe('array', () => {
           undefined,
           undefined,
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThan(0);
@@ -78,13 +80,15 @@ describe('array', () => {
           undefined,
           undefined,
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(0);
         expect(receivedGeneratedMaxLength).toBeLessThanOrEqual(maxLength);
         expect(Number.isInteger(receivedGeneratedMaxLength)).toBe(true);
         if (config.defaultSizeToMaxWhenMaxSpecified) {
-          expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength, undefined, undefined, []);
+          expect(ArrayArbitrary).toHaveBeenCalledWith(childInstance, 0, maxLength, maxLength, undefined, undefined, [], undefined, undefined);
         }
         expect(arb).toBe(instance);
       }),
@@ -114,6 +118,8 @@ describe('array', () => {
           undefined,
           undefined,
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         if (minLength !== 2 ** 31 - 1) {
@@ -156,6 +162,8 @@ describe('array', () => {
             undefined,
             undefined,
             [],
+            undefined,
+            undefined,
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);
@@ -170,6 +178,8 @@ describe('array', () => {
               undefined,
               undefined,
               [],
+              undefined,
+              undefined,
             );
           }
           expect(arb).toBe(instance);
@@ -209,6 +219,8 @@ describe('array', () => {
             depthIdentifier,
             undefined,
             [],
+            undefined,
+            undefined,
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);
@@ -223,8 +235,46 @@ describe('array', () => {
               depthIdentifier,
               undefined,
               [],
+              undefined,
+              undefined,
             );
           }
+          expect(arb).toBe(instance);
+        },
+      ),
+    );
+  });
+
+  it('should pass depthSize and maxDepth to ArrayArbitrary for array(arb, {depthSize, maxDepth})', () => {
+    fc.assert(
+      fc.property(
+        sizeRelatedGlobalConfigArb,
+        fc.constantFrom('xsmall' as const, 'small' as const, 'medium' as const),
+        fc.nat({ max: 10 }),
+        (config, depthSize, maxDepth) => {
+          // Arrange
+          const { instance: childInstance } = fakeArbitrary<unknown>();
+          const { instance } = fakeArbitrary<unknown[]>();
+          const ArrayArbitrary = vi.spyOn(ArrayArbitraryMock, 'ArrayArbitrary');
+          ArrayArbitrary.mockImplementation(function () {
+            return instance as ArrayArbitraryMock.ArrayArbitrary<unknown>;
+          });
+
+          // Act
+          const arb = withConfiguredGlobal(config, () => array(childInstance, { depthSize, maxDepth }));
+
+          // Assert
+          expect(ArrayArbitrary).toHaveBeenCalledWith(
+            childInstance,
+            0,
+            expect.any(Number),
+            0x7fffffff,
+            undefined,
+            undefined,
+            [],
+            depthSize,
+            maxDepth,
+          );
           expect(arb).toBe(instance);
         },
       ),

--- a/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/uniqueArray.spec.ts
@@ -44,6 +44,8 @@ describe('uniqueArray', () => {
           undefined,
           expect.any(Function),
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThan(0);
@@ -77,6 +79,8 @@ describe('uniqueArray', () => {
           undefined,
           expect.any(Function),
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(0);
@@ -91,6 +95,8 @@ describe('uniqueArray', () => {
             undefined,
             expect.any(Function),
             [],
+            undefined,
+            undefined,
           );
         }
         expect(arb).toBe(instance);
@@ -122,6 +128,8 @@ describe('uniqueArray', () => {
           undefined,
           expect.any(Function),
           [],
+          undefined,
+          undefined,
         );
         const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
         if (minLength !== 2 ** 31 - 1) {
@@ -165,6 +173,8 @@ describe('uniqueArray', () => {
             undefined,
             expect.any(Function),
             [],
+            undefined,
+            undefined,
           );
           const receivedGeneratedMaxLength = ArrayArbitrary.mock.calls[0][2]; // Expecting the real value would check an implementation detail
           expect(receivedGeneratedMaxLength).toBeGreaterThanOrEqual(minLength);
@@ -179,6 +189,8 @@ describe('uniqueArray', () => {
               undefined,
               expect.any(Function),
               [],
+              undefined,
+              undefined,
             );
           }
           expect(arb).toBe(instance);
@@ -235,6 +247,8 @@ describe('uniqueArray', () => {
             constraints.depthIdentifier,
             expect.any(Function),
             [],
+            undefined,
+            undefined,
           );
           expect(arb).toBe(instance);
         },


### PR DESCRIPTION
Add `depthSize` and `maxDepth` constraints to array-based arbitraries (`array`, `uniqueArray`, `set`, `sparseArray`, `dictionary`, `map`) to support depth-aware length adjustment in recursive structures.

Closes #6344

Generated with [Claude Code](https://claude.ai/code)