### PR TITLE
📝 Add index pages for documentation sections

### DIFF
--- a/website/docs/advanced/_category_.json
+++ b/website/docs/advanced/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 4, "label": "Advanced" }

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -10,8 +10,8 @@ The pages in this section assume you are already comfortable writing a property 
 
 Each page solves a different class of problem that cannot be expressed cleanly as a one-shot property:
 
-- **Model-based testing** — when the system under test has *state*, and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
-- **Race conditions** — when the bug is not in *what* your async code does but in *which order* its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
+- **Model-based testing** — when the system under test has _state_, and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
+- **Race conditions** — when the bug is not in _what_ your async code does but in _which order_ its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
 - **Fuzzing** — when you want to keep hunting for counterexamples across runs or beyond the default budget, turning fast-check into a continuous fuzz loop rather than a CI gate.
 - **Fake data** — when you need large volumes of realistic-looking values outside the property-test context, for seeding environments or staging datasets.
 

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 0
+slug: /advanced/
+description: Techniques that go beyond a single property — model-based testing, race conditions, fuzzing loops, and realistic fake data generation.
+---
+
+# Advanced
+
+The pages in this section assume you are already comfortable writing a property and running it with `fc.assert`. They show what happens when you want fast-check to do more than check a single invariant on a single call.
+
+Each page solves a different class of problem that cannot be expressed cleanly as a one-shot property:
+
+- **Model-based testing** — when the system under test has *state*, and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
+- **Race conditions** — when the bug is not in *what* your async code does but in *which order* its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
+- **Fuzzing** — when you want to keep hunting for counterexamples across runs or beyond the default budget, turning fast-check into a continuous fuzz loop rather than a CI gate.
+- **Fake data** — when you need large volumes of realistic-looking values outside the property-test context, for seeding environments or staging datasets.
+
+:::tip Want a hands-on walkthrough on race conditions?
+[Race conditions](/docs/advanced/race-conditions/) is the reference. If you would rather learn by writing a failing test step by step, the [Detect race conditions tutorial](/docs/tutorials/detect-race-conditions/) covers the same ground interactively.
+:::
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 4
 slug: /advanced/
 description: Techniques that go beyond a single property — model-based testing, race conditions, fuzzing loops and realistic fake data generation.
 ---

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 0
 slug: /advanced/
-description: Techniques that go beyond a single property — model-based testing, race conditions, fuzzing loops, and realistic fake data generation.
+description: Techniques that go beyond a single property — model-based testing, race conditions, fuzzing loops and realistic fake data generation.
 ---
 
 # Advanced

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -11,7 +11,7 @@ The pages in this section assume you are already comfortable writing a property 
 Each page solves a different class of problem that cannot be expressed cleanly as a one-shot property:
 
 - **Model-based testing** — when the system under test has state and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
-- **Race conditions** — when the bug is not in _what_ your async code does but in _which order_ its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
+- **Race conditions** — when the bug is not in what your async code does but in which order its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
 - **Fuzzing** — when you want to keep hunting for counterexamples across runs or beyond the default budget, turning fast-check into a continuous fuzz loop rather than a CI gate.
 - **Fake data** — when you need large volumes of realistic-looking values outside the property-test context, for seeding environments or staging datasets.
 

--- a/website/docs/advanced/index.md
+++ b/website/docs/advanced/index.md
@@ -10,7 +10,7 @@ The pages in this section assume you are already comfortable writing a property 
 
 Each page solves a different class of problem that cannot be expressed cleanly as a one-shot property:
 
-- **Model-based testing** — when the system under test has _state_, and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
+- **Model-based testing** — when the system under test has state and a bug only shows up after a specific sequence of operations. You describe the legal operations as commands and let fast-check search the space of sequences.
 - **Race conditions** — when the bug is not in _what_ your async code does but in _which order_ its callbacks resolve. fast-check's scheduler lets you deterministically explore those interleavings.
 - **Fuzzing** — when you want to keep hunting for counterexamples across runs or beyond the default budget, turning fast-check into a continuous fuzz loop rather than a CI gate.
 - **Fake data** — when you need large volumes of realistic-looking values outside the property-test context, for seeding environments or staging datasets.

--- a/website/docs/configuration/_category_.json
+++ b/website/docs/configuration/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 3, "label": "Configuration" }

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 0
+slug: /configuration/
+description: Tune fast-check — seeds, number of runs, entry sizes, timeouts, reports — per assertion or globally, with clear precedence rules.
+---
+
+# Configuration
+
+fast-check works out of the box, but everything it does is configurable: the number of runs per property, the seed that makes a failure reproducible, how large generated values can grow, how long a run can take, and how results are reported.
+
+There are **two levels** at which you can set any of these knobs, and knowing how they interact is the single most useful thing on this page:
+
+- **Per assertion** — pass a `Parameters` object as the second argument to `fc.assert(property, { ... })`. This wins over everything else and applies only to that one call.
+- **Globally** — call [`fc.configureGlobal({ ... })`](/docs/configuration/global-settings/) once, typically in a test setup file, to apply defaults to every assertion in the process.
+
+The per-assertion form always overrides the global one, so a common pattern is to pin conservative defaults globally (e.g. tighter timeouts in CI) and widen them locally for the few tests that need more runs, larger inputs, or a specific seed.
+
+:::tip The three knobs most users actually touch
+**`seed`** to reproduce a failure, **`numRuns`** to trade speed for confidence, and **`size`** / `maxLength` bounds to keep generation cheap. The remaining options exist for edge cases — do not reach for them until one of the pages below tells you why.
+:::
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -6,18 +6,14 @@ description: Tune fast-check — seeds, number of runs, entry sizes, timeouts, r
 
 # Configuration
 
