### PR TITLE
👷 Pass explicit string to `make_latest`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -59,5 +59,5 @@ jobs:
           name: ${{ steps.changelog.outputs.release_name }}
           body: ${{ steps.changelog.outputs.changelog }}
           draft: false
-          make_latest: ${{ github.event.inputs.package == 'fast-check' }}
+          make_latest: ${{ github.event.inputs.package == 'fast-check' && 'true' || 'false' }}
           discussion_category_name: Announcements


### PR DESCRIPTION
The make_latest parameter of softprops/action-gh-release expects string
values ('true', 'false', or 'legacy'). The boolean expression was being
passed directly, which could cause non-fast-check packages to still be
flagged as latest due to incorrect type handling.

https://claude.ai/code/session_0165ntLD72j7gjVexvJJUrbw