### PR TITLE
🔧 Use tilde ranges for security dependency overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
   },
   "pnpm": {
     "overrides": {
-      "tmp@<0.2.4": "0.2.4",
-      "serialize-javascript@<7.0.5": "7.0.5",
-      "follow-redirects@<1.16.0": "1.16.0",
-      "lodash-es@<4.18.0": "4.18.0",
-      "dompurify@<3.4.0": "3.4.0"
+      "tmp@<0.2.4": "~0.2.4",
+      "serialize-javascript@<7.0.5": "~7.0.5",
+      "follow-redirects@<1.16.0": "~1.16.0",
+      "lodash-es@<4.18.0": "~4.18.0",
+      "dompurify@<3.4.0": "~3.4.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  tmp@<0.2.4: 0.2.4
-  serialize-javascript@<7.0.5: 7.0.5
-  follow-redirects@<1.16.0: 1.16.0
-  lodash-es@<4.18.0: 4.18.0
-  dompurify@<3.4.0: 3.4.0
+  tmp@<0.2.4: ~0.2.4
+  serialize-javascript@<7.0.5: ~7.0.5
+  follow-redirects@<1.16.0: ~1.16.0
+  lodash-es@<4.18.0: ~4.18.0
+  dompurify@<3.4.0: ~3.4.0
 
 importers:
 


### PR DESCRIPTION
## Description

Updates pnpm dependency overrides to use tilde (`~`) version ranges instead of exact versions for security-related packages. This allows patch-level updates while maintaining the minimum security threshold for:

- `tmp@~0.2.4`
- `serialize-javascript@~7.0.5`
- `follow-redirects@~1.16.0`
- `lodash-es@~4.18.0`
- `dompurify@~3.4.0`

This change enables automatic patch updates for these critical security dependencies while preventing unintended minor or major version bumps that could introduce breaking changes.

## Checklist

- [x] I have a full understanding of every line in this PR
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

https://claude.ai/code/session_01EoNkHTqq5eiJyDnwSGmmMQ