### PR TITLE
✅(jest) Drop `babel-jest` from cjs test-bundle

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "rolldown -c && cp package.cjs-template.json lib/cjs/package.json && cp lib/*.d.ts lib/cjs/",
     "build-ci": "rolldown -c && cp package.cjs-template.json lib/cjs/package.json && cp lib/*.d.ts lib/cjs/",
-    "test-bundle:cjs": "jest --config test-bundle/cjs/jest.config.cjs",
+    "test-bundle:cjs": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config test-bundle/cjs/jest.config.cjs",
     "test-bundle:mjs": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config test-bundle/mjs/jest.config.mjs",
     "test-bundle": "pnpm run test-bundle:cjs && pnpm run test-bundle:mjs",
     "typecheck": "tsc --noEmit"

--- a/packages/jest/test-bundle/cjs/babel.config.cjs
+++ b/packages/jest/test-bundle/cjs/babel.config.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]],
-};

--- a/packages/jest/test-bundle/cjs/jest.config.cjs
+++ b/packages/jest/test-bundle/cjs/jest.config.cjs
@@ -1,8 +1,4 @@
 module.exports = {
   testMatch: ['<rootDir>/*.spec.cjs'],
   testTimeout: 20_000,
-  transform: {
-    '^.+\\.[t|j]sx?$': 'babel-jest',
-  },
-  transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'],
 };


### PR DESCRIPTION
Jest 30 now supports require(esm) on Node v24.9+, so the babel-jest
transform that converted @fast-check/worker (ESM-only) into CJS for
the CJS bundle test is no longer needed. The test-bundle job in CI
already runs on Node 24.x; switching the script to --experimental-vm-modules
unlocks Jest's native require(esm) path.