### PR TITLE
📝 Fix typo in the documentation

### DIFF
--- a/website/blog/2024-07-18-integrating-faker-with-fast-check/index.md
+++ b/website/blog/2024-07-18-integrating-faker-with-fast-check/index.md
@@ -87,7 +87,7 @@ function fakerToArb<TValue>(generator: (faker: Faker) => TValue): fc.Arbitrary<T
 }
 ```
 
-### Upadted usage
+### Updated usage
 
 The updated usage would be:
 


### PR DESCRIPTION
## Description

While researching an alternative to jsVerify (https://github.com/PrivateBin/PrivateBin/issues/1812) I found this project and wanted to read about this integration. Thus found a little typo...

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable) (N/A)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