-fast-check works out of the box, but everything it does is configurable: the number of runs per property, the seed that makes a failure reproducible, how large generated values can grow, how long a run can take, and how results are reported.
+fast-check works out of the box, but everything it does is configurable: the number of runs per property, the seed that makes a failure reproducible, how large generated values can grow, how long a run can take and how results are reported.
 
-There are **two levels** at which you can set any of these knobs, and knowing how they interact is the single most useful thing on this page:
+There are two levels at which you can set any of these knobs and knowing how they interact is the single most useful thing on this page:
 
 - **Per assertion** — pass a `Parameters` object as the second argument to `fc.assert(property, { ... })`. This wins over everything else and applies only to that one call.
 - **Globally** — call [`fc.configureGlobal({ ... })`](/docs/configuration/global-settings/) once, typically in a test setup file, to apply defaults to every assertion in the process.
 
-The per-assertion form always overrides the global one, so a common pattern is to pin conservative defaults globally (e.g. tighter timeouts in CI) and widen them locally for the few tests that need more runs, larger inputs, or a specific seed.
-
-:::tip The three knobs most users actually touch
-**`seed`** to reproduce a failure, **`numRuns`** to trade speed for confidence, and **`size`** / `maxLength` bounds to keep generation cheap. The remaining options exist for edge cases — do not reach for them until one of the pages below tells you why.
-:::
+The per-assertion form always overrides the global one, so a common pattern is to pin conservative defaults globally (e.g. tighter timeouts in CI) and widen them locally for the few tests that need more runs, larger input or a specific seed.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -15,10 +15,6 @@ There are two levels at which you can set any of these knobs and knowing how the
 
 The per-assertion form always overrides the global one, so a common pattern is to pin conservative defaults globally (e.g. tighter timeouts in CI) and widen them locally for the few tests that need more runs, larger input or a specific seed.
 
-:::tip The three knobs most users actually touch
-**`seed`** to reproduce a failure, **`numRuns`** to trade speed for confidence, and **`size`** / `maxLength` bounds to keep generation cheap. The remaining options exist for edge cases — do not reach for them until one of the pages below tells you why.
-:::
-
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
 

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 3
 slug: /configuration/
 description: Tune fast-check — seeds, number of runs, entry sizes, timeouts, reports — per assertion or globally, with clear precedence rules.
 ---
@@ -14,6 +14,10 @@ There are two levels at which you can set any of these knobs and knowing how the
 - **Globally** — call [`fc.configureGlobal({ ... })`](/docs/configuration/global-settings/) once, typically in a test setup file, to apply defaults to every assertion in the process.
 
 The per-assertion form always overrides the global one, so a common pattern is to pin conservative defaults globally (e.g. tighter timeouts in CI) and widen them locally for the few tests that need more runs, larger input or a specific seed.
+
+:::tip The three knobs most users actually touch
+**`seed`** to reproduce a failure, **`numRuns`** to trade speed for confidence, and **`size`** / `maxLength` bounds to keep generation cheap. The remaining options exist for edge cases — do not reach for them until one of the pages below tells you why.
+:::
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/core-blocks/_category_.json
+++ b/website/docs/core-blocks/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 2, "label": "Core Blocks" }

--- a/website/docs/core-blocks/arbitraries/_category_.json
+++ b/website/docs/core-blocks/arbitraries/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 1, "label": "Arbitraries" }

--- a/website/docs/core-blocks/arbitraries/combiners/_category_.json
+++ b/website/docs/core-blocks/arbitraries/combiners/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 3, "label": "Combiners" }

--- a/website/docs/core-blocks/arbitraries/combiners/index.md
+++ b/website/docs/core-blocks/arbitraries/combiners/index.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 0
+slug: /core-blocks/arbitraries/combiners/
+description: Transform and compose existing arbitraries — pick among them, constrain them, tie them together recursively, or promote plain values into generators.
+---
+
+# Combiners
+
+Combiners are the only arbitraries in fast-check that do not generate anything on their own. They take one or more existing arbitraries as input and return a new one — they are the functional glue that lets a handful of primitives and composites cover the full space of values a real codebase cares about.
+
+You will reach for a combiner whenever you want to:
+
+- **promote plain values** into the arbitrary world (`constant`, `constantFrom`),
+- **choose between alternatives** (`oneof`, `option`),
+- **tie arbitraries together recursively** (`letrec`) to generate trees, ASTs, or JSON-like structures,
+- **refine or transform** an existing arbitrary with `.filter`, `.map`, `.chain`, or adjust its shrinking with `noShrink` / `limitShrink`.
+
+Because every combiner wraps another arbitrary, shrinking composes too: the combiner preserves (or deliberately limits) the shrink behaviour of the arbitrary it wraps, so a counterexample through `oneof(...).map(...)` still collapses toward the simple values defined by the innermost primitive.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/arbitraries/combiners/index.md
+++ b/website/docs/core-blocks/arbitraries/combiners/index.md
@@ -6,13 +6,13 @@ description: Transform and compose existing arbitraries — pick among them, con
 
 # Combiners
 
