### PR TITLE
🔧 Remove unused vite dependency from multiple packages

### DIFF
--- a/packages/ava/package.json
+++ b/packages/ava/package.json
@@ -45,7 +45,6 @@
     "rolldown": "^1.0.0-rc.7",
     "rxjs": "^7.8.2",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
   "keywords": [

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -68,7 +68,6 @@
     }
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.28.6",
     "@fast-check/jest": "workspace:*",
     "@fast-check/worker": "workspace:*",
     "@jest/expect": "^30.2.0",

--- a/packages/packaged/package.json
+++ b/packages/packaged/package.json
@@ -41,7 +41,6 @@
     "@types/npmcli__arborist": "^6.3.3",
     "rolldown": "^1.0.0-rc.7",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
   "keywords": [],

--- a/packages/poisoning/package.json
+++ b/packages/poisoning/package.json
@@ -31,7 +31,6 @@
     "@types/node": "^24.12.0",
     "rolldown": "^1.0.0-rc.7",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
   "keywords": [

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,6 @@
     "@fast-check/worker": "workspace:*",
     "@types/node": "^24.12.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,9 +144,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(happy-dom@20.8.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
@@ -194,9 +191,6 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: link:../fast-check
     devDependencies:
-      '@babel/plugin-transform-modules-commonjs':
-        specifier: ^7.28.6
-        version: 7.28.6(@babel/core@7.29.0)
       '@fast-check/jest':
         specifier: workspace:*
         version: 'link:'
@@ -255,9 +249,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(happy-dom@20.8.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
@@ -276,9 +267,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(happy-dom@20.8.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
@@ -326,9 +314,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(happy-dom@20.8.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
@@ -417,9 +402,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(happy-dom@20.8.3)(jiti@1.21.7)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,6 @@
     "jest": "^30.2.0",
     "jimp": "^1.6.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
   "browserslist": {


### PR DESCRIPTION
## Description

Removes the unused `vite` dependency (^7.3.1) from devDependencies across multiple packages in the monorepo. The dependency was declared but not actively used in any of these packages, which were already using `vitest` for testing purposes.

Additionally removes the unused `@babel/plugin-transform-modules-commonjs` dependency from the jest package.

This cleanup reduces the dependency footprint and improves maintainability by removing unused transitive dependencies.

Affected packages:
- `packages/ava`
- `packages/jest`
- `packages/packaged`
- `packages/poisoning`
- `packages/worker`
- `website`

## Checklist

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

https://claude.ai/code/session_018sxngL3KKRU4jrp4YcVoLw