### PR TITLE
👷 Lowercase discussion_category_name to "announcements"

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -638,6 +638,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_fc.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -713,6 +715,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_ava.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -788,6 +792,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_jest.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -863,6 +869,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_packaged.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -938,6 +946,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_poisoning.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1013,6 +1023,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_vitest.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1088,6 +1100,8 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_worker.outputs.tag}}
+          draft: false
+          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -638,8 +638,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_fc.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -715,8 +713,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_ava.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -792,8 +788,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_jest.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -869,8 +863,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_packaged.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -946,8 +938,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_poisoning.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1023,8 +1013,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_vitest.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1100,8 +1088,6 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{needs.check_publish_worker.outputs.tag}}
-          draft: false
-          discussion_category_name: Announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -639,7 +639,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_fc.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -716,7 +716,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_ava.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -793,7 +793,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_jest.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -870,7 +870,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_packaged.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -947,7 +947,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_poisoning.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1024,7 +1024,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_vitest.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false
@@ -1101,7 +1101,7 @@ jobs:
         with:
           tag_name: ${{needs.check_publish_worker.outputs.tag}}
           draft: false
-          discussion_category_name: Announcements
+          discussion_category_name: announcements
           append_body: true
           fail_on_unmatched_files: true
           overwrite_files: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,15 +51,6 @@ jobs:
             core.setOutput('tag', tag);
             core.setOutput('release_name', releaseName);
             core.setOutput('changelog', changelog);
-      - name: Create GitHub Release
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          name: ${{ steps.changelog.outputs.release_name }}
-          body: ${{ steps.changelog.outputs.changelog }}
-          draft: true
-          make_latest: ${{ github.event.inputs.package == 'fast-check' && 'true' || 'false' }}
       - name: Push tag
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
@@ -67,3 +58,13 @@ jobs:
           git push origin "refs/tags/$TAG"
         env:
           TAG: ${{ steps.changelog.outputs.tag }}
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.release_name }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          discussion_category_name: Announcements
+          make_latest: ${{ github.event.inputs.package == 'fast-check' && 'true' || 'false' }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,13 +51,6 @@ jobs:
             core.setOutput('tag', tag);
             core.setOutput('release_name', releaseName);
             core.setOutput('changelog', changelog);
-      - name: Push tag
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: |
-          git tag "$TAG"
-          git push origin "refs/tags/$TAG"
-        env:
-          TAG: ${{ steps.changelog.outputs.tag }}
       - name: Create GitHub Release
         if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
@@ -65,6 +58,12 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           name: ${{ steps.changelog.outputs.release_name }}
           body: ${{ steps.changelog.outputs.changelog }}
-          draft: false
-          discussion_category_name: Announcements
+          draft: true
           make_latest: ${{ github.event.inputs.package == 'fast-check' && 'true' || 'false' }}
+      - name: Push tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
+        env:
+          TAG: ${{ steps.changelog.outputs.tag }}


### PR DESCRIPTION
## Description

Lowercase `discussion_category_name` from `Announcements` to `announcements` across all per-package release jobs in `build-status.yml`.

This fixes the `softprops/action-gh-release` error:
> HttpError: Discussion could not be created. Make sure you passed a valid category name.

The category name matching appears to be case-sensitive, and the actual GitHub Discussions category is lowercase.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)