### PR TITLE
👷 Add top-level `permissions: {}` to workflows missing it

### DIFF
--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   add_contributor:
     name: 'Add Contributor'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   format:
     name: 'Format code and commit changes'

--- a/.github/workflows/pr-pnpm-conflicts.yml
+++ b/.github/workflows/pr-pnpm-conflicts.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   fix-pnpm-lock:
     name: 'Fix pnpm lock conflicts and commit changes'

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -8,6 +8,8 @@ on:
       - 'next-*_*_*'
       - 'fix-v*'
 
+permissions: {}
+
 jobs:
   check-template:
     name: 'Check PR template usage'

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -8,6 +8,8 @@ on:
       - 'next-*_*_*'
       - 'fix-v*'
 
+permissions: {}
+
 jobs:
   validate-pr-title:
     name: 'Validate PR title'


### PR DESCRIPTION
## Description

<!-- Describe your change and explain what this PR is trying to solve -->

Add restrictive top-level permissions to 6 workflows that were missing them, improving the OpenSSF Scorecard Token-Permissions score by following the principle of least privilege.

https://claude.ai/code/session_018GeipzG17dG5PA5ZjLiix6

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
