### PR TITLE
✨ Add support for abort signal on assert

### DIFF
--- a/packages/fast-check/src/check/property/AbortedProperty.ts
+++ b/packages/fast-check/src/check/property/AbortedProperty.ts
@@ -1,0 +1,56 @@
+import type { Random } from '../../random/generator/Random.js';
+import type { Stream } from '../../stream/Stream.js';
+import type { Value } from '../arbitrary/definition/Value.js';
+import { PreconditionFailure } from '../precondition/PreconditionFailure.js';
+import type { IRawProperty } from './IRawProperty.js';
+
+/** @internal */
+export class AbortedProperty<Ts, IsAsync extends boolean> implements IRawProperty<Ts, IsAsync> {
+  constructor(
+    readonly property: IRawProperty<Ts, IsAsync>,
+    readonly signal: AbortSignal,
+  ) {}
+
+  isAsync(): IsAsync {
+    return this.property.isAsync();
+  }
+
+  generate(mrng: Random, runId?: number): Value<Ts> {
+    return this.property.generate(mrng, runId);
+  }
+
+  shrink(value: Value<Ts>): Stream<Value<Ts>> {
+    return this.property.shrink(value);
+  }
+
+  run(v: Ts): ReturnType<IRawProperty<Ts, IsAsync>['run']> {
+    if (this.signal.aborted) {
+      const preconditionFailure = new PreconditionFailure(true);
+      if (this.isAsync()) {
+        return Promise.resolve(preconditionFailure) as any;
+      } else {
+        return preconditionFailure as any;
+      }
+    }
+    if (this.isAsync()) {
+      const propRun = Promise.race([this.property.run(v), waitForAbort(this.signal)]);
+      return propRun as any;
+    }
+    return this.property.run(v);
+  }
+
+  runBeforeEach(): ReturnType<IRawProperty<Ts, IsAsync>['runBeforeEach']> {
+    return this.property.runBeforeEach();
+  }
+
+  runAfterEach(): ReturnType<IRawProperty<Ts, IsAsync>['runAfterEach']> {
+    return this.property.runAfterEach();
+  }
+}
+
+/** @internal */
+function waitForAbort(signal: AbortSignal): Promise<PreconditionFailure> {
+  return new Promise<PreconditionFailure>((resolve) => {
+    signal.addEventListener('abort', () => resolve(new PreconditionFailure(true)), { once: true });
+  });
+}

--- a/packages/fast-check/src/check/runner/DecorateProperty.ts
+++ b/packages/fast-check/src/check/runner/DecorateProperty.ts
@@ -1,4 +1,5 @@
 import type { IRawProperty } from '../property/IRawProperty.js';
+import { AbortedProperty } from '../property/AbortedProperty.js';
 import { SkipAfterProperty } from '../property/SkipAfterProperty.js';
 import { TimeoutProperty } from '../property/TimeoutProperty.js';
 import { UnbiasedProperty } from '../property/UnbiasedProperty.js';
@@ -12,7 +13,13 @@ const safeClearTimeout = clearTimeout;
 /** @internal */
 type MinimalQualifiedParameters<Ts> = Pick<
   QualifiedParameters<Ts>,
-  'unbiased' | 'timeout' | 'skipAllAfterTimeLimit' | 'interruptAfterTimeLimit' | 'skipEqualValues' | 'ignoreEqualValues'
+  | 'unbiased'
+  | 'timeout'
+  | 'skipAllAfterTimeLimit'
+  | 'interruptAfterTimeLimit'
+  | 'signal'
+  | 'skipEqualValues'
+  | 'ignoreEqualValues'
 >;
 
 /** @internal */
@@ -46,6 +53,9 @@ export function decorateProperty<Ts>(
       safeSetTimeout,
       safeClearTimeout,
     );