-Combiners are the only arbitraries in fast-check that do not generate anything on their own. They take one or more existing arbitraries as input and return a new one — they are the functional glue that lets a handful of primitives and composites cover the full space of values a real codebase cares about.
+Combiners are the only arbitraries in fast-check that do not generate anything on their own. They take one or more existing arbitraries as input and return a new one. They are the functional glue that lets a handful of primitives and composites cover the full space of values a real codebase cares about.
 
 You will reach for a combiner whenever you want to:
 
 - **promote plain values** into the arbitrary world (`constant`, `constantFrom`),
 - **choose between alternatives** (`oneof`, `option`),
-- **tie arbitraries together recursively** (`letrec`) to generate trees, ASTs, or JSON-like structures,
+- **tie arbitraries together recursively** (`letrec`) to generate trees, ASTs or JSON-like structures,
 - **refine or transform** an existing arbitrary with `.filter`, `.map`, `.chain`, or adjust its shrinking with `noShrink` / `limitShrink`.
 
 Because every combiner wraps another arbitrary, shrinking composes too: the combiner preserves (or deliberately limits) the shrink behaviour of the arbitrary it wraps, so a counterexample through `oneof(...).map(...)` still collapses toward the simple values defined by the innermost primitive.

--- a/website/docs/core-blocks/arbitraries/combiners/index.md
+++ b/website/docs/core-blocks/arbitraries/combiners/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 0
 slug: /core-blocks/arbitraries/combiners/
-description: Transform and compose existing arbitraries — pick among them, constrain them, tie them together recursively, or promote plain values into generators.
+description: Transform and compose existing arbitraries — pick among them, constrain them, tie them together recursively or promote plain values into generators.
 ---
 
 # Combiners

--- a/website/docs/core-blocks/arbitraries/combiners/index.md
+++ b/website/docs/core-blocks/arbitraries/combiners/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 3
 slug: /core-blocks/arbitraries/combiners/
 description: Transform and compose existing arbitraries — pick among them, constrain them, tie them together recursively or promote plain values into generators.
 ---

