### PR TITLE
👷 Skip PR template check for dubzzz

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -27,6 +27,10 @@ jobs:
               console.log('⏭️ Skipping PR template check for Renovate bot');
               return;
             }
+            if (author === 'dubzzz') {
+              console.log('⏭️ Skipping PR template check for dubzzz');
+              return;
+            }
 
             const body = context.payload.pull_request.body ?? '';
 


### PR DESCRIPTION
Allows the maintainer to bypass the PR template enforcement, same as Renovate.