+  }
+  if (qParams.signal !== undefined) {
+    prop = new AbortedProperty(prop, qParams.signal);
   }
   if (qParams.skipEqualValues) {
     prop = new IgnoreEqualValuesProperty(prop, true);

--- a/packages/fast-check/src/check/runner/configuration/Parameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/Parameters.ts
@@ -203,4 +203,16 @@ export interface Parameters<T = void> {
    * as part of the message and not as a cause.
    */
   includeErrorInReport?: boolean;
+  /**
+   * Abort signal to interrupt the property execution: disabled by default
+   *
+   * When the signal is aborted, the run will be interrupted.
+   * It can be useful to integrate with test runners such as Vitest that provide a signal to abort tests.
+   *
+   * Behavior is similar to `interruptAfterTimeLimit` but driven by an external signal.
+   * `markInterruptAsFailure` can be used to control whether the interruption counts as a failure.
+   *
+   * @remarks Since 3.x.0
+   */
+  signal?: AbortSignal;
 }

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -43,6 +43,7 @@ export class QualifiedParameters<T> {
   reporter: ((runDetails: RunDetails<T>) => void) | undefined;
   asyncReporter: ((runDetails: RunDetails<T>) => Promise<void>) | undefined;
   includeErrorInReport: boolean;
+  signal: AbortSignal | undefined;
 
   constructor(op?: Parameters<T>) {
     const p = op || {};
@@ -71,6 +72,7 @@ export class QualifiedParameters<T> {
     this.reporter = p.reporter;
     this.asyncReporter = p.asyncReporter;
     this.includeErrorInReport = p.includeErrorInReport === true;
+    this.signal = p.signal;
   }
 
   toParameters(): Parameters<T> {
@@ -94,6 +96,7 @@ export class QualifiedParameters<T> {
       reporter: this.reporter,
       asyncReporter: this.asyncReporter,
       includeErrorInReport: this.includeErrorInReport,
+      signal: this.signal,
     };
     return parameters;
   }

--- a/packages/fast-check/test/unit/check/property/AbortedProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/property/AbortedProperty.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { AbortedProperty } from '../../../../src/check/property/AbortedProperty.js';
+import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure.js';
+import { fakeProperty } from './__test-helpers__/PropertyHelpers.js';
+import { fakeRandom } from '../../arbitrary/__test-helpers__/RandomHelpers.js';
+import { Value } from '../../../../src/check/arbitrary/definition/Value.js';
+
+describe('AbortedProperty', () => {
+  it('should forward call to isAsync', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, isAsync, generate, shrink, run, runBeforeEach, runAfterEach } = fakeProperty();
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.isAsync();
+
+    // Assert
+    expect(isAsync).toHaveBeenCalledTimes(1);
+    expect(generate).not.toHaveBeenCalled();
+    expect(shrink).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(runBeforeEach).not.toHaveBeenCalled();
+    expect(runAfterEach).not.toHaveBeenCalled();
+  });
+
+  it('should forward call to generate', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, isAsync, generate, shrink, run, runBeforeEach, runAfterEach } = fakeProperty();
+    const { instance: mrng } = fakeRandom();
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.generate(mrng, 123);
+
+    // Assert
+    expect(isAsync).not.toHaveBeenCalled();
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(shrink).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(runBeforeEach).not.toHaveBeenCalled();
+    expect(runAfterEach).not.toHaveBeenCalled();
+  });
+
+  it('should forward call to shrink', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, isAsync, generate, shrink, run, runBeforeEach, runAfterEach } = fakeProperty();
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.shrink(new Value(Symbol('value'), Symbol('context')));
+
+    // Assert
+    expect(isAsync).not.toHaveBeenCalled();
+    expect(generate).not.toHaveBeenCalled();
+    expect(shrink).toHaveBeenCalledTimes(1);
+    expect(run).not.toHaveBeenCalled();
+    expect(runBeforeEach).not.toHaveBeenCalled();
+    expect(runAfterEach).not.toHaveBeenCalled();
+  });
+
+  it('should forward call to run when signal is not aborted', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, run } = fakeProperty(false);
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.run(Symbol('value'));
+
+    // Assert
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('should forward call to runBeforeEach', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, runBeforeEach } = fakeProperty();
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.runBeforeEach();
+
+    // Assert
+    expect(runBeforeEach).toHaveBeenCalledTimes(1);
+  });
+
+  it('should forward call to runAfterEach', () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, runAfterEach } = fakeProperty();
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    p.runAfterEach();
+
+    // Assert
+    expect(runAfterEach).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return a PreconditionFailure with interrupt when signal is already aborted (sync)', () => {
+    // Arrange
+    const abortController = new AbortController();
+    abortController.abort();
+    const { instance: decoratedProperty, run } = fakeProperty(false);
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    const out = p.run(Symbol('value'));
+
+    // Assert
+    expect(PreconditionFailure.isFailure(out)).toBe(true);
+    expect(PreconditionFailure.isFailure(out) && out.interruptExecution).toBe(true);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should return a PreconditionFailure with interrupt when signal is already aborted (async)', async () => {
+    // Arrange
+    const abortController = new AbortController();
+    abortController.abort();
+    const { instance: decoratedProperty, run } = fakeProperty(true);
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    const out = await p.run(Symbol('value'));
+
+    // Assert
+    expect(PreconditionFailure.isFailure(out)).toBe(true);
+    expect(PreconditionFailure.isFailure(out) && out.interruptExecution).toBe(true);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should interrupt async run when signal is aborted during execution', async () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, run } = fakeProperty(true);
+    run.mockReturnValueOnce(
+      new Promise((resolve) => {
+        setTimeout(() => resolve(null), 1000);
+      }),
+    );
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    const runPromise = p.run(Symbol('value'));
+    abortController.abort();
+
+    // Assert
+    const out = await runPromise;
+    expect(PreconditionFailure.isFailure(out)).toBe(true);
+    expect(PreconditionFailure.isFailure(out) && out.interruptExecution).toBe(true);
+  });
+
+  it('should return property result if it completes before abort (async)', async () => {
+    // Arrange
+    const abortController = new AbortController();
+    const { instance: decoratedProperty, run } = fakeProperty(true);
+    run.mockResolvedValueOnce(null);
+
+    // Act
+    const p = new AbortedProperty(decoratedProperty, abortController.signal);
+    const out = await p.run(Symbol('value'));
+
+    // Assert
+    expect(out).toBe(null);
+  });
+});

