### PR TITLE
👷 Scope permissions of clean-caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -3,13 +3,14 @@ name: Clean Caches
 on:
   workflow_dispatch:
 
-permissions:
-  actions: write
+permissions: {}
 
 jobs:
   clean_caches:
     name: 'Clean all caches'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Clean caches
         env:


### PR DESCRIPTION
## Description

Move the `actions: write` permission from the workflow top level into the single `clean_caches` job. This fixes the OpenSSF Scorecard Token-Permissions warning about an elevated top-level permission without changing behavior.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->