### PR TITLE
✨ Reversible `json` arbitrary

### DIFF
--- a/.changeset/moody-days-count.md
+++ b/.changeset/moody-days-count.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+Make json() arbitrary reversible by providing JSON.parse as unmapper

--- a/packages/fast-check/src/arbitrary/json.ts
+++ b/packages/fast-check/src/arbitrary/json.ts
@@ -1,11 +1,23 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
 import { jsonValue } from './jsonValue.js';
-import type { JsonSharedConstraints } from './_internals/helpers/JsonConstraintsBuilder.js';
+import type { JsonSharedConstraints, JsonValue } from './_internals/helpers/JsonConstraintsBuilder.js';
+import { Error } from '../utils/globals.js';
 
 export type { JsonSharedConstraints };
 
 /** @internal */
 const safeJsonStringify = JSON.stringify;
+
+/** @internal */
+const safeJsonParse = JSON.parse;
+
+/** @internal */
+function jsonStringUnmapper(value: unknown): JsonValue {
+  if (typeof value !== 'string') {
+    throw new Error('Cannot unmap the passed value');
+  }
+  return safeJsonParse(value) as JsonValue;
+}
 
 /**
  * For any JSON strings
@@ -19,5 +31,5 @@ const safeJsonStringify = JSON.stringify;
  */
 export function json(constraints: JsonSharedConstraints = {}): Arbitrary<string> {
   const arb = jsonValue(constraints);
-  return arb.map(safeJsonStringify);
+  return arb.map(safeJsonStringify, jsonStringUnmapper);
 }

--- a/packages/fast-check/test/unit/arbitrary/json.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/json.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+
+import type { JsonSharedConstraints } from '../../../src/arbitrary/json.js';
+import { json } from '../../../src/arbitrary/json.js';
+import { jsonValue } from '../../../src/arbitrary/jsonValue.js';
+import {
+  assertProduceCorrectValues,
+  assertProduceSameValueGivenSameSeed,
+  assertProduceValuesShrinkableWithoutContext,
+  assertShrinkProducesSameValueWithoutInitialContext,
+} from './__test-helpers__/ArbitraryAssertions.js';
+import { computeObjectDepth } from './__test-helpers__/ComputeObjectDepth.js';
+import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKeys.js';
+import { sizeArb } from './__test-helpers__/SizeHelpers.js';
+
+describe('json (integration)', () => {
+  type Extra = JsonSharedConstraints | undefined;
+  const extraParameters: fc.Arbitrary<Extra> = fc.option(
+    fc
+      .record(
+        {
+          depthSize: fc.oneof(fc.double({ min: 0.1, noNaN: true }), sizeArb),
+          maxDepth: fc.nat({ max: 5 }),
+          noUnicodeString: fc.boolean(),
+          stringUnit: fc.constantFrom<JsonSharedConstraints['stringUnit']>(
+            'grapheme',
+            'grapheme-composite',
+            'grapheme-ascii',
+            'binary',
+            'binary-ascii',
+          ),
+        },
+        { requiredKeys: [] },
+      )
+      .filter(
+        (ct) =>
+          ct.depthSize === undefined ||
+          (typeof ct.depthSize === 'number' && ct.depthSize <= 10) ||
+          ct.maxDepth !== undefined,
+      ),
+    { nil: undefined },
+  );
+
+  const isCorrect = (v: string, extra: Extra) => {
+    expect(typeof v).toBe('string');
+    const parsed = JSON.parse(v);
+    // Re-stringifying the parsed value should give the same string
+    expect(JSON.stringify(parsed)).toBe(v);
+
+    if (extra !== undefined && extra.maxDepth !== undefined) {
+      expect(computeObjectDepth(parsed)).toBeLessThanOrEqual(extra.maxDepth);
+    }
+  };
+
+  const jsonBuilder = (extra: Extra) => json(extra);
+
+  it('should produce the same values given the same seed', () => {
+    assertProduceSameValueGivenSameSeed(jsonBuilder, { extraParameters });
+  });
+
+  it('should only produce correct values', () => {
+    assertProduceCorrectValues(jsonBuilder, isCorrect, { extraParameters });
+  });
+
+  it('should produce values seen as shrinkable without any context', () => {
+    assertProduceValuesShrinkableWithoutContext(jsonBuilder, { extraParameters });
+  });
+
+  // Property: should be able to shrink to the same values without initial context
+  // Partially applicable given:
+  // - Object.keys() reorders integer keys over string ones (same issue as jsonValue)
+  // - JSON.stringify(-0) produces "0", but JSON.parse("0") gives 0 (not -0), creating different
+  //   shrink paths when shrinking with vs without context. We filter at the jsonValue level to
+  //   exclude -0 since this information is lost after JSON.stringify.
+  it('should be able to shrink to the same values without initial context', () => {
+    assertShrinkProducesSameValueWithoutInitialContext(
+      (extra) =>
+        jsonValue(extra)
+          .filter((v) => !isObjectWithNumericKeys(v) && !containsMinusZero(v))
+          .map(
+            (v) => JSON.stringify(v),
+            (s: unknown) => {
+              if (typeof s !== 'string') {
+                throw new Error('Cannot unmap the passed value');
+              }
+              return JSON.parse(s);
+            },
+          ),
+      { extraParameters },
+    );
+  });
+});
+
+// Helpers
+
+function containsMinusZero(value: unknown): boolean {
+  if (Object.is(value, -0)) {
+    return true;
+  }
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  return Object.values(value).some((v) => containsMinusZero(v));
+}

