### PR TITLE
👷 Make zizmor audit a required status check

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,21 +17,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   audit:
     name: 'Audit GitHub Actions workflows'
     if: github.event_name == 'push' || github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || (github.event.action == 'labeled' && github.event.label.name == 'force-build-status-execution')
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
-        with:
-          config: .github/zizmor.yml
-          version: 1.24.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,6 +2,7 @@ name: Workflow Security Audit
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
       - 'next-*_*_*'
@@ -22,6 +23,7 @@ permissions:
 jobs:
   audit:
     name: 'Audit GitHub Actions workflows'
+    if: github.event_name == 'push' || github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || (github.event.action == 'labeled' && github.event.label.name == 'force-build-status-execution')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   audit:
@@ -34,4 +35,3 @@ jobs:
         with:
           config: .github/zizmor.yml
           version: 1.24.1
-          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,17 +6,11 @@ on:
       - main
       - 'next-*_*_*'
       - 'fix-v*'
-    paths:
-      - '.github/workflows/**'
-      - '.github/zizmor.yml'
   push:
     branches:
       - main
       - 'next-*_*_*'
       - 'fix-v*'
-    paths:
-      - '.github/workflows/**'
-      - '.github/zizmor.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +27,36 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: Detect workflow changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$BASE_SHA"
+            head="$HEAD_SHA"
+          else
+            base="$BEFORE_SHA"
+            head="$AFTER_SHA"
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "Cannot determine base SHA, will run audit"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$base" "$head" -- '.github/workflows/' '.github/zizmor.yml' | grep -q .; then
+            echo "Workflow files changed, will run audit"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No workflow files changed, skipping audit steps"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install zizmor
+        if: steps.changes.outputs.should_run == 'true'
         run: pipx install zizmor==1.18.0
       - name: Run zizmor
+        if: steps.changes.outputs.should_run == 'true'
         run: zizmor --config .github/zizmor.yml .

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,36 +27,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          fetch-depth: 0
-      - name: Detect workflow changes
-        id: changes
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BEFORE_SHA: ${{ github.event.before }}
-          AFTER_SHA: ${{ github.sha }}
-        run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            base="$BASE_SHA"
-            head="$HEAD_SHA"
-          else
-            base="$BEFORE_SHA"
-            head="$AFTER_SHA"
-          fi
-          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
-            echo "Cannot determine base SHA, will run audit"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$base" "$head" -- '.github/workflows/' '.github/zizmor.yml' | grep -q .; then
-            echo "Workflow files changed, will run audit"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No workflow files changed, skipping audit steps"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Install zizmor
-        if: steps.changes.outputs.should_run == 'true'
-        run: pipx install zizmor==1.18.0
       - name: Run zizmor
-        if: steps.changes.outputs.should_run == 'true'
-        run: zizmor --config .github/zizmor.yml .
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          config: .github/zizmor.yml
+          version: 1.24.1
+          advanced-security: false


### PR DESCRIPTION
## Description

Make the `Audit GitHub Actions workflows` job behave like a reliable required status check so it can be wired into branch protection alongside `All checks passed`, and surface zizmor findings on the repository's Security tab.

Four connected changes to `.github/workflows/zizmor.yml`:

- Drop the `paths:` filter on `pull_request` and `push` triggers. With the filter, the workflow was skipped at the trigger level on PRs that did not touch `.github/workflows/**` or `.github/zizmor.yml`, so the status check was never reported and branch protection had nothing to wait on. The audit now runs on every PR/push to the protected branches.
- Replace the inline `pipx install zizmor==1.18.0` + manual invocation with the official `zizmorcore/zizmor-action`, pinned by full commit SHA (`b1d7e1fb5de872772f31590499237e7cce841e8e`, v0.5.3). This is safer than version-string pinning of a pip package and matches the SHA-pinning convention already used for `actions/checkout` and other actions in this repo. zizmor itself is bumped from 1.18.0 to 1.24.1 (the version bundled by the action). zizmor auto-detects `.github/zizmor.yml`, so no explicit `with:` input is needed.
- Add `labeled` to the `pull_request` trigger types and gate the `audit` job with the same `if:` condition used in `build-status.yml`, so applying the `force-build-status-execution` label re-runs the zizmor audit alongside the rest of the build status checks.
- Move to the least-privilege permission model recommended by zizmor's docs: workflow-level `permissions: {}` and job-scoped `security-events: write`. The action uploads its SARIF output to GitHub code scanning, so findings appear next to CodeQL alerts on the Security tab instead of only in the workflow log.

This is a CI-only change. There is no impact on published packages, so no changeset is required and the PR is scoped to a single concern (workflow plumbing for the zizmor audit). The audit was re-run locally against every workflow in the repo with no new findings.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
