### PR TITLE
🐛 Restore ability not to use `skipLibCheck`

### DIFF
--- a/.changeset/popular-oranges-glow.md
+++ b/.changeset/popular-oranges-glow.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+🐛 Avoid `!` definite assignment in published d.ts for `Value`

--- a/packages/fast-check/src/check/arbitrary/definition/Value.ts
+++ b/packages/fast-check/src/check/arbitrary/definition/Value.ts
@@ -29,7 +29,7 @@ export class Value<T> {
    * Depending on `hasToBeCloned` it will either be `value_` or a clone of it
    * @remarks Since 2.15.0
    */
-  readonly value!: T;
+  declare readonly value: T;
   /**
    * Internal value of the shrinkable
    * @remarks Since 2.15.0

--- a/packages/fast-check/src/check/arbitrary/definition/Value.ts
+++ b/packages/fast-check/src/check/arbitrary/definition/Value.ts
@@ -54,7 +54,11 @@ export class Value<T> {
     this.readOnce = false;
     this.value = value_;
     if (this.hasToBeCloned) {
-      safeObjectDefineProperty(this, 'value', { get: customGetValue !== undefined ? customGetValue : this.getValue });
+      safeObjectDefineProperty(this, 'value', {
+        get: customGetValue !== undefined ? customGetValue : this.getValue,
+        enumerable: false,
+        configurable: false,
+      });
     }
   }
 

--- a/packages/fast-check/src/check/arbitrary/definition/Value.ts
+++ b/packages/fast-check/src/check/arbitrary/definition/Value.ts
@@ -29,7 +29,7 @@ export class Value<T> {
    * Depending on `hasToBeCloned` it will either be `value_` or a clone of it
    * @remarks Since 2.15.0
    */
-  declare readonly value: T;
+  readonly value: T;
   /**
    * Internal value of the shrinkable
    * @remarks Since 2.15.0
@@ -52,10 +52,9 @@ export class Value<T> {
     this.context = context;
     this.hasToBeCloned = customGetValue !== undefined || hasCloneMethod(value_);
     this.readOnce = false;
+    this.value = value_;
     if (this.hasToBeCloned) {
       safeObjectDefineProperty(this, 'value', { get: customGetValue !== undefined ? customGetValue : this.getValue });
-    } else {
-      this.value = value_;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #6945

Restores fast-check's ability to compile under `tsc --noEmit` without `skipLibCheck: true`. From v4.7.0 onward the bundled `lib/cjs/fast-check.d.ts` (and its sibling `lib/fast-check.d.ts`, `lib/types57/…` variants) emitted `readonly value!: T;` on the `Value<T>` class, which TypeScript rejects in declaration files with `error TS1255: A definite assignment assertion '!' is not permitted in this context.` After this PR the same line is emitted as `readonly value: T;` and the exact repro from #6945 — `tsc --noEmit --ignoreConfig node_modules/fast-check/lib/cjs/fast-check.d.ts` — exits 0 under TypeScript 6.0.3.

### What's actually changed

A single source file is touched: `packages/fast-check/src/check/arbitrary/definition/Value.ts`.

1. The declaration was `readonly value!: T;`. The `!` (definite-assignment assertion) was needed because TypeScript's flow analysis can't see the `Object.defineProperty(this, 'value', { get })` path taken in the cloned branch of the constructor. It now becomes `readonly value: T;` — no `!`, no `declare`, no `// @ts-expect-error`.
2. The constructor now assigns `this.value = value_;` unconditionally up-front, which is what convinces TypeScript that the property is initialised. The `if (this.hasToBeCloned)` branch then reconfigures the property via `safeObjectDefineProperty`.
3. The `defineProperty` call now passes `enumerable: false, configurable: false` explicitly. Without those, the redefined accessor would inherit the data-property attributes from the just-set field and end up `enumerable: true, configurable: true`, whereas the previous code produced an accessor with `enumerable: false, configurable: false` (the `Object.defineProperty` defaults when creating a fresh property). Verified with `Object.getOwnPropertyDescriptor` — the descriptor is byte-for-byte identical to pre-PR behaviour for both cloned and non-cloned `Value` instances.

### Root cause

This isn't a misuse on the user's side, it is a real regression in fast-check 4.7.0. Bisecting between `v4.6.0` (good) and `v4.7.0` (bad) identified the first bad commit as `89ee23df` ("⬆️ Update dependency rolldown to ^1.0.0-rc.10", #6748). Nothing else relevant changed in that commit — no `Value.ts` diff, no `rolldown-plugin-dts` upgrade, no TypeScript upgrade.

`rolldown@1.0.0-rc.10` bumped its embedded oxc from `0.115.0` → `0.120.0` (visible as `@oxc-project/types` in the lockfile diff at that commit). That range includes [oxc-project/oxc#19785](https://github.com/oxc-project/oxc/pull/19785) — *"fix(codegen): print `definite` property on PropertyDefinition"* (camc314, 2026-02-27, first released in oxc `0.116.0`), with sibling [#19786](https://github.com/oxc-project/oxc/pull/19786) doing the same for `AccessorProperty`. The PR added the equivalent of:

```rust
if self.definite {
    p.print_ascii_byte(b'!');
}
```

to the codegen for property definitions, intentionally so that `subscribe!: string;` round-trips through TS→TS. The unintended side effect is that `oxc_isolated_declarations` (the `.ts → .d.ts` transformer used by `rolldown-plugin-dts`) copies `property.definite` straight through from the source AST into the declaration AST, and the freshly-fixed codegen now prints the `!` into `.d.ts` files — which is invalid TypeScript (TS1255 is raised by every TypeScript version I tested, 4.9 → 6.0.3).

The bug is still live upstream at the time of writing — `rolldown@1.0.0` (current stable, in this repo's lockfile) and `rolldown-plugin-dts@0.25.0` still emit the `!`. I checked rolldown and rolldown-plugin-dts issue trackers and found no existing report. A proper upstream fix is a one-liner in `crates/oxc_isolated_declarations/src/class.rs` forcing `definite: false` on the generated `class_element_property_definition` / `class_element_accessor_property` calls; worth raising separately.

### About the original repro command

The reporter ran `tsc --noEmit --ignoreConfig <…>/fast-check.d.ts`, which is unusual — it asks TS to type-check the declaration file directly with no `tsconfig.json` applied, which means `skipLibCheck` defaults to `false`. That makes the repro minimal but the underlying bug is real for any consumer project whose tsconfig doesn't set `skipLibCheck: true`. Most modern templates set it (which is presumably why the regression slipped through 4.7.0's release), but plenty of strict projects don't.

### Design choice

Three alternatives were considered for getting rid of the `!`:
- `declare readonly value: T;` — works, but introduces a `declare` modifier solely as a workaround.
- `// @ts-expect-error` above the field — works, but replaces one suppression token with another.
- Unconditional init + `Object.defineProperty` reconfiguration (this PR) — no special modifier, no suppression comment, and with the explicit `enumerable: false, configurable: false` flags the runtime property descriptor is preserved exactly.

### Impact, scope, tests

- **Impact level**: patch — pure bug fix, no API surface change, runtime property descriptor preserved byte-for-byte.
- **Scope**: single concern, single file (`Value.ts`).
- **Tests**: existing `packages/fast-check/test/unit/check/arbitrary/definition/NextValue.utest.spec.ts` covers `Value`'s read-through and clone behaviour and still passes. I did not add a new regression test because the actual regression lives in the bundled `.d.ts`, not in runtime behaviour, and a build-output assertion fits more naturally as a CI check (e.g. "the published `.d.ts` files must not contain `value!:`") than as a unit test. End-to-end verification was done manually: `pnpm run build` → `grep -n "value!:" lib/cjs/fast-check.d.ts lib/fast-check.d.ts lib/types57/* lib/cjs/types57/*` returns no matches → the user's exact command `tsc --noEmit --ignoreConfig packages/fast-check/lib/cjs/fast-check.d.ts` exits 0 under TS 6.0.3.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
