### PR TITLE
👷 Drop caches from publication steps

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -604,6 +604,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -680,6 +681,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -756,6 +758,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -832,6 +835,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -908,6 +912,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -984,6 +989,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1060,6 +1066,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          cache: ''
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -604,7 +604,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -681,7 +681,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -758,7 +758,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -835,7 +835,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -912,7 +912,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -989,7 +989,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1066,7 +1066,7 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
-          cache: ''
+          cache: '' # explicitly disable package manager caching on publication steps
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,10 +9,10 @@ rules:
     ignore:
       # These are false positives - attestations ensure artifact integrity
       # setup-node actions in publish jobs followed by gh-release for attestation uploads
-      - build-status.yml:602 # fast-check
-      - build-status.yml:678 # ava
-      - build-status.yml:754 # jest
-      - build-status.yml:830 # packaged
-      - build-status.yml:906 # poisoning
-      - build-status.yml:982 # vitest
-      - build-status.yml:1058 # worker
+      - build-status.yml:603 # fast-check
+      - build-status.yml:680 # ava
+      - build-status.yml:757 # jest
+      - build-status.yml:834 # packaged
+      - build-status.yml:911 # poisoning
+      - build-status.yml:988 # vitest
+      - build-status.yml:1065 # worker


### PR DESCRIPTION
## Description

<!-- Describe your change and explain what this PR is trying to solve -->

The seven `Publish *` jobs in the **Build Status** workflow now explicitly opt out of any package manager caching by setting `cache: ''` on their `actions/setup-node` step. Previously the input was simply omitted, which had the same effect at runtime but left the intent implicit — a future contributor could re-introduce `cache: 'pnpm'` without realising the no-cache choice was deliberate. Each new line carries an inline comment documenting why caching is disabled.

The change applies uniformly to every publication job (`publish_package_fc`, `publish_package_ava`, `publish_package_jest`, `publish_package_packaged`, `publish_package_poisoning`, `publish_package_vitest`, `publish_package_worker`). For the Node.js install itself, `actions/setup-node` exposes no flag to disable its internal tool-cache, so nothing further can be done there — consistent with the "if there exist flags" caveat in the original ask.

The companion change updates `.github/zizmor.yml` so the `cache-poisoning` ignore list follows the line shift introduced by the new `cache: ''` lines. The references now point at the `with:` block of each publish job's `setup-node` step — which is the location zizmor reports — and `zizmor --config .github/zizmor.yml .` runs clean locally.

<!-- Add any additional context here -->

Impact is **patch**: CI-only hardening, no runtime or public-API surface is touched. Scope is intentionally narrow — only `.github/workflows/build-status.yml` and `.github/zizmor.yml` change, both in service of the same goal. No automated tests apply; correctness was verified by running zizmor locally against the updated workflow.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->