### PR TITLE
👷 Grant `discussions: write` to release jobs

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -595,6 +595,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -672,6 +673,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -749,6 +751,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -826,6 +829,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -903,6 +907,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -980,6 +985,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:
@@ -1057,6 +1063,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      discussions: write
       id-token: write
       attestations: write
     steps:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,13 +9,13 @@ rules:
     ignore:
       # These are false positives - attestations ensure artifact integrity
       # setup-node actions in publish jobs followed by gh-release for attestation uploads
-      - build-status.yml:602 # fast-check
-      - build-status.yml:679 # ava
-      - build-status.yml:756 # jest
-      - build-status.yml:833 # packaged
-      - build-status.yml:910 # poisoning
-      - build-status.yml:987 # vitest
-      - build-status.yml:1064 # worker
+      - build-status.yml:603 # fast-check
+      - build-status.yml:681 # ava
+      - build-status.yml:759 # jest
+      - build-status.yml:837 # packaged
+      - build-status.yml:915 # poisoning
+      - build-status.yml:993 # vitest
+      - build-status.yml:1071 # worker
   dangerous-triggers:
     ignore:
       # We moved these workflows to "pull_request_target".


### PR DESCRIPTION
The release publish jobs use softprops/action-gh-release with
discussion_category_name to link an Announcements discussion to each
release, but the GITHUB_TOKEN was scoped to contents/id-token/attestations
write only. With discussions permission missing, GitHub's release update
endpoint surfaces the misleading error "Discussion could not be created.
Make sure you passed a valid category name." (and the action retries
exhausted), even though the category exists and the name is valid.

This is also why no past release ever had a linked discussion regardless
of the "Announcements" / "announcements" casing tried in #6877.

Add discussions: write to every per-package publish job so the linked
discussion can actually be created when finalizing the release.