### PR TITLE
✨ Support negated unicode properties in `stringMatching`

### DIFF
--- a/.changeset/negated-unicode-property.md
+++ b/.changeset/negated-unicode-property.md
@@ -1,5 +1,0 @@
----
-"fast-check": minor
----
-
-✨ Support for `\P{UnicodeProperty}` in `stringMatching`

--- a/.changeset/negated-unicode-property.md
+++ b/.changeset/negated-unicode-property.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Support for `\P{UnicodeProperty}` in `stringMatching`

--- a/.changeset/swift-rockets-collect.md
+++ b/.changeset/swift-rockets-collect.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Support negated unicode properties in stringMatching

--- a/packages/fast-check/src/arbitrary/_internals/helpers/UnicodePropertyArbitraryHelper.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/UnicodePropertyArbitraryHelper.ts
@@ -36,8 +36,9 @@ export function appendRangesForRegex(regex: RegExp, from: number, to: number, ra
 }
 
 /** @internal */
-function extractRangesForProperty(propertySpec: string): GraphemeRange[] {
-  const regex = new RegExp(`^\\p{${propertySpec}}$`, 'u');
+function extractRangesForProperty(propertySpec: string, negative: boolean): GraphemeRange[] {
+  const escape = negative ? 'P' : 'p';
+  const regex = new RegExp(`^\\${escape}{${propertySpec}}$`, 'u');
   const ranges: GraphemeRange[] = [];
   appendRangesForRegex(regex, 0, 0xd7ff, ranges);
   appendRangesForRegex(regex, 0xe000, 0x10ffff, ranges);
@@ -48,13 +49,14 @@ function extractRangesForProperty(propertySpec: string): GraphemeRange[] {
 const cache = new Map<string, GraphemeRange[]>();
 
 /** @internal */
-function extractRangesForPropertyOrFromCache(propertySpec: string): GraphemeRange[] {
-  const cachedRanges = cache.get(propertySpec);
+function extractRangesForPropertyOrFromCache(propertySpec: string, negative: boolean): GraphemeRange[] {
+  const cacheKey = `${negative ? 'P' : 'p'}:${propertySpec}`;
+  const cachedRanges = cache.get(cacheKey);
   if (cachedRanges !== undefined) {
     return cachedRanges;
   }
-  const ranges = extractRangesForProperty(propertySpec);
-  cache.set(propertySpec, ranges);
+  const ranges = extractRangesForProperty(propertySpec, negative);
+  cache.set(cacheKey, ranges);
   return ranges;
 }
 
@@ -64,10 +66,7 @@ function extractRangesForPropertyOrFromCache(propertySpec: string): GraphemeRang
  */
 export function unicodePropertyArbitrary(astNode: ResolvedUnicodeProperty): Arbitrary<string> {
   const spec = getPropertySpec(astNode);
-  const ranges = extractRangesForPropertyOrFromCache(spec);
-  if (astNode.negative) {
-    throw new Error(`Negated UnicodeProperty not supported yet in stringMatching!`);
-  }
+  const ranges = extractRangesForPropertyOrFromCache(spec, astNode.negative);
   const rangeEntries = safeMap(ranges, (range) => convertGraphemeRangeToMapToConstantEntry(range));
   return mapToConstant(...rangeEntries);
 }

--- a/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
@@ -71,6 +71,8 @@ function hardcodedRegex(): fc.Arbitrary<Extra> {
     { regex: /^https?:\/\/twitter.com\/[A-Za-z0-9_]+\/status\/[0-9]+$/ },
     // Emojis
     { regex: /^\p{Emoji}+$/u },
+    // Non-emojis
+    { regex: /^\P{Emoji}+$/u },
   );
 }
 


### PR DESCRIPTION
## Description

Add support for negated unicode properties (e.g., `\P{Emoji}`) in the `stringMatching` arbitrary, complementing the existing support for positive unicode properties (e.g., `\p{Emoji}`) added in #6870.

Changes:
- Modified `extractRangesForProperty` to accept a `negative` parameter and generate the appropriate regex pattern (`\P` for negated, `\p` for positive)
- Updated `extractRangesForPropertyOrFromCache` to include the negation flag in the cache key, ensuring negated and positive properties are cached separately
- Removed the error that was thrown when encountering negated unicode properties in `unicodePropertyArbitrary`
- Added test coverage for negated unicode properties

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)