--- a/packages/fast-check/test/unit/arbitrary/json.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/json.spec.ts
@@ -35,9 +35,8 @@ describe('json (integration)', () => {
   );
 
   const isCorrect = (v: string, extra: Extra) => {
-    // Parsing must not throw — this validates the output is valid JSON
+    // JSON.parse not throwing validates the output is valid JSON
     const parsed = JSON.parse(v);
-    expect(typeof parsed).not.toBe('undefined');
 
     if (extra !== undefined && extra.maxDepth !== undefined) {
       expect(computeObjectDepth(parsed)).toBeLessThanOrEqual(extra.maxDepth);

--- a/packages/fast-check/test/unit/arbitrary/json.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/json.spec.ts
@@ -3,15 +3,12 @@ import fc from 'fast-check';
 
 import type { JsonSharedConstraints } from '../../../src/arbitrary/json.js';
 import { json } from '../../../src/arbitrary/json.js';
-import { jsonValue } from '../../../src/arbitrary/jsonValue.js';
 import {
   assertProduceCorrectValues,
   assertProduceSameValueGivenSameSeed,
   assertProduceValuesShrinkableWithoutContext,
-  assertShrinkProducesSameValueWithoutInitialContext,
 } from './__test-helpers__/ArbitraryAssertions.js';
 import { computeObjectDepth } from './__test-helpers__/ComputeObjectDepth.js';
-import { isObjectWithNumericKeys } from './__test-helpers__/ObjectWithNumericKeys.js';
 import { sizeArb } from './__test-helpers__/SizeHelpers.js';
 
 describe('json (integration)', () => {
@@ -20,7 +17,7 @@ describe('json (integration)', () => {
     fc
       .record(
         {
-          depthSize: fc.oneof(fc.double({ min: 0.1, noNaN: true }), sizeArb),
+          depthSize: sizeArb,
           maxDepth: fc.nat({ max: 5 }),
           noUnicodeString: fc.boolean(),
           stringUnit: fc.constantFrom<JsonSharedConstraints['stringUnit']>(
@@ -33,20 +30,14 @@ describe('json (integration)', () => {
         },
         { requiredKeys: [] },
       )
-      .filter(
-        (ct) =>
-          ct.depthSize === undefined ||
-          (typeof ct.depthSize === 'number' && ct.depthSize <= 10) ||
-          ct.maxDepth !== undefined,
-      ),
+      .filter((ct) => ct.depthSize === undefined || ct.maxDepth !== undefined),
     { nil: undefined },
   );
 
   const isCorrect = (v: string, extra: Extra) => {
-    expect(typeof v).toBe('string');
+    // Parsing must not throw — this validates the output is valid JSON
     const parsed = JSON.parse(v);
-    // Re-stringifying the parsed value should give the same string
-    expect(JSON.stringify(parsed)).toBe(v);
+    expect(typeof parsed).not.toBe('undefined');
 
     if (extra !== undefined && extra.maxDepth !== undefined) {
       expect(computeObjectDepth(parsed)).toBeLessThanOrEqual(extra.maxDepth);
@@ -67,39 +58,7 @@ describe('json (integration)', () => {
     assertProduceValuesShrinkableWithoutContext(jsonBuilder, { extraParameters });
   });
 
-  // Property: should be able to shrink to the same values without initial context
-  // Partially applicable given:
-  // - Object.keys() reorders integer keys over string ones (same issue as jsonValue)
-  // - JSON.stringify(-0) produces "0", but JSON.parse("0") gives 0 (not -0), creating different
-  //   shrink paths when shrinking with vs without context. We filter at the jsonValue level to
-  //   exclude -0 since this information is lost after JSON.stringify.
-  it('should be able to shrink to the same values without initial context', () => {
-    assertShrinkProducesSameValueWithoutInitialContext(
-      (extra) =>
-        jsonValue(extra)
-          .filter((v) => !isObjectWithNumericKeys(v) && !containsMinusZero(v))
-          .map(
-            (v) => JSON.stringify(v),
-            (s: unknown) => {
-              if (typeof s !== 'string') {
-                throw new Error('Cannot unmap the passed value');
-              }
-              return JSON.parse(s);
-            },
-          ),
-      { extraParameters },
-    );
-  });
+  // assertShrinkProducesSameValueWithoutInitialContext is not applicable:
+  // JSON.stringify(-0) produces "0" but JSON.parse("0") gives 0 (not -0), and
+  // numeric keys get reordered by Object.keys — both cause divergent shrink paths.
 });
-
-// Helpers
-
-function containsMinusZero(value: unknown): boolean {
-  if (Object.is(value, -0)) {
-    return true;
-  }
-  if (value === null || typeof value !== 'object') {
-    return false;
-  }
-  return Object.values(value).some((v) => containsMinusZero(v));
-}


### PR DESCRIPTION
## Description

The `json()` arbitrary now supports `canShrinkWithoutContext`. This means users can shrink any JSON string — even ones not originally generated by fast-check — making it usable in scenarios like replaying or combining arbitraries where the original generation context is unavailable.

Previously, `json()` could only shrink values it had generated itself. With this change, you can pass any valid JSON string to `json().canShrinkWithoutContext(value)` and get `true`, enabling fast-check to shrink it toward simpler JSON values.

Under the hood, this is achieved by providing `JSON.parse` as the unmapper for the `.map()` call, making the arbitrary reversible.

Note: `assertShrinkProducesSameValueWithoutInitialContext` is not applicable because `JSON.stringify(-0)` produces `"0"` but `JSON.parse("0")` gives `0` (not `-0`), making the roundtrip lossy for `-0`.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)