### PR TITLE
🐛 Fix flaky worker test by improving Jest child process handling

### DIFF
--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -649,7 +649,7 @@ async function runSpec(
     );
     return specOutput;
   } catch (err) {
-    return (err as any).stderr;
+    return ((err as any).stdout || '') + ((err as any).stderr || '');
   }
 }
 

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -635,7 +635,7 @@ async function runSpec(
   opts: { jestSeed?: number; testTimeoutCLI?: number } = {},
 ): Promise<string> {
   try {
-    const { stderr: specOutput } = await execFile(
+    const { stdout, stderr } = await execFile(
       'node',
       [
         '../../node_modules/jest/bin/jest.js',
@@ -647,7 +647,7 @@ async function runSpec(
       ],
       { cwd: specDirectory },
     );
-    return specOutput;
+    return stdout + stderr;
   } catch (err) {
     return ((err as any).stdout || '') + ((err as any).stderr || '');
   }


### PR DESCRIPTION
## Description

Fix the flaky "should fail on property blocking the main thread" test in `@fast-check/jest` by improving how the test captures Jest child process output.

The Jest child process could produce output on either stdout or stderr depending on timing. The test was only capturing stderr, which sometimes missed the expected markers. Additionally, tightened timeout thresholds and reduced setTimeout values to make assertions more reliable.

Changes:
- Capture both stdout and stderr from the Jest child process (output can end up in either stream)
- Collect both streams on failure too (they may be undefined when the process errors)
- Reduce `jest.setTimeout` / `testTimeoutCLI` from 3000ms to 2000ms for consistency
- Tighten `expectTimeout` upper bound from `timeout * 2` to `timeout * 1.5`

Related: #6864 (extracted AI env var stripping), #6865 (vitest equivalent)

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)