### PR TITLE
🔒️ Pass `--ignore-scripts` to `pnpm i` calls

### DIFF
--- a/.claude/check-code.sh
+++ b/.claude/check-code.sh
@@ -10,7 +10,7 @@ if ! command -v pnpm &>/dev/null; then
 fi
 
 echo "Installing dependencies with pnpm..."
-if ! pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile 2>&1; then
+if ! pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile --ignore-scripts 2>&1; then
   ERRORS+="Dependency install failed. "
 fi
 

--- a/.claude/session-start.sh
+++ b/.claude/session-start.sh
@@ -14,4 +14,4 @@ fi
 # Install/sync dependencies — always run to ensure node_modules matches the lockfile
 # (e.g. after a dependency version bump, node_modules may exist but be stale)
 echo "Installing dependencies with pnpm..."
-pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile
+pnpm -C "$CLAUDE_PROJECT_DIR" install --frozen-lockfile --ignore-scripts

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -2,4 +2,4 @@
 set -x
 
 # Install locked dependencies
-pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Configure GIT
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -40,7 +40,7 @@ jobs:
           cache: 'pnpm'
       - name: Update pnpm cache
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
   warmup_pnpm_cache_others:
     name: 'Warm up pnpm cache (others)'
     if: github.event_name == 'push' || github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || (github.event.action == 'labeled' && github.event.label.name == 'force-build-status-execution')
@@ -62,7 +62,7 @@ jobs:
           cache: 'pnpm'
       - name: Update pnpm cache
         if: steps.pnpm-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
   # Jobs without any strong requirement on warmup_pnpm_cache
   # except that they have to wait for it to avoid setting an empty cache that would replace the one pushed by warmup_pnpm_cache
@@ -119,7 +119,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm --filter @fast-check/monorepo install --frozen-lockfile
+        run: pnpm --filter @fast-check/monorepo install --frozen-lockfile --ignore-scripts
       - name: Check format
         run: node --run format:check
       - name: Check lint
@@ -140,7 +140,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build production packages
         run: node --run build-ci:all
       - name: Create bundles
@@ -172,7 +172,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -202,7 +202,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -270,7 +270,7 @@ jobs:
           node-version: ${{matrix.node-version}}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -346,7 +346,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm --filter website install --frozen-lockfile
+        run: pnpm --filter website install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -396,7 +396,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -459,7 +459,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check current branch info
         env:
           PR_NUMBER: ${{ github.event.inputs.ref_value }}

--- a/.github/workflows/pr-pnpm-conflicts.yml
+++ b/.github/workflows/pr-pnpm-conflicts.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Regenerate pnpm-lock.yaml
         run: |
           echo "Regenerating pnpm-lock.yaml..."
-          pnpm install --lockfile-only
+          pnpm install --lockfile-only --ignore-scripts
       - name: Commit lock file changes
         env:
           WORKFLOW_NAME: ${{ github.workflow }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ In order to start playing with the code locally you must run the following set o
 
 ```bash
 git clone https://github.com/dubzzz/fast-check.git && cd fast-check
-pnpm install --ignore-scripts
+pnpm install
 pnpm --filter fast-check build    #compile the code in packages/fast-check/src, build the packages/fast-check/lib content
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ In order to start playing with the code locally you must run the following set o
 
 ```bash
 git clone https://github.com/dubzzz/fast-check.git && cd fast-check
-pnpm install
+pnpm install --ignore-scripts
 pnpm --filter fast-check build    #compile the code in packages/fast-check/src, build the packages/fast-check/lib content
 ```
 


### PR DESCRIPTION
## Description

Adds `--ignore-scripts` to every `pnpm install` invocation run in automated environments — CI workflows (`build-status.yml`, `pr-format.yml`, `pr-pnpm-conflicts.yml`, `add-contributor.yml`), the devcontainer post-create script, and the Claude hook scripts in `.claude/`. The `--lockfile-only` call in `pr-pnpm-conflicts.yml` also receives the flag for consistency, even though that command does not execute lifecycle scripts in practice.

End-user impact: no behavioral change for fast-check consumers — published packages are untouched. The change hardens the project's own build/CI surface by preventing arbitrary lifecycle scripts from third-party dependencies from running during dependency installation, reducing exposure to supply-chain attacks.

Why this design: `--ignore-scripts` is the canonical pnpm flag for skipping `preinstall` / `install` / `postinstall` / `prepare` hooks during install. It's safe to combine with `--frozen-lockfile` (and with `--lockfile-only`, where it is a no-op). The `CONTRIBUTING.md` snippet documenting local setup was intentionally left untouched: local contributors may legitimately depend on lifecycle scripts running during their first install, and the security benefit is targeted at automated environments where we control the input.

Trade-off: if any current or future dependency genuinely needs a lifecycle script to function (e.g. native module compilation), CI will fail until that dependency is allow-listed via pnpm's `onlyBuiltDependencies` (or similar). No such failure is currently observed.

Impact: patch — CI/devtool configuration only, no published-code change, no changeset needed.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->