### PR TITLE
✨ Towards shrinkable `entityGraph` thanks to `chainUntil`

### DIFF
--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -21,6 +21,7 @@ import { createDepthIdentifier, type DepthIdentifier } from './helpers/DepthCont
 import type { Arity, EntityLinks, EntityRelations, ProducedLinks, Strategy } from './interfaces/EntityGraphTypes.js';
 
 const safeObjectCreate = Object.create;
+const safeObjectAssign = Object.assign;
 
 /** @internal */
 function produceLinkUnitaryIndexArbitrary(
@@ -132,6 +133,7 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
   }
 
   return tuple<(number[] | number | undefined)[]>(...subArbitraries).map((results) => {
+    const newProducedLinks = safeObjectAssign(safeObjectCreate(null), producedLinks);
     const currentLinks = producedLinks[currentEntity.type][currentEntity.indexInType];
     let resultIndex = 0;
     let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
@@ -143,7 +145,6 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
       const targetType = relation.type;
       const countInTargetType = countsInTargetType[name];
       const linkOrLinks = results[resultIndex++];
-      const producedLinksInTargetType = producedLinks[targetType];
       currentLinks[name] = { type: targetType, index: linkOrLinks };
       const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
       for (const link of links) {
@@ -152,17 +153,20 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
             newToBeProducedEntities = [...toBeProducedEntities];
           }
           safePush(newToBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
-          safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(relations, targetType));
+          if (newProducedLinks[targetType] === producedLinks[targetType]) {
+            newProducedLinks[targetType] = [...producedLinks[targetType]];
+          }
+          safePush(newProducedLinks[targetType], createEmptyLinksInstanceFor(relations, targetType));
         }
         const inversed = safeMapGet(inversedRelations, relation);
         if (inversed !== undefined) {
-          const knownInversedLinks = producedLinksInTargetType[link][inversed.property].index;
+          const knownInversedLinks = producedLinks[targetType][link][inversed.property].index;
           safePush(knownInversedLinks as number[], currentEntity.indexInType);
         }
       }
     }
     return {
-      producedLinks,
+      producedLinks: newProducedLinks,
       toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
       nextIndex: nextIndex + 1,
     };

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -18,13 +18,7 @@ import { tuple } from '../tuple.js';
 import { uniqueArray } from '../uniqueArray.js';
 import { buildInversedRelationsMapping } from './helpers/BuildInversedRelationsMapping.js';
 import { createDepthIdentifier, type DepthIdentifier } from './helpers/DepthContext.js';
-import type {
-  Arity,
-  EntityLinks,
-  EntityRelations,
-  ProducedLinks,
-  Strategy,
-} from './interfaces/EntityGraphTypes.js';
+import type { Arity, EntityLinks, EntityRelations, ProducedLinks, Strategy } from './interfaces/EntityGraphTypes.js';
 
 const safeObjectCreate = Object.create;
 
