### PR TITLE
🔧 Scope Claude hooks to `$CLAUDE_PROJECT_DIR`

### DIFF
--- a/.claude/check-code.sh
+++ b/.claude/check-code.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 # Stop hook: build, lint, and typecheck after Claude finishes
-
 ERRORS=""
 
+if ! command -v pnpm &>/dev/null; then
+  echo "pnpm not found, installing via npm..."
+  if ! npm install -g pnpm 2>&1; then
+    ERRORS+="pnpm install via npm failed. "
+  fi
+fi
+
+echo "Installing dependencies with pnpm..."
+if ! pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile 2>&1; then
+  ERRORS+="Dependency install failed. "
+fi
+
 echo "Running build..."
-if ! pnpm build:all 2>&1; then
+if ! pnpm -C "$CLAUDE_PROJECT_DIR" build:all 2>&1; then
   ERRORS+="Build failed. "
 fi
 
 echo "Running lint check..."
-if ! pnpm lint:check 2>&1; then
+if ! pnpm -C "$CLAUDE_PROJECT_DIR" lint:check 2>&1; then
   ERRORS+="Lint failed. "
 fi
 
 echo "Running typecheck..."
-if ! pnpm typecheck:all 2>&1; then
+if ! pnpm -C "$CLAUDE_PROJECT_DIR" typecheck:all 2>&1; then
   ERRORS+="Typecheck failed. "
 fi
 

--- a/.claude/format-file.sh
+++ b/.claude/format-file.sh
@@ -4,7 +4,7 @@ INPUT=$(cat /dev/stdin)
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
-  pnpm format:file -- "$FILE_PATH" 2>/dev/null
+  pnpm -C "$CLAUDE_PROJECT_DIR" format:file -- "$FILE_PATH" 2>/dev/null
 fi
 
 exit 0  # Never block edits for formatting -- just fix silently

--- a/.claude/session-start.sh
+++ b/.claude/session-start.sh
@@ -14,4 +14,4 @@ fi
 # Install/sync dependencies — always run to ensure node_modules matches the lockfile
 # (e.g. after a dependency version bump, node_modules may exist but be stale)
 echo "Installing dependencies with pnpm..."
-pnpm install --frozen-lockfile
+pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile


### PR DESCRIPTION
## Description

<!-- Describe your change and explain what this PR is trying to solve -->

- Pass -C "$CLAUDE_PROJECT_DIR" to every pnpm invocation in .claude/check-code.sh, .claude/format-file.sh, and .claude/session-start.sh so the hooks run against the project regardless of Claude's current working directory.
- In .claude/check-code.sh, bootstrap pnpm via npm install -g if missing, and run pnpm install --frozen-lockfile before build/lint/typecheck so the Stop hook has a consistent, up-to-date node_modules.

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
