### PR TITLE
📝 Fix broken API reference links

### DIFF
--- a/packages/fast-check/README.md
+++ b/packages/fast-check/README.md
@@ -79,7 +79,7 @@ Useful documentations:
 - [🔧 Custom arbitraries](https://fast-check.dev/docs/core-blocks/arbitraries/combiners/)
 - [🏃‍♂️ Property based runners](https://fast-check.dev/docs/core-blocks/runners/)
 - [💥 Tips](https://fast-check.dev/docs/configuration/)
-- [🔌 API Reference](https://fast-check.dev/api-reference/index.html)
+- [🔌 API Reference](https://fast-check.dev/docs/api/)
 - [⭐ Awesome fast-check](https://fast-check.dev/docs/ecosystem/)
 
 ## Why should I migrate to fast-check?

--- a/website/docs/advanced/model-based-testing.md
+++ b/website/docs/advanced/model-based-testing.md
@@ -24,7 +24,7 @@ Although the model can be a useful tool, it's important to use it carefully. Mod
 
 ### Define the commands
 
-In fast-check, the commands have to implement the interface [`ICommand`](https://fast-check.dev/api-reference/interfaces/ICommand.html). They basically come with three important methods:
+In fast-check, the commands have to implement the interface [`ICommand`](/docs/api/interfaces/ICommand). They basically come with three important methods:
 
 - `check(model)` — Ensure that the model is in the appropriate state to execute the action
 - `run(model, real)` — Execute the action
@@ -36,7 +36,7 @@ If your system is a music player, here are some commands you may have: play, pau
 
 ### Generate the commands
 
-Then, to ingest your previously defined commands into fast-check as an arbitrary, you can use the [`commands`](https://fast-check.dev/api-reference/functions/commands.html) arbitrary. This function takes an array of commands as input and compiles them to produce a scenario that can be applied to your system.
+Then, to ingest your previously defined commands into fast-check as an arbitrary, you can use the [`commands`](/docs/api/functions/commands) arbitrary. This function takes an array of commands as input and compiles them to produce a scenario that can be applied to your system.
 
 :::info Isn't commands just an array builder?
 Yes and no!
@@ -76,9 +76,9 @@ class GoToTrackCommand {
 
 Commands have to be executed from the predicate. fast-check provides three model-based runners to run your commands:
 
-- [`modelRun`](https://fast-check.dev/api-reference/functions/modelRun.html) — Apply to any synchronous system: the commands have to be synchronous
-- [`asyncModelRun`](https://fast-check.dev/api-reference/functions/asyncModelRun.html) — Can work with asynchronous commands
-- [`scheduledModelRun`](https://fast-check.dev/api-reference/functions/scheduledModelRun.html) — Can work with asynchronous commands in a scheduled way for a better detection of race conditions
+- [`modelRun`](/docs/api/functions/modelRun) — Apply to any synchronous system: the commands have to be synchronous
+- [`asyncModelRun`](/docs/api/functions/asyncModelRun) — Can work with asynchronous commands
+- [`scheduledModelRun`](/docs/api/functions/scheduledModelRun) — Can work with asynchronous commands in a scheduled way for a better detection of race conditions
 
 ### Example
 

--- a/website/docs/advanced/race-conditions.md
+++ b/website/docs/advanced/race-conditions.md
@@ -18,7 +18,7 @@ Identifying and fixing race conditions can be challenging as they can occur unex
 
 ## The scheduler instance
 
-The [`scheduler`](/docs/core-blocks/arbitraries/others/#scheduler) arbitrary is able to generate instances of [`Scheduler`](https://fast-check.dev/api-reference/interfaces/Scheduler.html). They come with following interface:
+The [`scheduler`](/docs/core-blocks/arbitraries/others/#scheduler) arbitrary is able to generate instances of [`Scheduler`](/docs/api/interfaces/Scheduler). They come with following interface:
 
 - `schedule: <T>(task: Promise<T>, label?: string, metadata?: TMetadata, act?: SchedulerAct) => Promise<T>` - Wrap an existing promise using the scheduler. The newly created promise will resolve when the scheduler decides to resolve it (see `waitFor`, `waitNext` and `waitIdle` methods).
 - `scheduleFunction: <TArgs extends any[], T>(asyncFunction: (...args: TArgs) => Promise<T>, act?: SchedulerAct) => (...args: TArgs) => Promise<T>` - Wrap all the promise produced by an API using the scheduler. `scheduleFunction(callApi)`
@@ -305,7 +305,7 @@ function buildWrapWithTimersAct(s: fc.Scheduler) {
 
 ## Model based testing and race conditions
 
-Model-based testing features can be combined with race condition detection through the use of [`scheduledModelRun`](https://fast-check.dev/api-reference/functions/scheduledModelRun.html). By utilizing this function, the execution of the model will also be processed through the scheduler.
+Model-based testing features can be combined with race condition detection through the use of [`scheduledModelRun`](/docs/api/functions/scheduledModelRun). By utilizing this function, the execution of the model will also be processed through the scheduler.
 
 :::warning Do not depend on other scheduled tasks in the model
 Neither `check` nor `run` should rely on the completion of other scheduled tasks to fulfill themselves. But they can still trigger new scheduled tasks as long as they don't wait for them to resolve.

--- a/website/docs/configuration/global-settings.md
+++ b/website/docs/configuration/global-settings.md
@@ -8,7 +8,7 @@ Share settings cross runners.
 
 ## Per test settings
 
-By default, the [runners](/docs/core-blocks/runners/) take an [optional argument for extra settings](https://fast-check.dev/api-reference/interfaces/Parameters.html). Some of these settings can be re-used over-and-over in the same file and across several files.
+By default, the [runners](/docs/core-blocks/runners/) take an [optional argument for extra settings](/docs/api/interfaces/Parameters). Some of these settings can be re-used over-and-over in the same file and across several files.
 
 Example:
 
@@ -58,7 +58,7 @@ fc.configureGlobal({ ...fc.readConfigureGlobal(), ...myNewOptions });
 You can also fully reset all the global options by calling `resetConfigureGlobal`.
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/configureGlobal.html).  
+Resources: [API reference](/docs/api/functions/configureGlobal).  
 Available since 1.18.0.
 
 ## Integration with test frameworks

--- a/website/docs/configuration/timeouts.md
+++ b/website/docs/configuration/timeouts.md
@@ -72,7 +72,7 @@ Hint: Enable verbose mode in order to have the list of all failing values encoun
 Note that the function provided to `beforeEach` and `afterEach` are not included in the measured time for the timeout. If the execution is interrupted due to a timeout, `afterEach` will be called immediately without waiting for the predicate to finish.
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/interfaces/Parameters.html#timeout).  
+Resources: [API reference](/docs/api/interfaces/Parameters#timeout).  
 Available since 0.0.11.
 
 ## At runner level
@@ -95,7 +95,7 @@ Here is a summary:
 `interruptAfterTimeLimit` is particularly useful for fuzzing. For instance, setting it to `interruptAfterTimeLimit: 600_000` and adding `numRuns: Number.POSITIVE_INFINITY` would allow the runner to loop for 10 minutes, regardless of the number of predicates executed during that time.
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/interfaces/Parameters.html#interruptAfterTimeLimit).  
+Resources: [API reference](/docs/api/interfaces/Parameters#interruptaftertimelimit).  
 Available since 1.19.0.
 
 ### skipAllAfterTimeLimit
@@ -125,7 +125,7 @@ During the shrinking process, skipping predicates will result in one-by-one skip
 When we skip a predicate due to the `skipAllAfterTimeLimit` option, we still pass on it, which may take time. This is because each subsequent run needs to be marked as "will not be executed" one by one. On the other hand, with the `interruptAfterTimeLimit` option, the runner is stopped immediately when the deadline is reached, resulting in a faster stop.
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/interfaces/Parameters.html#timeout).  
+Resources: [API reference](/docs/api/interfaces/Parameters#timeout).  
 Available since 1.15.0.
 
 ## All timeout options

--- a/website/docs/core-blocks/arbitraries/combiners/any.md
+++ b/website/docs/core-blocks/arbitraries/combiners/any.md
@@ -43,7 +43,7 @@ fc.option(fc.string(), { nil: undefined });
 // Examples of such recursive structures are available with fc.letrec.
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/option.html).  
+Resources: [API reference](/docs/api/functions/option).  
 Available since 0.0.6.
 
 ## oneof
@@ -96,7 +96,7 @@ fc.oneof({ arbitrary: fc.string(), weight: 5 }, { arbitrary: fc.boolean(), weigh
 // Examples of such recursive structures are available with fc.letrec.
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/oneof.html).  
+Resources: [API reference](/docs/api/functions/oneof).  
 Available since 0.0.1.
 
 ## clone
@@ -130,7 +130,7 @@ fc.clone(fc.nat(), 3);
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/clone.html).  
+Resources: [API reference](/docs/api/functions/clone).  
 Available since 2.5.0.
 
 ## noBias
@@ -154,7 +154,7 @@ fc.noBias(fc.nat());
 // Examples of generated values: 394798768, 980149687, 1298483622, 1164017931, 646759550…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/noBias.html).  
+Resources: [API reference](/docs/api/functions/noBias).  
 Available since 3.20.0.
 
 ## noShrink
@@ -182,7 +182,7 @@ fc.noShrink(fc.nat());
 // Examples of generated values: 1395148595, 7, 1743838935, 879259091, 2147483640…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/noShrink.html).  
+Resources: [API reference](/docs/api/functions/noShrink).  
 Available since 3.20.0.
 
 ## limitShrink
@@ -211,7 +211,7 @@ fc.limitShrink(fc.nat(), 3);
 // Examples of generated values: 487640477, 1460784921, 1601237202, 1623804274, 5…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/limitShrink.html).  
+Resources: [API reference](/docs/api/functions/limitShrink).  
 Available since 3.20.0.
 
 ## .filter
@@ -242,7 +242,7 @@ fc.string().filter((s) => s[0] < s[1]);
 // Examples of generated values: "Aa]tp>", "apply", "?E%a$n x", "#l\"/L\"x&S{", "argument"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/classes/Arbitrary.html#filter).  
+Resources: [API reference](/docs/api/classes/Arbitrary#filter).  
 Available since 0.0.1.
 
 ## .map
@@ -276,7 +276,7 @@ fc.string().map((s) => `[${s.length}] -> ${s}`);
 // Examples of generated values: "[3] -> ref", "[8] -> xeE:81|z", "[9] -> B{1Z\\sxWa", "[3] -> key", "[1] -> _"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/classes/Arbitrary.html#map).  
+Resources: [API reference](/docs/api/classes/Arbitrary#map).  
 Available since 0.0.1.
 
 ## .chain
@@ -303,5 +303,5 @@ fc.nat().chain((min) => fc.tuple(fc.constant(min), fc.integer({ min, max: 0xffff
 // Examples of generated values: [1211945858,4294967292], [1068058184,2981851306], [2147483626,2147483645], [1592081894,1592081914], [2147483623,2147483639]…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/classes/Arbitrary.html#chain).  
+Resources: [API reference](/docs/api/classes/Arbitrary#chain).  
 Available since 1.2.0.

--- a/website/docs/core-blocks/arbitraries/combiners/constant.md
+++ b/website/docs/core-blocks/arbitraries/combiners/constant.md
@@ -28,7 +28,7 @@ fc.constant({});
 // Examples of generated values: {}…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/constant.html).  
+Resources: [API reference](/docs/api/functions/constant).  
 Available since 0.0.1.
 
 ## constantFrom
@@ -55,7 +55,7 @@ fc.constantFrom(1, 'string', {});
 // Examples of generated values: 1, "string", {}…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/constantFrom.html).  
+Resources: [API reference](/docs/api/functions/constantFrom).  
 Available since 0.0.12.
 
 ## mapToConstant
@@ -82,7 +82,7 @@ fc.mapToConstant(
 // Examples of generated values: "6", "8", "d", "9", "r"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/mapToConstant.html).  
+Resources: [API reference](/docs/api/functions/mapToConstant).  
 Available since 1.14.0.
 
 ## subarray
@@ -118,7 +118,7 @@ fc.subarray([1, 42, 48, 69, 75, 92], { minLength: 2, maxLength: 3 });
 // Examples of generated values: [48,75], [48,69,92], [42,75], [69,92], [1,42]…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/subarray.html).  
+Resources: [API reference](/docs/api/functions/subarray).  
 Available since 1.5.0.
 
 ## shuffledSubarray
@@ -154,5 +154,5 @@ fc.shuffledSubarray([1, 42, 48, 69, 75, 92], { minLength: 2, maxLength: 3 });
 // Examples of generated values: [1,92], [92,75], [1,48], [42,75], [48,69]…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/shuffledSubarray.html).  
+Resources: [API reference](/docs/api/functions/shuffledSubarray).  
 Available since 1.5.0.

--- a/website/docs/core-blocks/arbitraries/combiners/recursive-structure.md
+++ b/website/docs/core-blocks/arbitraries/combiners/recursive-structure.md
@@ -197,7 +197,7 @@ fc.statistics(
 // • 5 to 9 items.......0.14%
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/letrec.html).  
+Resources: [API reference](/docs/api/functions/letrec).  
 Available since 1.16.0.
 
 ## memo
@@ -240,7 +240,7 @@ tree(2);
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/memo.html).  
+Resources: [API reference](/docs/api/functions/memo).  
 Available since 1.16.0.
 
 ## entityGraph
@@ -465,5 +465,5 @@ fc.entityGraph(
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/entityGraph.html).  
+Resources: [API reference](/docs/api/functions/entityGraph).  
 Available since 4.5.0.

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -88,7 +88,7 @@ fc.stringMatching(
 );
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/stringMatching.html).  
+Resources: [API reference](/docs/api/functions/stringMatching).  
 Available since 3.10.0.
 
 ## mixedCase
@@ -134,5 +134,5 @@ fc.mixedCase(fc.constant('🐱🐢🐱🐢🐱🐢'), {
 // Examples of generated values: "🐯🐇🐱🐢🐯🐢", "🐱🐇🐱🐇🐯🐇", "🐱🐢🐯🐢🐱🐢", "🐱🐢🐱🐇🐯🐢", "🐱🐢🐯🐢🐱🐇"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/mixedCase.html).  
+Resources: [API reference](/docs/api/functions/mixedCase).  
 Available since 1.17.0.

--- a/website/docs/core-blocks/arbitraries/composites/array.md
+++ b/website/docs/core-blocks/arbitraries/composites/array.md
@@ -28,7 +28,7 @@ fc.tuple(fc.nat(), fc.string());
 // Examples of generated values: [17,"n"], [1187149108,"{}"], [302474255,"!!]"], [2147483618,"$#"], [21,"lv V!\""]…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/tuple.html).  
+Resources: [API reference](/docs/api/functions/tuple).  
 Available since 0.0.1.
 
 ## array
@@ -137,7 +137,7 @@ fc.letrec((tie) => ({
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/array.html).  
+Resources: [API reference](/docs/api/functions/array).  
 Available since 0.0.1.
 
 ## uniqueArray
@@ -221,7 +221,7 @@ fc.uniqueArray(fc.constantFrom(-1, -0, 0, 1, Number.NaN), { comparator: (a, b) =
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uniqueArray.html).  
+Resources: [API reference](/docs/api/functions/uniqueArray).  
 Available since 2.23.0.
 
 ## sparseArray
@@ -296,5 +296,5 @@ fc.sparseArray(fc.nat(), { size: '+1' });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/sparseArray.html).  
+Resources: [API reference](/docs/api/functions/sparseArray).  
 Available since 2.13.0.

--- a/website/docs/core-blocks/arbitraries/composites/function.md
+++ b/website/docs/core-blocks/arbitraries/composites/function.md
@@ -59,7 +59,7 @@ fc.compareBooleanFunc();
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/compareBooleanFunc.html).  
+Resources: [API reference](/docs/api/functions/compareBooleanFunc).  
 Available since 1.6.0.
 
 ## compareFunc
@@ -115,7 +115,7 @@ fc.compareFunc();
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/compareFunc.html).  
+Resources: [API reference](/docs/api/functions/compareFunc).  
 Available since 1.6.0.
 
 ## func
@@ -163,5 +163,5 @@ fc.func(fc.nat());
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/func.html).  
+Resources: [API reference](/docs/api/functions/func).  
 Available since 1.6.0.

--- a/website/docs/core-blocks/arbitraries/composites/iterable.md
+++ b/website/docs/core-blocks/arbitraries/composites/iterable.md
@@ -32,5 +32,5 @@ fc.infiniteStream(fc.nat(9), { noHistory: true });
 // Examples of generated values: Stream(0 emitted)…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/infiniteStream.html).  
+Resources: [API reference](/docs/api/functions/infiniteStream).  
 Available since 1.8.0.

--- a/website/docs/core-blocks/arbitraries/composites/object.md
+++ b/website/docs/core-blocks/arbitraries/composites/object.md
@@ -67,7 +67,7 @@ fc.dictionary(fc.string(), fc.string(), { noNullPrototype: true });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/dictionary.html).  
+Resources: [API reference](/docs/api/functions/dictionary).  
 Available since 1.0.0.
 
 ## set
@@ -139,7 +139,7 @@ fc.set(fc.constantFrom(-0, 0, Number.NaN, 1, 2));
 // Examples of generated values: new Set([Number.NaN,0,1,2]), new Set([0,2,1,Number.NaN]), new Set([2,1]), new Set([0,Number.NaN,2,1]), new Set([0])…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/set.html).  
+Resources: [API reference](/docs/api/functions/set).  
 Available since 4.4.0.
 
 ## map
@@ -196,7 +196,7 @@ fc.map(fc.constantFrom('a', 'b', 'c'), fc.boolean(), { maxKeys: 3 });
 // Examples of generated values: new Map([]), new Map([["c",false]]), new Map([["c",true],["b",true]]), new Map([["b",true],["a",false]]), new Map([["a",true]])…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/map.html).  
+Resources: [API reference](/docs/api/functions/map).  
 Available since 4.4.0.
 
 ## record
@@ -299,7 +299,7 @@ fc.record(
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/record.html).  
+Resources: [API reference](/docs/api/functions/record).  
 Available since 0.0.12.
 
 ## object
@@ -411,7 +411,7 @@ fc.object({
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/object.html).  
+Resources: [API reference](/docs/api/functions/object).  
 Available since 0.0.7.
 
 ## anything
@@ -518,5 +518,5 @@ fc.anything({
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/anything.html).  
+Resources: [API reference](/docs/api/functions/anything).  
 Available since 0.0.7.

--- a/website/docs/core-blocks/arbitraries/composites/typed-array.md
+++ b/website/docs/core-blocks/arbitraries/composites/typed-array.md
@@ -45,7 +45,7 @@ fc.int8Array({ min: 0, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/int8Array.html).  
+Resources: [API reference](/docs/api/functions/int8Array).  
 Available since 2.9.0.
 
 ## uint8Array
@@ -87,7 +87,7 @@ fc.uint8Array({ max: 42, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uint8Array.html).  
+Resources: [API reference](/docs/api/functions/uint8Array).  
 Available since 2.9.0.
 
 ## uint8ClampedArray
@@ -129,7 +129,7 @@ fc.uint8ClampedArray({ max: 42, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uint8ClampedArray.html).  
+Resources: [API reference](/docs/api/functions/uint8ClampedArray).  
 Available since 2.9.0.
 
 ## int16Array
@@ -171,7 +171,7 @@ fc.int16Array({ min: 0, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/int16Array.html).  
+Resources: [API reference](/docs/api/functions/int16Array).  
 Available since 2.9.0.
 
 ## uint16Array
@@ -213,7 +213,7 @@ fc.uint16Array({ max: 42, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uint16Array.html).  
+Resources: [API reference](/docs/api/functions/uint16Array).  
 Available since 2.9.0.
 
 ## int32Array
@@ -255,7 +255,7 @@ fc.int32Array({ min: 0, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/int32Array.html).  
+Resources: [API reference](/docs/api/functions/int32Array).  
 Available since 2.9.0.
 
 ## uint32Array
@@ -297,7 +297,7 @@ fc.uint32Array({ max: 42, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uint32Array.html).  
+Resources: [API reference](/docs/api/functions/uint32Array).  
 Available since 2.9.0.
 
 ## float32Array
@@ -342,7 +342,7 @@ fc.float32Array({ minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/float32Array.html).  
+Resources: [API reference](/docs/api/functions/float32Array).  
 Available since 2.9.0.
 
 ## float64Array
@@ -387,7 +387,7 @@ fc.float64Array({ minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/float64Array.html).  
+Resources: [API reference](/docs/api/functions/float64Array).  
 Available since 2.9.0.
 
 ## bigInt64Array
@@ -427,7 +427,7 @@ fc.bigInt64Array({ min: 0n, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/bigInt64Array.html).  
+Resources: [API reference](/docs/api/functions/bigInt64Array).  
 Available since 3.0.0.
 
 ## bigUint64Array
@@ -467,5 +467,5 @@ fc.bigUint64Array({ max: 42n, minLength: 1 });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/bigUint64Array.html).  
+Resources: [API reference](/docs/api/functions/bigUint64Array).  
 Available since 3.0.0.

--- a/website/docs/core-blocks/arbitraries/fake-data/file.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/file.md
@@ -44,7 +44,7 @@ fc.base64String({ minLength: 4, maxLength: 12 });
 // Examples of generated values: "YQ7D/IU8fE+2", "tjhMHtq9", "property", "9lm8Vx7bBF==", "roto"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/base64String.html).  
+Resources: [API reference](/docs/api/functions/base64String).  
 Available since 0.0.1.
 
 ## json
@@ -103,7 +103,7 @@ fc.json({ depthSize: 'medium' });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/json.html).  
+Resources: [API reference](/docs/api/functions/json).  
 Available since 0.0.7.
 
 ## jsonValue
@@ -220,7 +220,7 @@ fc.statistics(fc.jsonValue({ maxDepth: 2 }), (v) => {
 // • 5 to 9 items.......1.34%
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/jsonValue.html).  
+Resources: [API reference](/docs/api/functions/jsonValue).  
 Available since 2.20.0.
 
 ## lorem
@@ -263,5 +263,5 @@ fc.lorem({ maxCount: 3, mode: 'sentences' });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/lorem.html).  
+Resources: [API reference](/docs/api/functions/lorem).  
 Available since 0.0.1.

--- a/website/docs/core-blocks/arbitraries/fake-data/identifier.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/identifier.md
@@ -27,7 +27,7 @@ fc.ulid();
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/ulid.html).  
+Resources: [API reference](/docs/api/functions/ulid).  
 Available since 3.11.0.
 
 ### uuid
@@ -74,5 +74,5 @@ fc.uuid({ version: [4, 7] });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/uuid.html).  
+Resources: [API reference](/docs/api/functions/uuid).  
 Available since 1.17.0.

--- a/website/docs/core-blocks/arbitraries/fake-data/internet.md
+++ b/website/docs/core-blocks/arbitraries/fake-data/internet.md
@@ -21,7 +21,7 @@ fc.ipV4();
 // Examples of generated values: "149.2.84.39", "255.251.100.5", "151.253.2.4", "93.3.251.97", "121.3.113.229"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/ipV4.html).  
+Resources: [API reference](/docs/api/functions/ipV4).  
 Available since 1.14.0.
 
 ### ipV4Extended
@@ -39,7 +39,7 @@ fc.ipV4Extended();
 // Examples of generated values: "0x7.249.0xfe.0x79", "07.0x7b.1.0x6", "0xa5.0265.22.27", "0xd4.0xfd.15664", "0x1ed7207"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/ipV4Extended.html).  
+Resources: [API reference](/docs/api/functions/ipV4Extended).  
 Available since 1.17.0.
 
 ### ipV6
@@ -63,7 +63,7 @@ fc.ipV6();
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/ipV6.html).  
+Resources: [API reference](/docs/api/functions/ipV6).  
 Available since 1.14.0.
 
 ### domain
@@ -102,7 +102,7 @@ fc.domain({ size: '+1' });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/domain.html).  
+Resources: [API reference](/docs/api/functions/domain).  
 Available since 1.14.0.
 
 ### webAuthority
@@ -150,7 +150,7 @@ fc.webAuthority({
 // Examples of generated values: "0rog.cod:63367", "02.0x57fdd:45172", "0247.0332.0315.0x7a", "2498828715:50719", "169.3.232.223"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webAuthority.html).  
+Resources: [API reference](/docs/api/functions/webAuthority).  
 Available since 1.14.0.
 
 ### webFragments
@@ -175,7 +175,7 @@ fc.webFragments();
 // Examples of generated values: "", "kg%00au@b%08cg", "a", "?x%F1%80%9F%8Cti.k", "%F0%A1%85%AFR%F1%8F%B1%86rQ"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webFragments.html).  
+Resources: [API reference](/docs/api/functions/webFragments).  
 Available since 1.14.0.
 
 ### webPath
@@ -209,7 +209,7 @@ fc.webPath({ size: '+1' });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webPath.html).  
+Resources: [API reference](/docs/api/functions/webPath).  
 Available since 3.3.0.
 
 ### webQueryParameters
@@ -234,7 +234,7 @@ fc.webQueryParameters();
 // Examples of generated values: "argumentsp", "zB)MCS9r*", "=gcJbW:1", "RmE9%F1%A6%BE%968y:2", "1=eJ@5ic1"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webQueryParameters.html).  
+Resources: [API reference](/docs/api/functions/webQueryParameters).  
 Available since 1.14.0.
 
 ### webSegment
@@ -257,7 +257,7 @@ fc.webSegment();
 // Examples of generated values: "*lej@(", "", "+Y", "1FBtTF1GX", "V:%F2%96%A2%A1$PV4Yq"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webSegment.html).  
+Resources: [API reference](/docs/api/functions/webSegment).  
 Available since 1.14.0.
 
 ### webUrl
@@ -273,7 +273,7 @@ Following the specs specified by RFC 3986 and WHATWG URL Standard.
 
 **with:**
 
-- `authoritySettings?` — default: `{}` — _[constraints](https://fast-check.dev/api-reference/interfaces/WebAuthorityConstraints.html) on the web authority_
+- `authoritySettings?` — default: `{}` — _[constraints](/docs/api/interfaces/WebAuthorityConstraints) on the web authority_
 - `validSchemes?` — default: `['http', 'https']` — _list all the valid schemes_
 - `withFragments?` — default: `false` — _enable fragments_
 - `withQueryParameters?` — default: `false` — _enable query parameters_
@@ -313,7 +313,7 @@ fc.webUrl({ size: '-1' });
 // Examples of generated values: "https://pi.ca", "https://j.3ch.hy/", "https://5c.f.lbi/", "https://px.hw", "https://dcf.qr"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/webUrl.html).  
+Resources: [API reference](/docs/api/functions/webUrl).  
 Available since 1.14.0.
 
 ### emailAddress
@@ -348,5 +348,5 @@ fc.emailAddress({ size: '-1' });
 // Examples of generated values: "k.wh@l7.pc", "u@j.ag", "p.ag@1f.bj", "d@4.yd", "!@is8.gb"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/emailAddress.html).  
+Resources: [API reference](/docs/api/functions/emailAddress).  
 Available since 1.14.0.

--- a/website/docs/core-blocks/arbitraries/others.md
+++ b/website/docs/core-blocks/arbitraries/others.md
@@ -26,12 +26,12 @@ fc.falsy({ withBigInt: true });
 // Examples of generated values: null, Number.NaN, false, undefined, 0n…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/falsy.html).  
+Resources: [API reference](/docs/api/functions/falsy).  
 Available since 1.26.0.
 
 ## context
 
-Generate an [instance of `ContextValue`](https://fast-check.dev/api-reference/interfaces/ContextValue.html) for each predicate run.
+Generate an [instance of `ContextValue`](/docs/api/interfaces/ContextValue) for each predicate run.
 
 `ContextValue` can be used to log stuff within the run itself. In case of failure, the logs will be attached in the counterexample and visible in the stack trace.
 
@@ -47,7 +47,7 @@ fc.context();
 // It can be called as follow: ctx.log('My log')
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/context.html).  
+Resources: [API reference](/docs/api/functions/context).  
 Available since 1.8.0.
 
 ## commands
@@ -103,7 +103,7 @@ fc.assert(
 );
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/commands.html).  
+Resources: [API reference](/docs/api/functions/commands).  
 Available since .
 
 ## gen
@@ -142,7 +142,7 @@ fc.gen();
 // If you do need to create a dedicated builder, define it outside of `fc.assert` and use it in your predicate as `g(myBuilder, ...parametersForMyBuilder)`.
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/gen.html).  
+Resources: [API reference](/docs/api/functions/gen).  
 Available since 3.8.0.
 
 ## scheduler
@@ -158,5 +158,5 @@ Scheduler for asynchronous tasks.
 
 - `act` — _ensure that all scheduled tasks will be executed in the right context_
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/scheduler.html).  
+Resources: [API reference](/docs/api/functions/scheduler).  
 Available since 1.20.0.

--- a/website/docs/core-blocks/arbitraries/primitives/bigint.md
+++ b/website/docs/core-blocks/arbitraries/primitives/bigint.md
@@ -59,5 +59,5 @@ fc.bigInt({ min: 1n << 64n });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/bigInt.html).  
+Resources: [API reference](/docs/api/functions/bigInt).  
 Available since 1.9.0.

--- a/website/docs/core-blocks/arbitraries/primitives/boolean.md
+++ b/website/docs/core-blocks/arbitraries/primitives/boolean.md
@@ -21,5 +21,5 @@ fc.boolean();
 // Examples of generated values: true, false…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/boolean.html).  
+Resources: [API reference](/docs/api/functions/boolean).  
 Available since 0.0.6.

--- a/website/docs/core-blocks/arbitraries/primitives/date.md
+++ b/website/docs/core-blocks/arbitraries/primitives/date.md
@@ -72,5 +72,5 @@ fc.date({ noInvalidDate: true });
 // • …
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/date.html).  
+Resources: [API reference](/docs/api/functions/date).  
 Available since 1.17.0.

--- a/website/docs/core-blocks/arbitraries/primitives/number.md
+++ b/website/docs/core-blocks/arbitraries/primitives/number.md
@@ -39,7 +39,7 @@ fc.integer({ min: 65536 });
 // Examples of generated values: 487771549, 1460850457, 1601368274, 1623935346, 65541…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/integer.html).  
+Resources: [API reference](/docs/api/functions/integer).  
 Available since 0.0.1.
 
 ## nat
@@ -75,7 +75,7 @@ fc.nat({ max: 1000 });
 // Examples of generated values: 917, 60, 599, 696, 7…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/nat.html).  
+Resources: [API reference](/docs/api/functions/nat).  
 Available since 0.0.1.
 
 ## maxSafeInteger
@@ -95,7 +95,7 @@ fc.maxSafeInteger();
 // Examples of generated values: 4, -6906426479593829, -9007199254740981, 1468597314308129, -31…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/maxSafeInteger.html).  
+Resources: [API reference](/docs/api/functions/maxSafeInteger).  
 Available since 1.11.0.
 
 ## maxSafeNat
@@ -115,7 +115,7 @@ fc.maxSafeNat();
 // Examples of generated values: 8974418498592146, 7152466311278303, 7682568104547082, 5480146126393191, 6062166945524051…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/maxSafeNat.html).  
+Resources: [API reference](/docs/api/functions/maxSafeNat).  
 Available since 1.11.0.
 
 ## float
@@ -177,7 +177,7 @@ fc.noBias(fc.integer({ min: 0, max: (1 << 24) - 1 }).map((v) => v / (1 << 24)));
 // Examples of generated values: 0.06896239519119263, 0.5898661017417908, 0.7715556621551514, 0.4010099768638611, 0.8638045787811279…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/float.html).  
+Resources: [API reference](/docs/api/functions/float).  
 Available since 0.0.6.
 
 ## double
@@ -241,5 +241,5 @@ fc.noBias(
 // Examples of generated values: 0.5424979085274226, 0.8984809917404123, 0.577376440989232, 0.8433714130130558, 0.48219857913738606…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/double.html).  
+Resources: [API reference](/docs/api/functions/double).  
 Available since 0.0.6.

--- a/website/docs/core-blocks/arbitraries/primitives/string.md
+++ b/website/docs/core-blocks/arbitraries/primitives/string.md
@@ -77,5 +77,5 @@ fc.string({ unit: fc.constantFrom('Hello', 'World') });
 // Examples of generated values: "", "Hello", "HelloWorld", "HelloWorldHello", "WorldWorldHelloWorldHelloWorld"…
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/string.html).  
+Resources: [API reference](/docs/api/functions/string).  
 Available since 0.0.1.

--- a/website/docs/core-blocks/runners.md
+++ b/website/docs/core-blocks/runners.md
@@ -19,10 +19,10 @@ function assert<Ts>(property: IAsyncProperty<Ts>, params?: Parameters<Ts>): Prom
 ```
 
 :::tip
-Check [`Parameters`](https://fast-check.dev/api-reference/interfaces/Parameters.html) to run `assert` with advanced options.
+Check [`Parameters`](/docs/api/interfaces/Parameters) to run `assert` with advanced options.
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/assert.html).  
+Resources: [API reference](/docs/api/functions/assert).  
 Available since 0.0.1.
 
 ## check
@@ -60,7 +60,7 @@ function assert(property, params) {
 
 :::
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/check.html).  
+Resources: [API reference](/docs/api/functions/check).  
 Available since 0.0.1.
 
 ## sample
@@ -73,7 +73,7 @@ Its signature is:
 function sample<Ts>(generator: IRawProperty<Ts, boolean> | Arbitrary<Ts>, params?: number | Parameters<Ts>): Ts[];
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/sample.html).  
+Resources: [API reference](/docs/api/functions/sample).  
 Available since 0.0.6.
 
 ## statistics
@@ -112,5 +112,5 @@ fc.statistics(
 // >  5 characters...8.68%
 ```
 
-Resources: [API reference](https://fast-check.dev/api-reference/functions/statistics.html).  
+Resources: [API reference](/docs/api/functions/statistics).  
 Available since 0.0.6.

--- a/website/docs/tutorials/index.md
+++ b/website/docs/tutorials/index.md
@@ -44,4 +44,4 @@ These tutorials are intentionally focused. Once you are comfortable with the bas
 - [**Core Blocks**](/docs/core-blocks/properties/) — the reference for properties, runners and arbitraries.
 - [**Configuration**](/docs/configuration/user-definable-values/) — fine-tune fast-check to match your project's constraints.
 - [**Advanced**](/docs/advanced/model-based-testing/) — model-based testing, race conditions in depth, and more.
-- [**API Reference**](https://fast-check.dev/api-reference/index.html) — the exhaustive list of every exported symbol.
+- [**API Reference**](/docs/api/) — the exhaustive list of every exported symbol.


### PR DESCRIPTION
The API reference docs are now generated internally by
docusaurus-plugin-typedoc under /docs/api/. Update all links that
still pointed to the legacy https://fast-check.dev/api-reference/
URLs so they use internal paths, and switch the README to the new
public URL.