@@ -83,9 +77,9 @@ type ToBeProducedEntity<TEntityFields> = { type: keyof TEntityFields; indexInTyp
 
 /** @internal */
 type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> = {
-  producedLinks: ProducedLinks<TEntityFields, TEntityRelations>;
-  toBeProducedEntities: ToBeProducedEntity<TEntityFields>[];
-  nextIndex: number;
+  readonly producedLinks: ProducedLinks<TEntityFields, TEntityRelations>;
+  readonly toBeProducedEntities: readonly ToBeProducedEntity<TEntityFields>[];
+  readonly nextIndex: number;
 };
 
 /** @internal */
@@ -174,6 +168,7 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
     return tuple<(number[] | number | undefined)[]>(...subArbitraries).map((results) => {
       const currentLinks = producedLinks[currentEntity.type][currentEntity.indexInType];
       let resultIndex = 0;
+      let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
       for (const name in currentRelations) {
         const relation = currentRelations[name];
         if (relation.arity === 'inverse') {
@@ -187,7 +182,10 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
         const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
         for (const link of links) {
           if (link >= countInTargetType) {
-            safePush(toBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
+            if (newToBeProducedEntities === undefined) {
+              newToBeProducedEntities = [...toBeProducedEntities];
+            }
+            safePush(newToBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
             safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(targetType));
           }
           const inversed = safeMapGet(inversedRelations, relation);
@@ -197,25 +195,29 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
           }
         }
       }
-      return { producedLinks, toBeProducedEntities, nextIndex: nextIndex + 1 };
+      return {
+        producedLinks,
+        toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
+        nextIndex: nextIndex + 1,
+      };
     });
   }
 
-  // Initial state arbitrary: rebuilds a fresh state on every generate call so that calls do not
-  // share their `producedLinks` / `toBeProducedEntities` arrays.
-  const initialStateArb = constant(undefined).map<ProductionState<TEntityFields, TEntityRelations>>(() => {
-    const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
-    for (const name in relations) {
-      producedLinks[name as Extract<keyof TEntityFields, string>] = [];
-    }
-    const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
-    for (const name of defaultEntities) {
-      safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
-      safePush(producedLinks[name], createEmptyLinksInstanceFor(name));
-    }
-    return { producedLinks, toBeProducedEntities, nextIndex: 0 };
-  });
-
+  const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
+  for (const name in relations) {
+    producedLinks[name as Extract<keyof TEntityFields, string>] = [];
+  }
+  const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
+  for (const name of defaultEntities) {
+    safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
+    safePush(producedLinks[name], createEmptyLinksInstanceFor(name));
+  }
+  const initialProductionState: ProductionState<TEntityFields, TEntityRelations> = {
+    producedLinks,
+    toBeProducedEntities,
+    nextIndex: 0,
+  };
+  const initialStateArb = constant(initialProductionState);
   return chainUntil(initialStateArb, (state) => {
     if (state.nextIndex >= state.toBeProducedEntities.length) {
       return undefined;

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -12,10 +12,12 @@ import {
   Error as SError,
   String as SString,
 } from '../../utils/globals.js';
+import { chainUntil } from '../chainUntil.js';
 import { constant } from '../constant.js';
 import { integer } from '../integer.js';
 import { noBias } from '../noBias.js';
 import { option } from '../option.js';
+import { tuple } from '../tuple.js';
 import { uniqueArray } from '../uniqueArray.js';
 import { buildInversedRelationsMapping } from './helpers/BuildInversedRelationsMapping.js';
 import type { InversedRelationsEntry } from './helpers/BuildInversedRelationsMapping.js';
@@ -50,25 +52,22 @@ function produceLinkUnitaryIndexArbitrary(
 }
 
 /** @internal */
-function computeLinkIndex(
+function buildLinkIndexArbitrary(
   arity: Exclude<Arity, 'inverse'>,
   strategy: Strategy,
   currentIndexIfSameType: number | undefined,
   countInTargetType: number,
   currentEntityDepth: DepthIdentifier,
-  mrng: Random,
-  biasFactor: number | undefined,
-): number[] | number | undefined {
+): Arbitrary<number[] | number | undefined> {
   const linkArbitrary = produceLinkUnitaryIndexArbitrary(strategy, currentIndexIfSameType, countInTargetType);
   switch (arity) {
     case '0-1':
-      return option(linkArbitrary, { nil: undefined, depthIdentifier: currentEntityDepth }).generate(mrng, biasFactor)
-        .value;
+      return option(linkArbitrary, { nil: undefined, depthIdentifier: currentEntityDepth });
     case '1':
-      return linkArbitrary.generate(mrng, biasFactor).value;
+      return linkArbitrary;
     case 'many': {
       let randomUnicity = 0;
-      const values = option(
+      return option(
         // given the depth does not control the size of an array, we cheat and use an option to do so
         uniqueArray(linkArbitrary, {
           depthIdentifier: currentEntityDepth, // passed just in case, but probably ignored by arrays
@@ -76,12 +75,23 @@ function computeLinkIndex(
           minLength: 1, // we handle length 0 with the option
         }),
         { nil: [], depthIdentifier: currentEntityDepth },
-      ).generate(mrng, biasFactor).value;
-      let offset = 0;
-      return safeMap(values, (v) => (v === countInTargetType ? v + offset++ : v));
+      ).map((values) => {
+        let offset = 0;
+        return safeMap(values, (v) => (v === countInTargetType ? v + offset++ : v));
+      });
     }
   }
 }
+
+/** @internal */
+type ToBeProducedEntity<TEntityFields> = { type: keyof TEntityFields; indexInType: number; depth: number };
+
+/** @internal */
+type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> = {
+  producedLinks: ProducedLinks<TEntityFields, TEntityRelations>;
+  toBeProducedEntities: ToBeProducedEntity<TEntityFields>[];
+  nextIndex: number;
+};
 
 /** @internal */
 class OnTheFlyLinksForEntityGraphArbitrary<
@@ -142,47 +152,51 @@ class OnTheFlyLinksForEntityGraphArbitrary<
     return emptyLinksInstance;
   }
 
-  generate(mrng: Random, biasFactor: number | undefined): Value<ProducedLinks<TEntityFields, TEntityRelations>> {
-    // The set of all produced links between entities.
-    const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
-    for (const name in this.relations) {
-      producedLinks[name as Extract<keyof TEntityFields, string>] = [];
-    }
-    // Made of any entity whose links have to be created before building the whole graph.
-    const toBeProducedEntities: { type: keyof TEntityFields; indexInType: number; depth: number }[] = [];
-    for (const name of this.defaultEntities) {
-      safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
-      safePush(producedLinks[name], this.createEmptyLinksInstanceFor(name));
+  private buildEntityStepArbitrary(
+    state: ProductionState<TEntityFields, TEntityRelations>,
+  ): Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
+    const { producedLinks, toBeProducedEntities, nextIndex } = state;
+    const currentEntity = toBeProducedEntities[nextIndex];
+    const currentRelations = this.relations[currentEntity.type];
+    const currentEntityDepth = createDepthIdentifier();
+    currentEntityDepth.depth = currentEntity.depth;
+
+    // Snapshot of the count of entities of each target type at the moment we start producing links
+    // for the current entity. Captured here because both the underlying arbitraries and the post
+    // processing rely on it, and the count would otherwise grow as new entities get queued.
+    const countsInTargetType: { [name: string]: number } = safeObjectCreate(null);
+    const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
+    for (const name in currentRelations) {
+      const relation = currentRelations[name];
+      if (relation.arity === 'inverse') {
+        continue;
+      }
+      const targetType = relation.type;
+      const countInTargetType = producedLinks[targetType].length;
+      countsInTargetType[name] = countInTargetType;
+      subArbitraries.push(
+        buildLinkIndexArbitrary(
+          relation.arity,
+          relation.strategy || 'any',
+          targetType === currentEntity.type ? currentEntity.indexInType : undefined,
+          countInTargetType,
+          currentEntityDepth,
+        ),
+      );
     }
 
-    // Ideally toBeProducedEntities should be a queue, but given JavaScript built-ins arrays perform badly in queue mode,
-    // we decided to consider an always growing array that will grow up to the numer of entities before being dropped.
-    let lastTreatedEntities = -1;
-    while (++lastTreatedEntities < toBeProducedEntities.length) {
-      const currentEntity = toBeProducedEntities[lastTreatedEntities];
-      const currentRelations = this.relations[currentEntity.type];
-      const currentProducedLinks = producedLinks[currentEntity.type];
-      // Create all the links going from the current entity to others
-      const currentLinks = currentProducedLinks[currentEntity.indexInType];
-      const currentEntityDepth = createDepthIdentifier();
-      currentEntityDepth.depth = currentEntity.depth;
+    return tuple<(number[] | number | undefined)[]>(...subArbitraries).map((results) => {
+      const currentLinks = producedLinks[currentEntity.type][currentEntity.indexInType];
+      let resultIndex = 0;
       for (const name in currentRelations) {
         const relation = currentRelations[name];
         if (relation.arity === 'inverse') {
           continue;
         }
         const targetType = relation.type;
+        const countInTargetType = countsInTargetType[name];
+        const linkOrLinks = results[resultIndex++];
         const producedLinksInTargetType = producedLinks[targetType];
-        const countInTargetType = producedLinksInTargetType.length;
-        const linkOrLinks = computeLinkIndex(
-          relation.arity,
-          relation.strategy || 'any',
-          targetType === currentEntity.type ? currentEntity.indexInType : undefined,
-          producedLinksInTargetType.length,
-          currentEntityDepth,
-          mrng,
-          biasFactor,
-        );
         currentLinks[name] = { type: targetType, index: linkOrLinks };
         const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
         for (const link of links) {
@@ -197,7 +211,37 @@ class OnTheFlyLinksForEntityGraphArbitrary<
           }
         }
       }
+      return { producedLinks, toBeProducedEntities, nextIndex: nextIndex + 1 };
+    });
+  }
+
+  generate(mrng: Random, biasFactor: number | undefined): Value<ProducedLinks<TEntityFields, TEntityRelations>> {
+    // The set of all produced links between entities.
+    const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
+    for (const name in this.relations) {
+      producedLinks[name as Extract<keyof TEntityFields, string>] = [];
     }
+    // Made of any entity whose links have to be created before building the whole graph.
+    const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
+    for (const name of this.defaultEntities) {
+      safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
+      safePush(producedLinks[name], this.createEmptyLinksInstanceFor(name));
+    }
+
+    // Drive the link production loop with chainUntil: at each step we produce all links for the
+    // entity at `nextIndex`. The chainer stops once all entities (including those queued during
+    // earlier steps) have been processed.
+    const initialState: ProductionState<TEntityFields, TEntityRelations> = {
+      producedLinks,
+      toBeProducedEntities,
+      nextIndex: 0,
+    };
+    chainUntil(constant(initialState), (state) => {
+      if (state.nextIndex >= state.toBeProducedEntities.length) {
+        return undefined;
+      }
+      return this.buildEntityStepArbitrary(state);
+    }).generate(mrng, biasFactor);
     // Drop any item from the array
     toBeProducedEntities.length = 0;
 

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -1,7 +1,4 @@
-import { Arbitrary } from '../../check/arbitrary/definition/Arbitrary.js';
-import { Value } from '../../check/arbitrary/definition/Value.js';
-import type { Random } from '../../random/generator/Random.js';
-import { Stream } from '../../stream/Stream.js';
+import type { Arbitrary } from '../../check/arbitrary/definition/Arbitrary.js';
 import {
   safeAdd,
   safeHas,
@@ -20,14 +17,12 @@ import { option } from '../option.js';
 import { tuple } from '../tuple.js';
 import { uniqueArray } from '../uniqueArray.js';
 import { buildInversedRelationsMapping } from './helpers/BuildInversedRelationsMapping.js';
-import type { InversedRelationsEntry } from './helpers/BuildInversedRelationsMapping.js';
 import { createDepthIdentifier, type DepthIdentifier } from './helpers/DepthContext.js';
 import type {
   Arity,
   EntityLinks,
   EntityRelations,
   ProducedLinks,
-  Relationship,
   Strategy,
 } from './interfaces/EntityGraphTypes.js';
 
@@ -94,55 +89,46 @@ type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEn
 };
 
 /** @internal */
-class OnTheFlyLinksForEntityGraphArbitrary<
-  TEntityFields,
-  TEntityRelations extends EntityRelations<TEntityFields>,
-> extends Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
-  private inversedRelations: Map<Relationship<keyof TEntityFields>, InversedRelationsEntry<TEntityFields>>;
-
-  constructor(
-    readonly relations: TEntityRelations,
-    readonly defaultEntities: (keyof TEntityFields)[],
-  ) {
-    super();
-
-    // Basic sanity checks on the relations
-    const nonExclusiveEntities = new SSet<keyof TEntityRelations>();
-    const exclusiveEntities = new SSet<keyof TEntityRelations>();
-    for (const name in relations) {
-      const relationsForName = relations[name];
-      for (const fieldName in relationsForName) {
-        const relation = relationsForName[fieldName];
-        if (relation.arity === 'inverse') {
-          continue;
+export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  defaultEntities: (keyof TEntityFields)[],
+): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
+  // Basic sanity checks on the relations
+  const nonExclusiveEntities = new SSet<keyof TEntityRelations>();
+  const exclusiveEntities = new SSet<keyof TEntityRelations>();
+  for (const name in relations) {
+    const relationsForName = relations[name];
+    for (const fieldName in relationsForName) {
+      const relation = relationsForName[fieldName];
+      if (relation.arity === 'inverse') {
+        continue;
+      }
+      if (relation.strategy === 'exclusive') {
+        if (safeHas(nonExclusiveEntities, relation.type)) {
+          throw new SError(`Cannot mix exclusive with other strategies for type ${SString(relation.type)}`);
         }
-        if (relation.strategy === 'exclusive') {
-          if (safeHas(nonExclusiveEntities, relation.type)) {
-            throw new SError(`Cannot mix exclusive with other strategies for type ${SString(relation.type)}`);
-          }
-          safeAdd(exclusiveEntities, relation.type);
-        } else {
-          if (safeHas(exclusiveEntities, relation.type)) {
-            throw new SError(`Cannot mix exclusive with other strategies for type ${SString(relation.type)}`);
-          }
-          safeAdd(nonExclusiveEntities, relation.type);
+        safeAdd(exclusiveEntities, relation.type);
+      } else {
+        if (safeHas(exclusiveEntities, relation.type)) {
+          throw new SError(`Cannot mix exclusive with other strategies for type ${SString(relation.type)}`);
         }
-        if (relation.strategy === 'successor' && relation.type !== (name as keyof TEntityRelations)) {
-          throw new SError(`Cannot mix types for the strategy successor`);
-        }
-        if (relation.strategy === 'successor' && relation.arity === '1') {
-          throw new SError(`Cannot use an arity of 1 for the strategy successor`);
-        }
+        safeAdd(nonExclusiveEntities, relation.type);
+      }
+      if (relation.strategy === 'successor' && relation.type !== (name as keyof TEntityRelations)) {
+        throw new SError(`Cannot mix types for the strategy successor`);
+      }
+      if (relation.strategy === 'successor' && relation.arity === '1') {
+        throw new SError(`Cannot use an arity of 1 for the strategy successor`);
       }
     }
-
-    // Building inversed relations map
-    this.inversedRelations = buildInversedRelationsMapping(relations);
   }
 
-  createEmptyLinksInstanceFor(targetType: keyof TEntityFields): EntityLinks<TEntityFields, TEntityRelations> {
+  // Building inversed relations map
+  const inversedRelations = buildInversedRelationsMapping(relations);
+
+  function createEmptyLinksInstanceFor(targetType: keyof TEntityFields): EntityLinks<TEntityFields, TEntityRelations> {
     const emptyLinksInstance = safeObjectCreate(null);
-    const relationsForType = this.relations[targetType];
+    const relationsForType = relations[targetType];
     for (const name in relationsForType) {
       const relation = relationsForType[name];
       if (relation.arity === 'inverse') {
@@ -152,12 +138,12 @@ class OnTheFlyLinksForEntityGraphArbitrary<
     return emptyLinksInstance;
   }
 
-  private buildEntityStepArbitrary(
+  function buildEntityStepArbitrary(
     state: ProductionState<TEntityFields, TEntityRelations>,
   ): Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
     const { producedLinks, toBeProducedEntities, nextIndex } = state;
     const currentEntity = toBeProducedEntities[nextIndex];
-    const currentRelations = this.relations[currentEntity.type];
+    const currentRelations = relations[currentEntity.type];
     const currentEntityDepth = createDepthIdentifier();
     currentEntityDepth.depth = currentEntity.depth;
 
@@ -202,9 +188,9 @@ class OnTheFlyLinksForEntityGraphArbitrary<
         for (const link of links) {
           if (link >= countInTargetType) {
             safePush(toBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
-            safePush(producedLinksInTargetType, this.createEmptyLinksInstanceFor(targetType));
+            safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(targetType));
           }
-          const inversed = safeMapGet(this.inversedRelations, relation);
+          const inversed = safeMapGet(inversedRelations, relation);
           if (inversed !== undefined) {
             const knownInversedLinks = producedLinksInTargetType[link][inversed.property].index;
             safePush(knownInversedLinks as number[], currentEntity.indexInType);
@@ -215,55 +201,25 @@ class OnTheFlyLinksForEntityGraphArbitrary<
     });
   }
 
-  generate(mrng: Random, biasFactor: number | undefined): Value<ProducedLinks<TEntityFields, TEntityRelations>> {
-    // The set of all produced links between entities.
+  // Initial state arbitrary: rebuilds a fresh state on every generate call so that calls do not
+  // share their `producedLinks` / `toBeProducedEntities` arrays.
+  const initialStateArb = constant(undefined).map<ProductionState<TEntityFields, TEntityRelations>>(() => {
     const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
-    for (const name in this.relations) {
+    for (const name in relations) {
       producedLinks[name as Extract<keyof TEntityFields, string>] = [];
     }
-    // Made of any entity whose links have to be created before building the whole graph.
     const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
-    for (const name of this.defaultEntities) {
+    for (const name of defaultEntities) {
       safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
-      safePush(producedLinks[name], this.createEmptyLinksInstanceFor(name));
+      safePush(producedLinks[name], createEmptyLinksInstanceFor(name));
     }
+    return { producedLinks, toBeProducedEntities, nextIndex: 0 };
+  });
 
-    // Drive the link production loop with chainUntil: at each step we produce all links for the
-    // entity at `nextIndex`. The chainer stops once all entities (including those queued during
-    // earlier steps) have been processed.
-    const initialState: ProductionState<TEntityFields, TEntityRelations> = {
-      producedLinks,
-      toBeProducedEntities,
-      nextIndex: 0,
-    };
-    chainUntil(constant(initialState), (state) => {
-      if (state.nextIndex >= state.toBeProducedEntities.length) {
-        return undefined;
-      }
-      return this.buildEntityStepArbitrary(state);
-    }).generate(mrng, biasFactor);
-    // Drop any item from the array
-    toBeProducedEntities.length = 0;
-
-    return new Value(producedLinks, undefined);
-  }
-
-  canShrinkWithoutContext(_value: unknown): _value is ProducedLinks<TEntityFields, TEntityRelations> {
-    return false; // for now, we reject any shrink without context
-  }
-
-  shrink(
-    _value: ProducedLinks<TEntityFields, TEntityRelations>,
-    _context: unknown | undefined,
-  ): Stream<Value<ProducedLinks<TEntityFields, TEntityRelations>>> {
-    return Stream.nil(); // for now, we don't support any shrink
-  }
-}
-
-/** @internal */
-export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  relations: TEntityRelations,
-  defaultEntities: (keyof TEntityFields)[],
-): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
-  return new OnTheFlyLinksForEntityGraphArbitrary(relations, defaultEntities);
+  return chainUntil(initialStateArb, (state) => {
+    if (state.nextIndex >= state.toBeProducedEntities.length) {
+      return undefined;
+    }
+    return buildEntityStepArbitrary(state);
+  }).map((state) => state.producedLinks);
 }

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -83,6 +83,96 @@ type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEn
 };
 
 /** @internal */
+function createEmptyLinksInstanceFor<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  targetType: keyof TEntityFields,
+): EntityLinks<TEntityFields, TEntityRelations> {
+  const emptyLinksInstance = safeObjectCreate(null);
+  const relationsForType = relations[targetType];
+  for (const name in relationsForType) {
+    const relation = relationsForType[name];
+    if (relation.arity === 'inverse') {
+      emptyLinksInstance[name] = { type: relation.type, index: [] };
+    }
+  }
+  return emptyLinksInstance;
+}
+
+/** @internal */
+function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
+  state: ProductionState<TEntityFields, TEntityRelations>,
+): Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
+  const { producedLinks, toBeProducedEntities, nextIndex } = state;
+  const currentEntity = toBeProducedEntities[nextIndex];
+  const currentRelations = relations[currentEntity.type];
+  const currentEntityDepth = createDepthIdentifier();
+  currentEntityDepth.depth = currentEntity.depth;
+
+  // Snapshot of the count of entities of each target type at the moment we start producing links
+  // for the current entity. Captured here because both the underlying arbitraries and the post
+  // processing rely on it, and the count would otherwise grow as new entities get queued.
+  const countsInTargetType: { [name: string]: number } = safeObjectCreate(null);
+  const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
+  for (const name in currentRelations) {
+    const relation = currentRelations[name];
+    if (relation.arity === 'inverse') {
+      continue;
+    }
+    const targetType = relation.type;
+    const countInTargetType = producedLinks[targetType].length;
+    countsInTargetType[name] = countInTargetType;
+    subArbitraries.push(
+      buildLinkIndexArbitrary(
+        relation.arity,
+        relation.strategy || 'any',
+        targetType === currentEntity.type ? currentEntity.indexInType : undefined,
+        countInTargetType,
+        currentEntityDepth,
+      ),
+    );
+  }
+
+  return tuple<(number[] | number | undefined)[]>(...subArbitraries).map((results) => {
+    const currentLinks = producedLinks[currentEntity.type][currentEntity.indexInType];
+    let resultIndex = 0;
+    let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
+    for (const name in currentRelations) {
+      const relation = currentRelations[name];
+      if (relation.arity === 'inverse') {
+        continue;
+      }
+      const targetType = relation.type;
+      const countInTargetType = countsInTargetType[name];
+      const linkOrLinks = results[resultIndex++];
+      const producedLinksInTargetType = producedLinks[targetType];
+      currentLinks[name] = { type: targetType, index: linkOrLinks };
+      const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
+      for (const link of links) {
+        if (link >= countInTargetType) {
+          if (newToBeProducedEntities === undefined) {
+            newToBeProducedEntities = [...toBeProducedEntities];
+          }
+          safePush(newToBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
+          safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(relations, targetType));
+        }
+        const inversed = safeMapGet(inversedRelations, relation);
+        if (inversed !== undefined) {
+          const knownInversedLinks = producedLinksInTargetType[link][inversed.property].index;
+          safePush(knownInversedLinks as number[], currentEntity.indexInType);
+        }
+      }
+    }
+    return {
+      producedLinks,
+      toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
+      nextIndex: nextIndex + 1,
+    };
+  });
+}
+
+/** @internal */
 export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
   defaultEntities: (keyof TEntityFields)[],
@@ -117,92 +207,7 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
     }
   }
 
-  // Building inversed relations map
-  const inversedRelations = buildInversedRelationsMapping(relations);
-
-  function createEmptyLinksInstanceFor(targetType: keyof TEntityFields): EntityLinks<TEntityFields, TEntityRelations> {
-    const emptyLinksInstance = safeObjectCreate(null);
-    const relationsForType = relations[targetType];
-    for (const name in relationsForType) {
-      const relation = relationsForType[name];
-      if (relation.arity === 'inverse') {
-        emptyLinksInstance[name] = { type: relation.type, index: [] };
-      }
-    }
-    return emptyLinksInstance;
-  }
-
-  function buildEntityStepArbitrary(
-    state: ProductionState<TEntityFields, TEntityRelations>,
-  ): Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
-    const { producedLinks, toBeProducedEntities, nextIndex } = state;
-    const currentEntity = toBeProducedEntities[nextIndex];
-    const currentRelations = relations[currentEntity.type];
-    const currentEntityDepth = createDepthIdentifier();
-    currentEntityDepth.depth = currentEntity.depth;
-
-    // Snapshot of the count of entities of each target type at the moment we start producing links
-    // for the current entity. Captured here because both the underlying arbitraries and the post
-    // processing rely on it, and the count would otherwise grow as new entities get queued.
-    const countsInTargetType: { [name: string]: number } = safeObjectCreate(null);
-    const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
-    for (const name in currentRelations) {
-      const relation = currentRelations[name];
-      if (relation.arity === 'inverse') {
-        continue;
-      }
-      const targetType = relation.type;
-      const countInTargetType = producedLinks[targetType].length;
-      countsInTargetType[name] = countInTargetType;
-      subArbitraries.push(
-        buildLinkIndexArbitrary(
-          relation.arity,
-          relation.strategy || 'any',
-          targetType === currentEntity.type ? currentEntity.indexInType : undefined,
-          countInTargetType,
-          currentEntityDepth,
-        ),
-      );
-    }
-
-    return tuple<(number[] | number | undefined)[]>(...subArbitraries).map((results) => {
-      const currentLinks = producedLinks[currentEntity.type][currentEntity.indexInType];
-      let resultIndex = 0;
-      let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
-      for (const name in currentRelations) {
-        const relation = currentRelations[name];
-        if (relation.arity === 'inverse') {
-          continue;
-        }
-        const targetType = relation.type;
-        const countInTargetType = countsInTargetType[name];
-        const linkOrLinks = results[resultIndex++];
-        const producedLinksInTargetType = producedLinks[targetType];
-        currentLinks[name] = { type: targetType, index: linkOrLinks };
-        const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
-        for (const link of links) {
-          if (link >= countInTargetType) {
-            if (newToBeProducedEntities === undefined) {
-              newToBeProducedEntities = [...toBeProducedEntities];
-            }
-            safePush(newToBeProducedEntities, { type: targetType, indexInType: link, depth: currentEntity.depth + 1 }); // indexInType should be equal to producedLinksInTargetType.length
-            safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(targetType));
-          }
-          const inversed = safeMapGet(inversedRelations, relation);
-          if (inversed !== undefined) {
-            const knownInversedLinks = producedLinksInTargetType[link][inversed.property].index;
-            safePush(knownInversedLinks as number[], currentEntity.indexInType);
-          }
-        }
-      }
-      return {
-        producedLinks,
-        toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
-        nextIndex: nextIndex + 1,
-      };
-    });
-  }
-
+  // Building initial state
   const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
   for (const name in relations) {
     producedLinks[name as Extract<keyof TEntityFields, string>] = [];
@@ -210,18 +215,21 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
   const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
   for (const name of defaultEntities) {
     safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
-    safePush(producedLinks[name], createEmptyLinksInstanceFor(name));
+    safePush(producedLinks[name], createEmptyLinksInstanceFor(relations, name));
   }
   const initialProductionState: ProductionState<TEntityFields, TEntityRelations> = {
     producedLinks,
     toBeProducedEntities,
     nextIndex: 0,
   };
+
+  // Building all relations
+  const inversedRelations = buildInversedRelationsMapping(relations);
   const initialStateArb = constant(initialProductionState);
   return chainUntil(initialStateArb, (state) => {
     if (state.nextIndex >= state.toBeProducedEntities.length) {
       return undefined;
     }
-    return buildEntityStepArbitrary(state);
+    return buildEntityStepArbitrary(relations, inversedRelations, state);
   }).map((state) => state.producedLinks);
 }

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -110,9 +110,6 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
   const currentEntityDepth = createDepthIdentifier();
   currentEntityDepth.depth = currentEntity.depth;
 
-  // Snapshot of the count of entities of each target type at the moment we start producing links
-  // for the current entity. Captured here because both the underlying arbitraries and the post
-  // processing rely on it, and the count would otherwise grow as new entities get queued.
   const countsInTargetType: { [name: string]: number } = safeObjectCreate(null);
   const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
   for (const name in currentRelations) {
@@ -173,10 +170,9 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
 }
 
 /** @internal */
-export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+export function assertAcceptableRelations<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
-  defaultEntities: (keyof TEntityFields)[],
-): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
+): void {
   // Basic sanity checks on the relations
   const nonExclusiveEntities = new SSet<keyof TEntityRelations>();
   const exclusiveEntities = new SSet<keyof TEntityRelations>();
@@ -206,8 +202,13 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
       }
     }
   }
+}
 
