### PR TITLE
✅ Stabilize flaky timeout tests on Windows

### DIFF
--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -519,7 +519,7 @@ describe.each<DescribeOptions>([
       // Arrange
       const specDirectory = await writeToFile(runnerName, options, () => {
         if (typeof jest !== 'undefined') {
-          jest.setTimeout(2000);
+          jest.setTimeout(3000);
         }
         runner.prop([fc.nat()])(
           'property favor local Jest timeout over Jest setTimeout',
@@ -535,7 +535,7 @@ describe.each<DescribeOptions>([
 
       // Assert
       expectFail(out);
-      expectTimeout(out, 1000); // neither 2000 (setTimeout), nor 5000 (default)
+      expectTimeout(out, 1000); // neither 3000 (setTimeout), nor 5000 (default)
       expect(out).toMatch(/[×✕] property favor local Jest timeout over Jest setTimeout/);
     });
 
@@ -551,11 +551,11 @@ describe.each<DescribeOptions>([
       });
 
       // Act
-      const out = await runSpec(specDirectory, { testTimeoutCLI: 2000 });
+      const out = await runSpec(specDirectory, { testTimeoutCLI: 3000 });
 
       // Assert
       expectFail(out);
-      expectTimeout(out, 1000); // neither 2000 (cli), nor 5000 (default)
+      expectTimeout(out, 1000); // neither 3000 (cli), nor 5000 (default)
       expect(out).toMatch(/[×✕] property favor Jest setTimeout over Jest CLI timeout/);
     });
   });
@@ -667,7 +667,7 @@ function expectTimeout(out: string, timeout: number): void {
   expect(out).toMatch(timeRegex);
   const time = timeRegex.exec(out)!;
   expect(Number(time[1])).toBeGreaterThanOrEqual(timeout);
-  expect(Number(time[1])).toBeLessThan(timeout * 1.5);
+  expect(Number(time[1])).toBeLessThan(timeout * 2);
 }
 
 function expectAlignedSeeds(out: string, opts: { noAlignWithJest?: boolean } = {}): void {


### PR DESCRIPTION
Widen timeout tolerance from 1.5x to 2x in expectTimeout to accommodate
Windows CI overhead (observed up to 1695ms for 1000ms timeouts). Increase
the "other" timeout in comparison tests from 2000ms to 3000ms to maintain
a clear gap between timeout sources under the wider tolerance.

https://claude.ai/code/session_01Kyd5CoEo1Hc2gYXYRTceN7