--- a/website/docs/core-blocks/arbitraries/composites/_category_.json
+++ b/website/docs/core-blocks/arbitraries/composites/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 2, "label": "Composites" }

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 0
+slug: /core-blocks/arbitraries/composites/
+description: Combine smaller arbitraries into arrays, objects, iterables, functions and typed arrays — with size control and two-dimensional shrinking.
+---
+
+# Composites
+
+Composite arbitraries take other arbitraries as input and assemble them into structured values. An `array` is built from an arbitrary for its elements, a `record` is built from arbitraries for each of its fields, and so on — there is no "random structure" to speak of, only a shape you describe and a child arbitrary that fills it.
+
+Two concepts recur on every page in this section and are worth learning once:
+
+- **Size control.** Most composites accept `minLength` / `maxLength` bounds and a `size` modifier that scales how large generated values tend to be in practice (see [`size` explained](/docs/configuration/larger-entries-by-default/#size-explained)). These are the main knobs to keep generation costs under control when your children are themselves expensive.
+- **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) *and* the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -11,7 +11,7 @@ Composite arbitraries take other arbitraries as input and assemble them into str
 Two concepts recur on every page in this section and are worth learning once:
 
 - **Size control.** Most composites accept `minLength` / `maxLength` bounds and a `size` modifier that scales how large generated values tend to be in practice (see [`size` explained](/docs/configuration/larger-entries-by-default/#size-explained)). These are the main knobs to keep generation costs under control when your children are themselves expensive.
-- **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) *and* the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
+- **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) _and_ the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -11,7 +11,7 @@ Composite arbitraries take other arbitraries as input and assemble them into str
 Two concepts recur on every page in this section and are worth learning once:
 
 - **Size control.** Most composites accept `minLength` / `maxLength` bounds and a `size` modifier that scales how large generated values tend to be in practice (see [`size` explained](/docs/configuration/larger-entries-by-default/#size-explained)).
-- **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) _and_ the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
+- **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) and the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -10,7 +10,7 @@ Composite arbitraries take other arbitraries as input and assemble them into str
 
 Two concepts recur on every page in this section and are worth learning once:
 
-- **Size control.** Most composites accept `minLength` / `maxLength` bounds and a `size` modifier that scales how large generated values tend to be in practice (see [`size` explained](/docs/configuration/larger-entries-by-default/#size-explained)). These are the main knobs to keep generation costs under control when your children are themselves expensive.
+- **Size control.** Most composites accept `minLength` / `maxLength` bounds and a `size` modifier that scales how large generated values tend to be in practice (see [`size` explained](/docs/configuration/larger-entries-by-default/#size-explained)).
 - **Two-dimensional shrinking.** When a test fails on a composite, fast-check shrinks along two axes independently: the **structure** (it tries shorter arrays, fewer object keys, smaller tuples) _and_ the **contents** (each surviving element is shrunk by its own arbitrary). This is why counterexamples on nested data tend to collapse cleanly to the minimal offender rather than to an opaque blob.
 
 ```mdx-code-block

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 2
 slug: /core-blocks/arbitraries/composites/
 description: Combine smaller arbitraries into arrays, objects, iterables, functions and typed arrays — with size control and two-dimensional shrinking.
 ---

--- a/website/docs/core-blocks/arbitraries/composites/index.md
+++ b/website/docs/core-blocks/arbitraries/composites/index.md
@@ -6,7 +6,7 @@ description: Combine smaller arbitraries into arrays, objects, iterables, functi
 
 # Composites
 
-Composite arbitraries take other arbitraries as input and assemble them into structured values. An `array` is built from an arbitrary for its elements, a `record` is built from arbitraries for each of its fields, and so on — there is no "random structure" to speak of, only a shape you describe and a child arbitrary that fills it.
+Composite arbitraries take other arbitraries as input and assemble them into structured values. An `array` is built from an arbitrary for its elements, a `record` is built from arbitraries for each of its fields and so on. There is no "random structure" to speak of, only a shape you describe and a child arbitrary that fills it.
 
 Two concepts recur on every page in this section and are worth learning once:
 

--- a/website/docs/core-blocks/arbitraries/fake-data/_category_.json
+++ b/website/docs/core-blocks/arbitraries/fake-data/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 4, "label": "Fake Data" }

--- a/website/docs/core-blocks/arbitraries/fake-data/index.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/index.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 0
+slug: /core-blocks/arbitraries/fake-data/
+description: Ready-made generators for realistic-shape values — UUIDs, emails, URLs, IPs, filenames — when your code branches on the shape of its inputs.
+---
+
+# Fake Data
+
+The fake-data arbitraries produce values that *look* like production data: UUIDs, email addresses, IPv4/IPv6, URLs, filenames, MIME types. Each one is a convenience wrapper built on top of primitives and composites, pre-configured so that generated values satisfy a recognisable format.
+
+Reach for them when **your code branches on the shape** of its input — a regex that expects a valid email, a parser that only accepts well-formed URLs, a router that inspects filename extensions. Feeding such code a plain `fc.string()` would spend almost every run in the error path and tell you nothing about the happy path you actually care about.
+
+:::warning Do not over-use fake data
+Fake-data arbitraries have narrower shrink spaces than primitives: a shrunk counterexample for `fc.emailAddress()` is still a valid email, not an empty string. When your code does **not** care about the format, plain primitives give better coverage *and* tighter counterexamples. Use fake data to unblock a specific branch, not as a default.
+:::
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/arbitraries/fake-data/index.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/index.md
@@ -6,12 +6,12 @@ description: Ready-made generators for realistic-shape values — UUIDs, emails,
 
 # Fake Data
 
-The fake-data arbitraries produce values that *look* like production data: UUIDs, email addresses, IPv4/IPv6, URLs, filenames, MIME types. Each one is a convenience wrapper built on top of primitives and composites, pre-configured so that generated values satisfy a recognisable format.
+The fake-data arbitraries produce values that _look_ like production data: UUIDs, email addresses, IPv4/IPv6, URLs, filenames, MIME types. Each one is a convenience wrapper built on top of primitives and composites, pre-configured so that generated values satisfy a recognisable format.
 
 Reach for them when **your code branches on the shape** of its input — a regex that expects a valid email, a parser that only accepts well-formed URLs, a router that inspects filename extensions. Feeding such code a plain `fc.string()` would spend almost every run in the error path and tell you nothing about the happy path you actually care about.
 
 :::warning Do not over-use fake data
-Fake-data arbitraries have narrower shrink spaces than primitives: a shrunk counterexample for `fc.emailAddress()` is still a valid email, not an empty string. When your code does **not** care about the format, plain primitives give better coverage *and* tighter counterexamples. Use fake data to unblock a specific branch, not as a default.
+Fake-data arbitraries have narrower shrink spaces than primitives: a shrunk counterexample for `fc.emailAddress()` is still a valid email, not an empty string. When your code does **not** care about the format, plain primitives give better coverage _and_ tighter counterexamples. Use fake data to unblock a specific branch, not as a default.
 :::
 
 ```mdx-code-block

--- a/website/docs/core-blocks/arbitraries/fake-data/index.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/index.md
@@ -11,7 +11,7 @@ The fake-data arbitraries produce values that _look_ like production data: UUIDs
 Reach for them when **your code branches on the shape** of its input — a regex that expects a valid email, a parser that only accepts well-formed URLs, a router that inspects filename extensions. Feeding such code a plain `fc.string()` would spend almost every run in the error path and tell you nothing about the happy path you actually care about.
 
 :::warning Do not over-use fake data
-Fake-data arbitraries have narrower shrink spaces than primitives: a shrunk counterexample for `fc.emailAddress()` is still a valid email, not an empty string. When your code does **not** care about the format, plain primitives give better coverage _and_ tighter counterexamples. Use fake data to unblock a specific branch, not as a default.
+Fake-data arbitraries have narrower shrink spaces than primitives: a shrunk counterexample for `fc.emailAddress()` is still a valid email, not an empty string. When your code does **not** care about the format, plain primitives give better coverage and tighter counterexamples. Use fake data to unblock a specific branch, not as a default.
 :::
 
 ```mdx-code-block

--- a/website/docs/core-blocks/arbitraries/fake-data/index.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 4
 slug: /core-blocks/arbitraries/fake-data/
 description: Ready-made generators for realistic-shape values — UUIDs, emails, URLs, IPs, filenames — when your code branches on the shape of its inputs.
 ---

--- a/website/docs/core-blocks/arbitraries/index.md
+++ b/website/docs/core-blocks/arbitraries/index.md
@@ -11,11 +11,11 @@ An arbitrary in fast-check is **not just a random value generator**. It is a gen
 fast-check groups its built-in arbitraries into four families, each with its own rules:
 
 - **Primitives** — strings, numbers, booleans, dates, bigints. The only arbitraries with no upstream dependency; they anchor the shrink targets that every other family converges toward.
-- **Composites** — arrays, objects, iterables, functions, typed arrays. Arbitraries you build *out of* other arbitraries to describe structured values.
+- **Composites** — arrays, objects, iterables, functions, typed arrays. Arbitraries you build _out of_ other arbitraries to describe structured values.
 - **Combiners** — `oneof`, `option`, `letrec`, `.filter`, `.map`, `.chain`, and friends. The functional glue: they take arbitraries as input and return new ones without generating anything themselves.
 - **Fake data** — UUIDs, emails, URLs, filenames, and other realistic-shape values for code that branches on format.
 
-A short decision guide: start from a primitive if the value is atomic, a composite if it has a shape you can describe, a combiner when you already have an arbitrary and need to refine it, and fake data only when your code cares about the *format* of a value rather than its raw contents. Anything that does not fit those four buckets lives on the [Others](/docs/core-blocks/arbitraries/others/) page.
+A short decision guide: start from a primitive if the value is atomic, a composite if it has a shape you can describe, a combiner when you already have an arbitrary and need to refine it, and fake data only when your code cares about the _format_ of a value rather than its raw contents. Anything that does not fit those four buckets lives on the [Others](/docs/core-blocks/arbitraries/others/) page.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/core-blocks/arbitraries/index.md
+++ b/website/docs/core-blocks/arbitraries/index.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 0
+slug: /core-blocks/arbitraries/
+description: Every arbitrary in fast-check is a generator paired with a shrinker. This page explains that contract and helps you pick the right family for your test.
+---
+
+# Arbitraries
+
+An arbitrary in fast-check is **not just a random value generator**. It is a generator paired with a **shrinker** — a rule that, when a test fails, walks the failing input back toward a simpler, easier-to-read one. Every arbitrary you compose inherits both halves of that contract, which is why a counterexample on a deeply nested object can still collapse to something like `[{ id: 0 }]` instead of a random wall of JSON.
+
+fast-check groups its built-in arbitraries into four families, each with its own rules:
+
+- **Primitives** — strings, numbers, booleans, dates, bigints. The only arbitraries with no upstream dependency; they anchor the shrink targets that every other family converges toward.
+- **Composites** — arrays, objects, iterables, functions, typed arrays. Arbitraries you build *out of* other arbitraries to describe structured values.
+- **Combiners** — `oneof`, `option`, `letrec`, `.filter`, `.map`, `.chain`, and friends. The functional glue: they take arbitraries as input and return new ones without generating anything themselves.
+- **Fake data** — UUIDs, emails, URLs, filenames, and other realistic-shape values for code that branches on format.
+
+A short decision guide: start from a primitive if the value is atomic, a composite if it has a shape you can describe, a combiner when you already have an arbitrary and need to refine it, and fake data only when your code cares about the *format* of a value rather than its raw contents. Anything that does not fit those four buckets lives on the [Others](/docs/core-blocks/arbitraries/others/) page.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/arbitraries/index.md
+++ b/website/docs/core-blocks/arbitraries/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 slug: /core-blocks/arbitraries/
 description: Every arbitrary in fast-check is a generator paired with a shrinker. This page explains that contract and helps you pick the right family for your test.
 ---

--- a/website/docs/core-blocks/arbitraries/index.md
+++ b/website/docs/core-blocks/arbitraries/index.md
@@ -6,16 +6,16 @@ description: Every arbitrary in fast-check is a generator paired with a shrinker
 
 # Arbitraries
 
-An arbitrary in fast-check is **not just a random value generator**. It is a generator paired with a **shrinker** — a rule that, when a test fails, walks the failing input back toward a simpler, easier-to-read one. Every arbitrary you compose inherits both halves of that contract, which is why a counterexample on a deeply nested object can still collapse to something like `[{ id: 0 }]` instead of a random wall of JSON.
+An arbitrary in fast-check is **not just a random value generator**. It is a generator paired with a **shrinker**. When a test fails, the shrinker walks the failing input back toward a simpler, easier-to-read one. Every arbitrary you compose inherits both halves of that contract, which is why a counterexample on a deeply nested object can still collapse to something like `[{ id: 0 }]` instead of a random JSON.
 
 fast-check groups its built-in arbitraries into four families, each with its own rules:
 
-- **Primitives** — strings, numbers, booleans, dates, bigints. The only arbitraries with no upstream dependency; they anchor the shrink targets that every other family converges toward.
-- **Composites** — arrays, objects, iterables, functions, typed arrays. Arbitraries you build _out of_ other arbitraries to describe structured values.
-- **Combiners** — `oneof`, `option`, `letrec`, `.filter`, `.map`, `.chain`, and friends. The functional glue: they take arbitraries as input and return new ones without generating anything themselves.
-- **Fake data** — UUIDs, emails, URLs, filenames, and other realistic-shape values for code that branches on format.
+- **Primitives** — strings, numbers, booleans, dates, bigints. The only arbitraries with no upstream dependency, they anchor the shrink targets that every other family converges toward.
+- **Composites** — arrays, objects, iterables, functions, typed arrays. Arbitraries you build out of other arbitraries to describe structured values.
+- **Combiners** — `oneof`, `option`, `letrec`, `.filter`, `.map`, `.chain` and friends. The functional glue: they take arbitraries as input and return new ones without generating anything themselves.
+- **Fake data** — UUIDs, emails, URLs, filenames and other realistic-shape values for code that branches on format.
 
-A short decision guide: start from a primitive if the value is atomic, a composite if it has a shape you can describe, a combiner when you already have an arbitrary and need to refine it, and fake data only when your code cares about the _format_ of a value rather than its raw contents. Anything that does not fit those four buckets lives on the [Others](/docs/core-blocks/arbitraries/others/) page.
+A short decision guide: start from a primitive if the value is atomic, a composite if it has a shape you can describe, a combiner when you already have an arbitrary and need to refine it and fake data only when your code cares about the format of a value rather than its raw contents. Anything that does not fit those four buckets lives on the [Others](/docs/core-blocks/arbitraries/others/) page.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/core-blocks/arbitraries/primitives/_category_.json
+++ b/website/docs/core-blocks/arbitraries/primitives/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 1, "label": "Primitives" }

--- a/website/docs/core-blocks/arbitraries/primitives/index.md
+++ b/website/docs/core-blocks/arbitraries/primitives/index.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 0
+slug: /core-blocks/arbitraries/primitives/
+description: The base arbitraries fast-check builds every other generator on — strings, numbers, booleans, dates and bigints, with their canonical shrink targets.
+---
+
+# Primitives
+
+Primitive arbitraries are the only arbitraries in fast-check that do not depend on another one. Everything else — composites, combiners, fake data — is eventually wired back to a primitive, which makes the rules on this page the foundation of how the whole library behaves.
+
+Two things are worth knowing before you open any child page:
+
+- **Constraints stay local.** Each primitive exposes its own constraints (ranges for numbers, allowed characters for strings, bounds for dates…). When a more complex arbitrary is built on top, it inherits whatever constraints you put here — so the narrower you make a primitive, the narrower every downstream value becomes.
+- **Shrinking converges to canonical "simple" values.** When a test fails, fast-check shrinks each primitive toward a well-known minimum: `0` for numbers, `''` for strings, `false` for booleans, the Unix epoch for dates, `0n` for bigints. Every counterexample you read in the terminal is the product of that convergence, so it pays to recognise these anchors on sight.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/arbitraries/primitives/index.md
+++ b/website/docs/core-blocks/arbitraries/primitives/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 slug: /core-blocks/arbitraries/primitives/
 description: The base arbitraries fast-check builds every other generator on — strings, numbers, booleans, dates and bigints, with their canonical shrink targets.
 ---

--- a/website/docs/core-blocks/index.md
+++ b/website/docs/core-blocks/index.md
@@ -8,9 +8,9 @@ description: The three reference building blocks of fast-check — arbitraries, 
 
 Every fast-check test, however elaborate, is built from the same three pieces:
 
-1. **Arbitraries** describe *what values to generate*. They pair a random generator with a shrinker so that failing inputs collapse back to readable counterexamples.
-2. **Properties** describe *what must hold* for those values. A property takes one or more arbitraries and a predicate, and asserts `∀ inputs, predicate(inputs)`.
-3. **Runners** describe *how to execute* the property: how many runs, with what seed, how to report failures, whether to throw or return details.
+1. **Arbitraries** describe _what values to generate_. They pair a random generator with a shrinker so that failing inputs collapse back to readable counterexamples.
+2. **Properties** describe _what must hold_ for those values. A property takes one or more arbitraries and a predicate, and asserts `∀ inputs, predicate(inputs)`.
+3. **Runners** describe _how to execute_ the property: how many runs, with what seed, how to report failures, whether to throw or return details.
 
 The pipeline always flows in that order — arbitraries feed properties, properties are handed to runners — and each section of this reference follows the same order. The children below are the reference pages for each block: start with [Properties](/docs/core-blocks/properties/) if you have never written one, jump to [Arbitraries](/docs/core-blocks/arbitraries/) when you need the right generator, and come back to [Runners](/docs/core-blocks/runners/) when you need to tune execution.
 

--- a/website/docs/core-blocks/index.md
+++ b/website/docs/core-blocks/index.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 0
+slug: /core-blocks/
+description: The three reference building blocks of fast-check — arbitraries, properties, and runners — and how they fit together into a single test.
+---
+
+# Core Blocks
+
+Every fast-check test, however elaborate, is built from the same three pieces:
+
+1. **Arbitraries** describe *what values to generate*. They pair a random generator with a shrinker so that failing inputs collapse back to readable counterexamples.
+2. **Properties** describe *what must hold* for those values. A property takes one or more arbitraries and a predicate, and asserts `∀ inputs, predicate(inputs)`.
+3. **Runners** describe *how to execute* the property: how many runs, with what seed, how to report failures, whether to throw or return details.
+
+The pipeline always flows in that order — arbitraries feed properties, properties are handed to runners — and each section of this reference follows the same order. The children below are the reference pages for each block: start with [Properties](/docs/core-blocks/properties/) if you have never written one, jump to [Arbitraries](/docs/core-blocks/arbitraries/) when you need the right generator, and come back to [Runners](/docs/core-blocks/runners/) when you need to tune execution.
+
+:::tip Reference, not tutorial
+The Core Blocks pages are the exhaustive reference. If you are looking for a guided, hands-on walkthrough instead, start with the [Quick Start tutorial](/docs/tutorials/quick-start/basic-setup/).
+:::
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/core-blocks/index.md
+++ b/website/docs/core-blocks/index.md
@@ -1,18 +1,18 @@
 ---
 sidebar_position: 2
 slug: /core-blocks/
-description: The three reference building blocks of fast-check — arbitraries, properties, and runners — and how they fit together into a single test.
+description: The three reference building blocks of fast-check — arbitraries, properties and runners — and how they fit together into a single test.
 ---
 
 # Core Blocks
 
-Every fast-check test, however elaborate, is built from the same three pieces:
+Every fast-check test is built from the same three pieces:
 
-1. **Arbitraries** describe _what values to generate_. They pair a random generator with a shrinker so that failing inputs collapse back to readable counterexamples.
-2. **Properties** describe _what must hold_ for those values. A property takes one or more arbitraries and a predicate, and asserts `∀ inputs, predicate(inputs)`.
-3. **Runners** describe _how to execute_ the property: how many runs, with what seed, how to report failures, whether to throw or return details.
+1. **Arbitraries** describe what values to generate. They pair a random generator with a shrinker so that failing inputs collapse back to readable counterexamples.
+2. **Properties** describe what must hold for those values. A property takes one or more arbitraries and a predicate. It asserts that for any input the predicate stays valid.
+3. **Runners** describe how to execute the property: how many runs, with what seed, how to report failures, whether to throw or return details.
 
-The pipeline always flows in that order — arbitraries feed properties, properties are handed to runners — and each section of this reference follows the same order. The children below are the reference pages for each block: start with [Properties](/docs/core-blocks/properties/) if you have never written one, jump to [Arbitraries](/docs/core-blocks/arbitraries/) when you need the right generator, and come back to [Runners](/docs/core-blocks/runners/) when you need to tune execution.
+The children below are the reference pages for each block: start with [Properties](/docs/core-blocks/properties/) if you have never written one, jump to [Arbitraries](/docs/core-blocks/arbitraries/) when you need the right generator and come back to [Runners](/docs/core-blocks/runners/) when you need to tune execution.
 
 :::tip Reference, not tutorial
 The Core Blocks pages are the exhaustive reference. If you are looking for a guided, hands-on walkthrough instead, start with the [Quick Start tutorial](/docs/tutorials/quick-start/basic-setup/).

--- a/website/docs/core-blocks/index.md
+++ b/website/docs/core-blocks/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 2
 slug: /core-blocks/
 description: The three reference building blocks of fast-check — arbitraries, properties, and runners — and how they fit together into a single test.
 ---

--- a/website/docs/introduction/_category_.json
+++ b/website/docs/introduction/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 1, "label": "Introduction" }

--- a/website/docs/introduction/index.md
+++ b/website/docs/introduction/index.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 0
+slug: /introduction/
+description: Start here — what property-based testing is, why fast-check exists, who already trusts it, and how to install it in your project.
+---
+
+# Introduction
+
+fast-check is the property-based testing library for JavaScript and TypeScript. Instead of asking you to hand-pick the inputs your tests run on, it generates them for you, runs your assertion over hundreds of cases, and — when it finds a failure — shrinks that failure down to the smallest input that still reproduces it.
+
+This section is the **why** of fast-check, not the how. Four pages, each answering a question a newcomer usually asks in order:
+
+- **What is property-based testing?** The core idea, contrasted with the example-based tests you already write.
+- **Why property-based?** The concrete bugs this approach surfaces that example-based tests miss.
+- **Track record.** Real projects and bugs that property-based testing — and fast-check specifically — have caught.
+- **Getting started.** Installing fast-check and running your first property in your existing test runner.
+
+:::tip Prefer learning by doing?
+If you would rather skip the theory and open an editor, head straight to the [Quick Start tutorial](/docs/tutorials/quick-start/basic-setup/) — it walks you through a runnable project step by step. Come back here whenever you want the background.
+:::
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/introduction/index.md
+++ b/website/docs/introduction/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 slug: /introduction/
 description: Start here — what property-based testing is, why fast-check exists, who already trusts it, and how to install it in your project.
 ---

--- a/website/docs/introduction/index.md
+++ b/website/docs/introduction/index.md
@@ -1,22 +1,22 @@
 ---
 sidebar_position: 1
 slug: /introduction/
-description: Start here — what property-based testing is, why fast-check exists, who already trusts it, and how to install it in your project.
+description: Start here — what property-based testing is, why fast-check exists, who already trusts it and how to install it in your project.
 ---
 
 # Introduction
 
-fast-check is the property-based testing library for JavaScript and TypeScript. Instead of asking you to hand-pick the inputs your tests run on, it generates them for you, runs your assertion over hundreds of cases, and — when it finds a failure — shrinks that failure down to the smallest input that still reproduces it.
+fast-check is the property-based testing library for JavaScript and TypeScript. Instead of asking you to hand-pick the inputs your tests run on, it generates them for you, runs your assertion over hundreds of cases and shrinks failures down to the smallest inputs that still reproduces them.
 
-This section is the **why** of fast-check, not the how. Four pages, each answering a question a newcomer usually asks in order:
+This section is the why of fast-check, not the how. Four pages, each answering a question a newcomer usually asks in order:
 
 - **What is property-based testing?** The core idea, contrasted with the example-based tests you already write.
 - **Why property-based?** The concrete bugs this approach surfaces that example-based tests miss.
-- **Track record.** Real projects and bugs that property-based testing — and fast-check specifically — have caught.
+- **Track record.** Real projects and bugs that property-based testing and fast-check specifically have caught.
 - **Getting started.** Installing fast-check and running your first property in your existing test runner.
 
 :::tip Prefer learning by doing?
-If you would rather skip the theory and open an editor, head straight to the [Quick Start tutorial](/docs/tutorials/quick-start/basic-setup/) — it walks you through a runnable project step by step. Come back here whenever you want the background.
+If you would rather skip the theory and open an editor, head straight to the [Quick Start tutorial](/docs/tutorials/quick-start/basic-setup/). It walks you through a runnable project step by step. Come back here whenever you want the background.
 :::
 
 ```mdx-code-block

--- a/website/docs/migration/_category_.json
+++ b/website/docs/migration/_category_.json
@@ -1,1 +1,1 @@
-{ "position": 8, "label": "Migration Guides" }
+{ "position": 8, "label": "Migration Guides", "link": { "type": "doc", "id": "migration/from-3.x-to-4.x" } }

--- a/website/docs/tutorials/quick-start/_category_.json
+++ b/website/docs/tutorials/quick-start/_category_.json
@@ -1,1 +1,0 @@
-{ "position": 1, "label": "Quick Start" }

--- a/website/docs/tutorials/quick-start/index.md
+++ b/website/docs/tutorials/quick-start/index.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 0
+slug: /tutorials/quick-start/
+description: A three-step linear walkthrough — set up a project, write your first property, and learn how to read the report fast-check prints on failure.
+---
+
+# Quick Start
+
+The Quick Start is the fastest path from "I have heard of fast-check" to "I have a property-based test running on my machine". Unlike the other tutorials, **its three pages are meant to be read in order** — each step builds on the repository state left by the previous one, and skipping ahead will leave you without the files the next page expects.
+
+By the end you will have:
+
+- a runnable project with fast-check wired into a real test runner,
+- one working property-based test you wrote yourself,
+- the vocabulary to interpret the counterexamples and seeds fast-check prints when something fails.
+
+Expect roughly fifteen minutes start to finish if you already have Node.js installed. No prior exposure to property-based testing is required; if anything in the tutorial feels hand-wavy, the [Introduction](/docs/introduction/) section covers the concepts in depth.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/website/docs/tutorials/quick-start/index.md
+++ b/website/docs/tutorials/quick-start/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 slug: /tutorials/quick-start/
-description: A three-step linear walkthrough — set up a project, write your first property, and learn how to read the report fast-check prints on failure.
+description: A three-step linear walkthrough — set up a project, write your first property and learn how to read the report fast-check prints on failure.
 ---
 
 # Quick Start
 
-The Quick Start is the fastest path from "I have heard of fast-check" to "I have a property-based test running on my machine". Unlike the other tutorials, **its three pages are meant to be read in order** — each step builds on the repository state left by the previous one, and skipping ahead will leave you without the files the next page expects.
+The Quick Start is the fastest path from "I have heard of fast-check" to "I have a property-based test running on my machine". Unlike the other tutorials, its three pages are meant to be read in order.
 
 By the end you will have:
 
@@ -14,7 +14,7 @@ By the end you will have:
 - one working property-based test you wrote yourself,
 - the vocabulary to interpret the counterexamples and seeds fast-check prints when something fails.
 
-Expect roughly fifteen minutes start to finish if you already have Node.js installed. No prior exposure to property-based testing is required; if anything in the tutorial feels hand-wavy, the [Introduction](/docs/introduction/) section covers the concepts in depth.
+After this Quick Start, if you want to cover the concepts in depth you can refer to our [Introduction](/docs/introduction/) section.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/website/docs/tutorials/quick-start/index.md
+++ b/website/docs/tutorials/quick-start/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 slug: /tutorials/quick-start/
 description: A three-step linear walkthrough — set up a project, write your first property, and learn how to read the report fast-check prints on failure.
 ---


### PR DESCRIPTION
## Description

Adds a landing/index page to every documentation category that previously had none, using the same `index.md` + `<DocCardList />` pattern that the `tutorials/` section already uses. Each new page carries a specific cross-cutting insight (arbitraries pipeline, canonical shrink targets, two-level configuration model, …) instead of rephrasing its children — `<DocCardList />` handles the child listing automatically.

The `migration/` category has only one guide today; rather than adding a boilerplate landing page, its `_category_.json` is re-pointed directly at `from-3.x-to-4.x` so clicking the sidebar category opens the guide.

**New files (10):**
- `website/docs/introduction/index.md`
- `website/docs/core-blocks/index.md`
- `website/docs/core-blocks/arbitraries/index.md`
- `website/docs/core-blocks/arbitraries/primitives/index.md`
- `website/docs/core-blocks/arbitraries/composites/index.md`
- `website/docs/core-blocks/arbitraries/combiners/index.md`
- `website/docs/core-blocks/arbitraries/fake-data/index.md`
- `website/docs/configuration/index.md`
- `website/docs/advanced/index.md`
- `website/docs/tutorials/quick-start/index.md`

**Modified (1):**
- `website/docs/migration/_category_.json` — added `link: { type: "doc", id: "migration/from-3.x-to-4.x" }`

Verified locally with `pnpm exec docusaurus build`: every new URL renders with breadcrumb, H1, prose, and the child `DocCardList` cards. No broken links or slug conflicts.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

<!-- Documentation-only PR: the `website` package is in the changeset `ignore` list (see `.changeset/config.json`), so no changeset is required. No runtime code is touched, so no new tests are applicable. -->