-  // Building initial state
+/** @internal */
+function buildInitialProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  defaultEntities: (keyof TEntityFields)[],
+): ProductionState<TEntityFields, TEntityRelations> {
   const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
   for (const name in relations) {
     producedLinks[name as Extract<keyof TEntityFields, string>] = [];
@@ -217,15 +218,18 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
     safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
     safePush(producedLinks[name], createEmptyLinksInstanceFor(relations, name));
   }
-  const initialProductionState: ProductionState<TEntityFields, TEntityRelations> = {
-    producedLinks,
-    toBeProducedEntities,
-    nextIndex: 0,
-  };
+  return { producedLinks, toBeProducedEntities, nextIndex: 0 };
+}
 
-  // Building all relations
+/** @internal */
+export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  defaultEntities: (keyof TEntityFields)[],
+): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
+  assertAcceptableRelations(relations);
+
   const inversedRelations = buildInversedRelationsMapping(relations);
-  const initialStateArb = constant(initialProductionState);
+  const initialStateArb = constant(buildInitialProductionState(relations, defaultEntities));
   return chainUntil(initialStateArb, (state) => {
     if (state.nextIndex >= state.toBeProducedEntities.length) {
       return undefined;


### PR DESCRIPTION
Replace the manual queue-walking loop in `OnTheFlyLinksForEntityGraphArbitrary`
with a `chainUntil` that processes one queued entity per step, building the
relation arbitraries up front and applying their results in a `tuple().map()`.