### PR TITLE
✨ Use Vitest's sequence.seed to seed fast-check in @fast-check/vitest

### DIFF
--- a/packages/vitest/src/internals/TestAlongGenerator.ts
+++ b/packages/vitest/src/internals/TestAlongGenerator.ts
@@ -4,6 +4,7 @@ import type { ExtraContext } from './types.js';
 
 import { createTaskCollector, getCurrentSuite } from 'vitest/suite';
 import { assert, asyncProperty, gen, readConfigureGlobal } from 'fast-check';
+import { readVitestSeed } from './VitestSeedReader.js';
 
 type TestCollectorOptions = Omit<TestOptions, 'shuffle'>;
 
@@ -33,6 +34,7 @@ function taskCollectorBuilder(this: any, ...args: Sig1 | Sig2 | Sig3) {
               const parameters: Parameters<unknown> = {
                 // Remark: We should turn it back to 1 in case g never gets called by the first execution of the predicate
                 numRuns: config.numRuns ?? 1,
+                seed: config.seed ?? readVitestSeed(),
                 endOnFailure: config.endOnFailure ?? true,
                 includeErrorInReport: false,
                 // @ts-expect-error - Added for backward compatility with fast-check@3

--- a/packages/vitest/src/internals/TestWithPropRunnerBuilder.ts
+++ b/packages/vitest/src/internals/TestWithPropRunnerBuilder.ts
@@ -2,6 +2,7 @@ import { readConfigureGlobal } from 'fast-check';
 
 import type { Parameters as FcParameters } from 'fast-check';
 import type { Prop, PromiseProp, It, ArbitraryTuple, FcExtra } from './types.js';
+import { readVitestSeed } from './VitestSeedReader.js';
 
 function wrapProp<Ts extends [any] | any[]>(prop: Prop<Ts>): PromiseProp<Ts> {
   return (...args: Ts) => Promise.resolve(prop(...args));
@@ -23,7 +24,8 @@ export function buildTestWithPropRunner<Ts extends [any] | any[], TsParameters e
     if (seedFromGlobals !== undefined) {
       customParams.seed = seedFromGlobals;
     } else {
-      customParams.seed = Date.now() ^ (Math.random() * 0x100000000);
+      const seedFromVitest = readVitestSeed();
+      customParams.seed = seedFromVitest !== undefined ? seedFromVitest : Date.now() ^ (Math.random() * 0x100000000);
     }
   }
   // Handle timeout

--- a/packages/vitest/src/internals/VitestSeedReader.ts
+++ b/packages/vitest/src/internals/VitestSeedReader.ts
@@ -1,0 +1,14 @@
+/**
+ * Read the seed configured by Vitest for the current run.
+ * Vitest stores it inside the worker global state under `config.sequence.seed`.
+ * This value corresponds to what `vitest.getSeed()` returns at the node-level API.
+ */
+export function readVitestSeed(): number | undefined {
+  try {
+    const workerState: { config?: { sequence?: { seed?: number } } } | undefined = (globalThis as any)
+      .__vitest_worker__;
+    return workerState?.config?.sequence?.seed;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/vitest/test/vitest-fast-check.spec.ts
+++ b/packages/vitest/test/vitest-fast-check.spec.ts
@@ -152,6 +152,26 @@ describe.each<DescribeOptions>([
       expectPass(out);
     });
 
+    it.concurrent(
+      `should use vitest sequence.seed as the default seed in ${runnerName}.prop`,
+      async () => {
+        // Arrange
+        const specDirectory = await writeToFile(runnerName, () => {
+          runner.prop([fc.string(), fc.string(), fc.string()])('property', (a, b, c) => {
+            return `${a}${b}${c}`.includes(b);
+          });
+        });
+
+        // Act
+        const vitestSeed = 12345;
+        const out = await runSpec(specDirectory, { sequenceSeed: vitestSeed });
+
+        // Assert
+        expectPass(out);
+        expect(out).toContain(`(with seed=${vitestSeed})`);
+      },
+    );
+
     it.concurrent(`should take into account configureGlobal numRuns in ${runnerName}.prop`, async () => {
       // Arrange
       const specDirectory = await writeToFile(runnerName, () => {
@@ -360,7 +380,10 @@ async function writeToFile(runner: 'test' | 'it', fileContent: () => void): Prom
   return specDirectory;
 }
 
-async function runSpec(specDirectory: string, options?: { allowOnly?: boolean }): Promise<string> {
+async function runSpec(
+  specDirectory: string,
+  options?: { allowOnly?: boolean; sequenceSeed?: number },
+): Promise<string> {
   try {
     const args = [
       '../../node_modules/vitest/vitest.mjs',
@@ -371,6 +394,9 @@ async function runSpec(specDirectory: string, options?: { allowOnly?: boolean })
     ];
     if (options?.allowOnly) {
       args.push('--allowOnly');
+    }
+    if (options?.sequenceSeed !== undefined) {
+      args.push(`--sequence.seed=${options.sequenceSeed}`);
     }
     const { stdout: specOutput } = await execFile('node', args, { cwd: specDirectory });
     return specOutput;


### PR DESCRIPTION
Use Vitest's `sequence.seed` to seed fast-check in `@fast-check/vitest`. When no seed is explicitly provided (via params or configureGlobal), the package now reads the seed from Vitest's sequence config, allowing users to control fast-check's randomness through Vitest's `--sequence.seed` flag.

Fixes #6481

Generated with [Claude Code](https://claude.ai/code)