### PR TITLE
🔧 Add PR-authoring guidance for Claude

### DIFF
--- a/.claude/skills/pr-authoring/SKILL.md
+++ b/.claude/skills/pr-authoring/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: pr-authoring
+description: Use whenever creating, drafting, or updating a pull request (title or body) for the dubzzz/fast-check repository, including via the mcp__github__create_pull_request and mcp__github__update_pull_request tools.
+---
+
+# Authoring a pull request for fast-check
+
+## Title — gitmoji convention
+
+See `CONTRIBUTING.md` (§ "Naming your pull request") and
+`.github/copilot-instructions.md` for the full emoji mapping.
+
+- Main package: `emoji Description`
+- Other packages: `emoji(scope) Description`
+  - Scopes: `ava`, `jest`, `vitest`, `worker`, `poisoning`, `packaged`
+- The Description part must be ≤ 50 characters.
+
+Common emojis: ✨ feature · 🐛 fix · 📝 docs · ✅ tests · 🏷️ types ·
+⚡️ perf · ♻️ refactor · 🔧 config · 🎨 style · 🔥 remove ·
+⬆️ upgrade deps · ⬇️ downgrade deps · 🗑️ deprecation · 👷 CI.
+
+## Body — always use the template
+
+1. Copy `.github/PULL_REQUEST_TEMPLATE.md` **verbatim**. Keep every
+   section and every checklist item, in order. Do not delete, rename,
+   or reorder anything.
+2. **Never tick a checkbox.** Every `- [ ]` stays unchecked — the
+   reviewer (or the author during review) ticks them.
+3. Link the issue with `Fixes #<n>` when one exists.
+
+## Description section — required order
+
+1. **End-user point of view first.** What does this PR bring to users?
+   New capability, fixed behavior, changed default, …? Call out any
+   implied changes: breaking changes, migration steps, perf
+   characteristics, deprecations.
+2. **Then justify.** Why this change, why this design, main trade-offs
+   considered — enough context for a reviewer to evaluate the approach.
+
+## Enrich the description from the checklist
+
+Don't tick the boxes, but use them as prompts to preempt reviewer
+questions inside the description prose:
+
+- **Impact level** — minor / patch / major (and mention if `pnpm run bump`
+  or the changeset bot instructions were followed).
+- **Single-concern scope** — state that the PR is focused, or explain
+  why bundled changes belong together.
+- **Tests** — which tests were added/updated, what they cover, and
+  why they would have failed without this PR. If no tests, say why.
+- **Gitmoji / scope** — the title itself is evidence; no need to restate.
+- **Understanding of every line** — nothing to write, but keep it true.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude guidance for fast-check
+
+## Pull requests
+
+When opening or updating a pull request in this repo, follow the
+`pr-authoring` skill at `.claude/skills/pr-authoring/SKILL.md`.
+It covers the PR template, the gitmoji title format, the required
+description structure, and the rule that checkboxes stay unchecked
+(reviewers tick them, not the author).


### PR DESCRIPTION
## Description

Add PR-authoring guidance so that Claude follows the repository's gitmoji naming convention and PR template when creating or updating pull requests. This introduces a new skill file (`.claude/skills/pr-authoring/SKILL.md`) with detailed instructions on title formatting, body structure, and checklist handling, along with a root `CLAUDE.md` that points to it.

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)