--- a/packages/fast-check/test/unit/check/runner/DecorateProperty.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/DecorateProperty.spec.ts
@@ -5,10 +5,12 @@ import { Value } from '../../../../src/check/arbitrary/definition/Value.js';
 import { Stream } from '../../../../src/stream/Stream.js';
 
 // Mocks
+import { AbortedProperty } from '../../../../src/check/property/AbortedProperty.js';
 import { SkipAfterProperty } from '../../../../src/check/property/SkipAfterProperty.js';
 import { TimeoutProperty } from '../../../../src/check/property/TimeoutProperty.js';
 import { UnbiasedProperty } from '../../../../src/check/property/UnbiasedProperty.js';
 import { IgnoreEqualValuesProperty } from '../../../../src/check/property/IgnoreEqualValuesProperty.js';
+vi.mock('../../../../src/check/property/AbortedProperty');
 vi.mock('../../../../src/check/property/SkipAfterProperty');
 vi.mock('../../../../src/check/property/TimeoutProperty');
 vi.mock('../../../../src/check/property/UnbiasedProperty');
@@ -27,6 +29,7 @@ function buildProperty(asyncProp: boolean) {
 
 describe('decorateProperty', () => {
   beforeEach(() => {
+    (AbortedProperty as any).mockClear();
     (SkipAfterProperty as any).mockClear();
     (TimeoutProperty as any).mockClear();
     (UnbiasedProperty as any).mockClear();
@@ -40,7 +43,9 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
+    expect(AbortedProperty).toHaveBeenCalledTimes(0);
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
     expect(UnbiasedProperty).toHaveBeenCalledTimes(0);
@@ -54,6 +59,7 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(1);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
@@ -68,6 +74,7 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(1);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
@@ -82,6 +89,7 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(1);
@@ -96,6 +104,7 @@ describe('decorateProperty', () => {
       unbiased: true,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
@@ -110,7 +119,9 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: false,
+      signal: undefined,
     });
+    expect(AbortedProperty).toHaveBeenCalledTimes(0);
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
     expect(UnbiasedProperty).toHaveBeenCalledTimes(0);
@@ -124,6 +135,7 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: false,
       ignoreEqualValues: true,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
@@ -138,13 +150,32 @@ describe('decorateProperty', () => {
       unbiased: false,
       skipEqualValues: true,
       ignoreEqualValues: false,
+      signal: undefined,
     });
     expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
     expect(TimeoutProperty).toHaveBeenCalledTimes(0);
     expect(UnbiasedProperty).toHaveBeenCalledTimes(0);
     expect(IgnoreEqualValuesProperty).toHaveBeenCalledTimes(1);
   });
+  it('Should enable AbortedProperty on signal', () => {
+    const abortController = new AbortController();
+    decorateProperty(buildProperty(true), {
+      skipAllAfterTimeLimit: undefined,
+      interruptAfterTimeLimit: undefined,
+      timeout: undefined,
+      unbiased: false,
+      skipEqualValues: false,
+      ignoreEqualValues: false,
+      signal: abortController.signal,
+    });
+    expect(AbortedProperty).toHaveBeenCalledTimes(1);
+    expect(SkipAfterProperty).toHaveBeenCalledTimes(0);
+    expect(TimeoutProperty).toHaveBeenCalledTimes(0);
+    expect(UnbiasedProperty).toHaveBeenCalledTimes(0);
+    expect(IgnoreEqualValuesProperty).toHaveBeenCalledTimes(0);
+  });
   it('Should enable multiple wrappers when needed', () => {
+    const abortController = new AbortController();
     decorateProperty(buildProperty(true), {
       skipAllAfterTimeLimit: 1,
       interruptAfterTimeLimit: 1,
@@ -152,7 +183,9 @@ describe('decorateProperty', () => {
       unbiased: true,
       skipEqualValues: true,
       ignoreEqualValues: true,
+      signal: abortController.signal,
     });
+    expect(AbortedProperty).toHaveBeenCalledTimes(1);
     expect(SkipAfterProperty).toHaveBeenCalledTimes(2);
     expect(TimeoutProperty).toHaveBeenCalledTimes(1);
     expect(UnbiasedProperty).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Description

Add a `signal` parameter to `Parameters<T>` that accepts an `AbortSignal`. When aborted, the property run is interrupted using the existing interrupt mechanism. This enables integration with test runners like Vitest 3.2+ that provide a test signal API.

Closes #5990

Generated with [Claude Code](https://claude.ai/code)