### PR TITLE
👷 Fix Claude's session start hook

### DIFF
--- a/.claude/session-start.sh
+++ b/.claude/session-start.sh
@@ -11,8 +11,7 @@ if ! command -v pnpm &>/dev/null; then
   npm install -g pnpm
 fi
 
-# Install dependencies if node_modules is missing or empty
-if [ ! -d "node_modules" ] || [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
-  echo "Installing dependencies with pnpm..."
-  pnpm install --frozen-lockfile
-fi
+# Install/sync dependencies — always run to ensure node_modules matches the lockfile
+# (e.g. after a dependency version bump, node_modules may exist but be stale)
+echo "Installing dependencies with pnpm..."
+pnpm install --frozen-lockfile

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"]
   }
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "types": ["node", "@docusaurus/module-type-aliases", "@docusaurus/theme-classic"]
   }
 }


### PR DESCRIPTION
Remove `"ignoreDeprecations": "6.0"` from website/tsconfig.json as
TypeScript only accepts "5.0" as a valid value. The option is not
needed since the Docusaurus base config has no deprecated options.

https://claude.ai/code/session_019eYYDDKy6qqNgptrcCPkEU