### PR TITLE
✅ Fix poisoning tests for latest Node

### DIFF
--- a/packages/fast-check/test/e2e/Poisoning.spec.ts
+++ b/packages/fast-check/test/e2e/Poisoning.spec.ts
@@ -281,6 +281,10 @@ function dropMainGlobals(): () => void {
     typeof AsyncDisposableStack !== 'undefined' ? AsyncDisposableStack : undefined,
     typeof Float16Array !== 'undefined' ? Float16Array : undefined,
     typeof Storage !== 'undefined' ? Storage : undefined,
+    // @ts-expect-error Unknown for TypeScript given our current compilation options
+    typeof QuotaExceededError !== 'undefined' ? QuotaExceededError : undefined,
+    // @ts-expect-error Unknown for TypeScript given our current compilation options
+    typeof Temporal !== 'undefined' ? Temporal : undefined,
   ].filter((mainGlobal) => mainGlobal !== undefined);
   const skippedGlobals = new Set(['Array']);
   const allAccessibleGlobals = Object.keys(Object.getOwnPropertyDescriptors(globalThis)).filter(


### PR DESCRIPTION
Recent Node.js versions expose QuotaExceededError and Temporal as
globals, causing the dropMainGlobals helper to flag them as missing
from the known list and fail the e2e poisoning suite.