### PR TITLE
👷 Pin pnpm in npm install commands

### DIFF
--- a/.claude/check-code.sh
+++ b/.claude/check-code.sh
@@ -4,7 +4,7 @@ ERRORS=""
 
 if ! command -v pnpm &>/dev/null; then
   echo "pnpm not found, installing via npm..."
-  if ! npm install -g pnpm 2>&1; then
+  if ! npm install -g pnpm@10.33.2 2>&1; then
     ERRORS+="pnpm install via npm failed. "
   fi
 fi

--- a/.claude/session-start.sh
+++ b/.claude/session-start.sh
@@ -8,7 +8,7 @@ set -e
 # Install pnpm via npm if not already available
 if ! command -v pnpm &>/dev/null; then
   echo "pnpm not found, installing via npm..."
-  npm install -g pnpm
+  npm install -g pnpm@10.33.2
 fi
 
 # Install/sync dependencies — always run to ensure node_modules matches the lockfile


### PR DESCRIPTION
Pin pnpm to a specific version when installed via `npm install -g`
in the SessionStart and Stop hooks, matching the project's
`packageManager` field. Resolves the OSSF Scorecard
"npmCommand not pinned by hash" warnings.