### PR TITLE
📝 Extract manual setup guide into dedicated page

### DIFF
--- a/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup.md
+++ b/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup.md
@@ -1,0 +1,138 @@
+---
+sidebar_position: 0
+slug: /tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/
+description: Set up fast-check with any JavaScript or TypeScript test runner. Learn the runner-agnostic patterns for writing synchronous and asynchronous property-based tests
+sidebar_label: Manual setup
+---
+
+# Property Based Testing — Manual setup
+
+fast-check is designed to be test runner agnostic. You can plug it into any existing test runner without needing a dedicated connector. This page walks through the generic setup that applies whatever runner you use — from runners that do not have a dedicated connector (such as the [Node.js test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-nodejs-test-runner/), [Bun test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-bun-test-runner/), [Deno test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-deno-test-runner/), Mocha, AVA, …) to runners where you prefer full control over connectors like [@fast-check/jest](https://www.npmjs.com/package/@fast-check/jest) or [@fast-check/vitest](https://www.npmjs.com/package/@fast-check/vitest).
+
+:::tip Runner has a connector?
+If you use [Jest](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-jest/) or [Vitest](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-vitest/), we recommend starting with our dedicated connector library — it simplifies integration and handles timeouts and lifecycle for you. The manual setup described here remains a valid alternative whenever you need ultimate flexibility.
+:::
+
+## Install
+
+Start by installing fast-check:
+
+```bash npm2yarn
+npm install --save-dev fast-check
+```
+
+Congratulations! You're now ready to start exploring Property-Based Testing with your favorite runner 🚀
+
+## Your first test
+
+Since we're not relying on any connector, there's no direct integration of fast-check within your runner. Instead, writing a property-based test will largely follow your usual practices, with the test's body calling fast-check to generate inputs and perform assertions.
+
+```js title="isSubstring.spec.js"
+// test/expect come from your test runner — adjust the import to match it
+const fc = require('fast-check');
+
+test('should detect the substring', () => {
+  fc.assert(
+    fc.property(fc.string(), fc.string(), fc.string(), (a, b, c) => {
+      const text = a + b + c;
+      expect(isSubstring(text, b)).toBe(true);
+    }),
+  );
+});
+
+// Code under test: should rather be imported from another file
+function isSubstring(text, pattern) {
+  return text.includes(pattern);
+}
+```
+
+You can now run your test with your usual test command.
+
+You've just written your first Property-Based Test 🚀
+
+:::info Where does `fc.property` come from?
+`fc.property` is the standard way to declare a synchronous property in fast-check. For a deeper dive into properties, arbitraries, and predicates, refer to the [Properties documentation](/docs/core-blocks/properties/).
+:::
+
+## Your first asynchronous test
+
+Now that we've covered synchronous tests, let's explore how to write an asynchronous one. The key difference here is that `fc.property` does not handle asynchronous predicates, so we'll use its asynchronous counterpart, `fc.asyncProperty`.
+
+```js title="queue.spec.js"
+// test/expect come from your test runner — adjust the import to match it
+const fc = require('fast-check');
+const { queue } = require('./queue.js');
+
+test('should resolve in call order', async () => {
+  await fc.assert(
+    fc.asyncProperty(fc.scheduler(), async (s) => {
+      // Arrange
+      const pendingQueries = [];
+      const seenAnswers = [];
+      const call = (v) => Promise.resolve(v);
+
+      // Act
+      const queued = queue(s.scheduleFunction(call));
+      pendingQueries.push(queued(1).then((v) => seenAnswers.push(v)));
+      pendingQueries.push(queued(2).then((v) => seenAnswers.push(v)));
+      await s.waitFor(Promise.all(pendingQueries));
+
+      // Assert
+      expect(seenAnswers).toEqual([1, 2]);
+    }),
+  );
+});
+
+// Code under test: should rather be imported from another file
+function queue(fun) {
+  let lastQuery = Promise.resolve();
+  return (...args) => {
+    const currentQuery = fun(...args);
+    const returnedQuery = lastQuery.then(() => currentQuery);
+    lastQuery = currentQuery;
+    return returnedQuery;
+  };
+}
+```
+
+You can now run your test with your usual test command.
+
+You've just written your first asynchronous Property-Based Test 🚀
+
+:::info Synchronous vs asynchronous predicates
+When the predicate is asynchronous, you must use `fc.asyncProperty` instead of `fc.property`, and `await` the call to `fc.assert`. More details are available in the [Asynchronous properties section](/docs/core-blocks/properties/#asynchronous-properties).
+:::
+
+## Share configuration across your tests
+
+Property-based tests often benefit from shared configuration: aligning time limits with the runner's default timeout, registering `beforeEach`/`afterEach` hooks, or fixing a seed to reproduce a failure. fast-check exposes `fc.configureGlobal` for this exact purpose:
+
+```js
+const fc = require('fast-check');
+
+fc.configureGlobal({ interruptAfterTimeLimit: 5_000 });
+```
+
+With this setup, fast-check will interrupt any property-based test that exceeds the configured time limit — a useful knob to make sure property-based tests fit within your runner's default timeout.
+
+How you hook this configuration call so it runs before your tests depends on your runner. The [Global settings documentation](/docs/configuration/global-settings/#integration-with-test-frameworks) covers the most common cases (Jest, Mocha, Vitest). Most other runners offer an equivalent mechanism (for example a `--require`/`--import` flag, or a preload option).
+
+:::warning Multiple time limits
+The global setup documented above does not automatically adapt to command-line or test-level time limits. Unlike connector libraries such as `@fast-check/jest` or `@fast-check/vitest`, it will ignore any customized time limit passed via the runner's CLI or at individual test level.
+:::
+
+## Pick your runner
+
+Looking for runner-specific integration tips? Head over to the page that matches your setup:
+
+- [With Jest](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-jest/)
+- [With Vitest](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-vitest/)
+- [With the Node.js test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-nodejs-test-runner/)
+- [With the Bun test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-bun-test-runner/)
+- [With the Deno test runner](/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-deno-test-runner/)
+
+## Going further
+
+Now that you have a solid foundation, it's time to delve deeper into the world of property-based testing. Our official documentation covers a range of advanced topics, from [generating custom values](/docs/core-blocks/arbitraries/primitives/number/) tailored to your specific needs to exploring [advanced patterns](/docs/advanced/race-conditions/).
+
+By diving into these resources, you'll gain a deeper understanding of fast-check's capabilities and unlock new possibilities for enhancing your testing workflow.

--- a/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-bun-test-runner.md
+++ b/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-bun-test-runner.md
@@ -19,6 +19,10 @@ bun install -D fast-check
 
 Congratulations, everything is ready to start using Property-Based Tests with the Bun test runner 🚀
 
+:::info Runner-agnostic patterns
+fast-check does not ship a dedicated connector for Bun: you use it the same way you would with any other runner. For the generic sync and async patterns, along with tips on sharing configuration via `fc.configureGlobal`, refer to our [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/) page. The rest of this tutorial focuses on the Bun-specific bits.
+:::
+
 ## Your first test
 
 For our first test, we will consider a function called `decompose`. `decompose` takes an integer value between 1 (included) and 2,147,483,647 (included) and decomposes it into the list of its prime factors. For example, the value `20` can be decomposed as `20 = 2 x 2 x 5`, where neither `2` nor `5` can be decomposed further.

--- a/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-deno-test-runner.md
+++ b/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-deno-test-runner.md
@@ -9,6 +9,10 @@ image: /img/socials/fast-check-deno.png
 
 Want to start playing with property-based testing in [Deno](https://deno.com/)? Welcome to this short and concise tutorial on integrating fast-check within Deno.
 
+:::info Runner-agnostic patterns
+fast-check does not ship a dedicated connector for Deno: you use it the same way you would with any other runner. For the generic sync and async patterns, along with tips on sharing configuration via `fc.configureGlobal`, refer to our [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/) page. The rest of this tutorial focuses on the Deno-specific bits.
+:::
+
 ## Your first test
 
 Let's write a test for [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) using fast-check.

--- a/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-jest.md
+++ b/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-jest.md
@@ -13,9 +13,9 @@ Integrating Property Based Testing capabilities within [Jest](https://jestjs.io/
 We recommend two distinct approaches for integrating fast-check with Jest:
 
 1. **Using our Connector Library:** Simplify your integration process with our dedicated connector library: [@fast-check/jest](https://www.npmjs.com/package/@fast-check/jest). Designed to streamline the setup, this option offers a quick and simple way to leverage fast-check with Jest.
-2. **Manual Integration:** Learn how to connect fast-check with Jest from scratch. This option provides ultimate flexibility and control over your testing setup.
+2. **Manual Integration:** Connect fast-check with Jest without any connector. This option provides ultimate flexibility and control over your testing setup and is covered on our [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/) page.
 
-Both options have their unique benefits and strengths. In this guide, we'll walk you through each method in detail.
+Both options have their unique benefits and strengths. This guide walks you through the connector-based approach; the manual path is documented in its own page.
 
 :::info You don't have Jest yet?
 
@@ -112,7 +112,7 @@ You've connected your first asynchronous Property-Based Test within Jest 🚀
 
 :::info Difference with synchronous predicate
 
-The only difference is that the predicate function is now asynchronous. Compared to the **Manual Integration** (see below), we don't have to use another set of helpers to run asynchronous checks.
+The only difference is that the predicate function is now asynchronous. Compared to the [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/) approach, we don't have to use another set of helpers to run asynchronous checks.
 
 ```diff
 - test.prop({ s: fc.scheduler() })('should resolve in call order', ({ s }) => {
@@ -127,136 +127,14 @@ For more advanced options and configurations of the connector, explore the [Adva
 
 ## Manual setup
 
-Leveraging fast-check within an existing Jest project doesn't require the use of a connector. In fact, fast-check is designed to be test runner agnostic, making the connector a convenient option for users seeking seamless integration within their existing tooling.
+Prefer full control and do not want to rely on `@fast-check/jest`? fast-check is test runner agnostic and plugs into Jest without any connector.
 
-In this section, we'll explore how to set up fast-check directly in your Jest projects.
+The generic sync and async patterns, along with the recommended usage of `fc.configureGlobal`, are documented in a single runner-agnostic page: [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/). When writing tests the Jest way, you can import `test` and `expect` from [`@jest/globals`](https://jestjs.io/docs/api) (or rely on Jest's global injection).
 
-### Basic setup
+### Sharing `fc.configureGlobal` with Jest
 
-Start by installing the necessary libraries for your project with the following command:
-
-```bash npm2yarn
-npm install --save-dev fast-check
-```
-
-Congratulations! You're now ready to start exploring Property-Based Testing within Jest 🚀
-
-While you could begin writing property-based tests now, we recommend some additional setup to enhance integration and maximize the benefits of fast-check within Jest.
-
-### Recommended setup
-
-As Property-Based Tests can take longer to run compared to other tests, it's recommended to adjust their time allocation appropriately. In this section, we'll focus on ensuring that property-based tests stay within the time constraints set for all your other tests. While it might be tempting to specify separate time limits for them, we recommend letting them run with the same time limit as any other tests, especially in Continuous Integration environments.
-
-To globally apply our setup across all tests, Jest provides a mechanism for executing setup files before tests start running. If you haven't already created a setup file, you can do so as follows:
-
-```js title="jest.config.js"
-module.exports = {
-  setupFiles: ['./jest.setup.js'],
-};
-```
-
-Now that we have the setup file in place, let's configure fast-check:
-
-```js title="jest.setup.js"
-const fc = require('fast-check');
-fc.configureGlobal({ interruptAfterTimeLimit: 5_000 });
-```
-
-With this setup, we ensure that fast-check stops any running property-based tests that exceed the 5-second limit, which is [the default time limit in Jest](https://jestjs.io/docs/cli#--testtimeoutnumber).
-
-:::tip Checking the setup
-
-You can confirm that the setup has been properly applied to your test files by using the following temporary test and running the tests:
-
-```js
-test('fast-check properly configured', () => {
-  expect(fc.readConfigureGlobal()).toEqual({ interruptAfterTimeLimit: 5_000 });
-});
-```
-
-:::
+The most common reason to call `fc.configureGlobal` is to align property-based tests with [Jest's default 5-second timeout](https://jestjs.io/docs/cli#--testtimeoutnumber) via `interruptAfterTimeLimit`. Jest exposes `setupFiles` for this use case — the exact snippet (`jest.config.js` + `jest.setup.js`) is documented in the [Jest section of Global settings](/docs/configuration/global-settings/#jest).
 
 :::warning Multiple time limits
-
-Unlike the implementation provided by `@fast-check/jest`, the global setup documented above does not automatically adapt itself to command-line dependent time limits or test-dependent ones. In other words, our documented setup will ignore any customized time limit passed via `--testTimeout=<number>` or directly defined at test level via `test(label, fn, timeout)`.
+Unlike `@fast-check/jest`, this manual setup does not automatically adapt to command-line or test-level time limits. It will ignore any customized time limit passed via `--testTimeout=<number>` or at test level via `test(label, fn, timeout)`.
 :::
-
-You can even customize this setup further by instructing fast-check to run tests until they reach a specified time limit. While this approach might not be suitable for general Continuous Integration, environments, it can be valuable in fuzzing-like CI pipelines. In such cases, you'll want to increase the number of runs passed to fast-check to an arbitrarily high value, such as `numRuns: Number.POSITIVE_INFINITY`.
-
-### Your first test
-
-Since we're not using a specific connector, there's no direct integration of fast-check within Jest. Instead, writing a property-based test will largely follow your usual Jest practices, with the test's content calling fast-check to generate inputs and expectations.
-
-```js title="isSubstring.spec.js"
-const { test } = require('@jest/globals');
-const fc = require('fast-check');
-
-test('should detect the substring', () => {
-  fc.assert(
-    fc.property(fc.string(), fc.string(), fc.string(), (a, b, c) => {
-      const text = a + b + c;
-      expect(isSubtring(text, b)).toBe(true);
-    }),
-  );
-});
-
-// Code under test: should rather be imported from another file
-function isSubtring(text, pattern) {
-  return text.includes(pattern);
-}
-```
-
-You can now run your test with your usual test command.
-
-You've connected your first Property-Based Test within Jest 🚀
-
-### Your first asynchronous test
-
-Now that we've covered synchronous tests, let's explore how to integrate an asynchronous one. The key difference here is that `fc.property` does not handle asynchronous predicates, so we'll use its asynchronous counterpart, `fc.asyncProperty`.
-
-```js title="queue.spec.js"
-const { test } = require('@jest/globals');
-const fc = require('fast-check');
-const { queue } = require('./queue.js'); // refer to the section "connector" for the code
-
-test('should resolve in call order', async () => {
-  await fc.assert(
-    fc.asyncProperty(fc.scheduler(), async (s) => {
-      // Arrange
-      const pendingQueries = [];
-      const seenAnswers = [];
-      const call = jest.fn().mockImplementation((v) => Promise.resolve(v));
-
-      // Act
-      const queued = queue(s.scheduleFunction(call));
-      pendingQueries.push(queued(1).then((v) => seenAnswers.push(v)));
-      pendingQueries.push(queued(2).then((v) => seenAnswers.push(v)));
-      await s.waitFor(Promise.all(pendingQueries));
-
-      // Assert
-      expect(seenAnswers).toEqual([1, 2]);
-    }),
-  );
-});
-
-// Code under test: should rather be imported from another file
-function queue(fun) {
-  let lastQuery = Promise.resolve();
-  return (...args) => {
-    const currentQuery = fun(...args);
-    const returnedQuery = lastQuery.then(() => currentQuery);
-    lastQuery = currentQuery;
-    return returnedQuery;
-  };
-}
-```
-
-You can now run your test with your usual test command.
-
-You've connected your first asynchronous Property-Based Test within Jest 🚀
-
-### Going further
-
-Now that you have a solid foundation, it's time to delve deeper into the world of property-based testing. Our official documentation covers a range of advanced topics, from [generating custom values](/docs/core-blocks/arbitraries/primitives/number/) tailored to your specific needs to exploring [advanced patterns](/docs/advanced/race-conditions/).
-
-By diving into these resources, you'll gain a deeper understanding of fast-check's capabilities and unlock new possibilities for enhancing your testing workflow. Continue your exploration and elevate your property-based testing skills to new heights.

--- a/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-nodejs-test-runner.md
+++ b/website/docs/tutorials/setting-up-your-test-environment/property-based-testing-with-nodejs-test-runner.md
@@ -21,6 +21,10 @@ npm install --save-dev fast-check
 
 Congratulations, everything is ready to start using Property-Based Tests with the Node.js test runner 🚀
 
+:::info Runner-agnostic patterns
+fast-check does not ship a dedicated connector for the Node.js test runner: you use it the same way you would with any other runner. For the generic sync and async patterns, along with tips on sharing configuration via `fc.configureGlobal`, refer to our [Manual setup](/docs/tutorials/setting-up-your-test-environment/property-based-testing-manual-setup/) page. The rest of this tutorial focuses on the Node-specific bits.
+:::
+
 ## Your first test
 
 For our first test, we will test an algorithm computing a value of the [Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence). Our property-based test will assess that our implementation respects the rule: `fibo(n) = fibo(n-1) + fibo(n-2)`.


### PR DESCRIPTION
## Description

Refactor the documentation structure for the "Setting up your test environment" section by extracting the runner-agnostic manual setup patterns into a dedicated page, removing duplication across runner-specific guides.

### Changes

1. **New page** `property-based-testing-manual-setup.md` (`sidebar_position: 0`) — runner-agnostic walkthrough that covers:
   - Generic installation instructions
   - Synchronous property-based test pattern using `fc.property` + `fc.assert`
   - Asynchronous test pattern using `fc.asyncProperty`
   - Recommended use of `fc.configureGlobal` for sharing settings (timeout alignment, hooks, seeds)
   - Links to runner-specific integration pages and to `/docs/configuration/global-settings/` for hook details

2. **Jest page** — removed the ~130-line "Manual setup" section (install, recommended setup, sync test, async test, going further) and replaced it with a short pointer that links to the new page and to `/docs/configuration/global-settings/#jest` for the `setupFiles` snippet. Connector path stays as the recommended option.

3. **Bun, Node.js, Deno pages** — added an `:::info Runner-agnostic patterns` callout pointing to the new page so readers can find sync/async patterns and `configureGlobal` guidance in one place. The runner-specific install commands, imports, run commands, and example tests are kept untouched.

### Rationale

- **DRY** — eliminates duplication of sync/async test patterns and the `configureGlobal` recommendation across multiple pages
- **Better discoverability** — Bun and Node users gain easy access to async-property guidance that previously only lived inside the Jest page
- **Clearer split** — runner-specific pages now focus on what is unique to each runner, while shared patterns live in one canonical place

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

https://claude.ai/code/session_01LduMT1azz85eVZ2YsAk8Aj