### PR TITLE
🐛(vitest) Bind `each` method to preserve `this` context in test builder

### DIFF
--- a/packages/vitest/src/internals/TestBuilder.ts
+++ b/packages/vitest/src/internals/TestBuilder.ts
@@ -146,7 +146,7 @@ export function buildTest<T extends (...args: any[]) => any>(
       extraKeys[key] =
         key !== 'each'
           ? buildTest((testFn as any)[key], testFnExtended[key] as any, fc, new Set([...ancestors, key]))
-          : testFn[key];
+          : testFn[key].bind(testFn);
     }
   }
   if (!atLeastOneExtra) {


### PR DESCRIPTION
Fixes PR https://github.com/dubzzz/fast-check/pull/6804.

The `each` method (e.g. `it.each` / `test.each`) in Vitest requires a valid `this` context, as it uses `this` internally to access class methods. When assigning via `testFn[key]`, the context was lost, leading to errors when calling `it.each(...)`.

Fix: explicitly bind the method to `testFn` via `.bind(testFn)`, ensuring the correct context is used when calling.