### PR TITLE
✨ Generate bigint typed arrays in anything when withBigInt and withTypedArray are set

### DIFF
--- a/.changeset/bigint-typed-arrays-anything.md
+++ b/.changeset/bigint-typed-arrays-anything.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Generate `BigInt64Array` and `BigUint64Array` in `fc.anything` when both `withBigInt` and `withTypedArray` are enabled

--- a/packages/fast-check/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
+++ b/packages/fast-check/src/arbitrary/_internals/builders/AnyArbitraryBuilder.ts
@@ -4,6 +4,8 @@ import { stringify } from '../../../utils/stringify.js';
 import { array } from '../../array.js';
 import { oneof } from '../../oneof.js';
 import { bigInt } from '../../bigInt.js';
+import { bigInt64Array } from '../../bigInt64Array.js';
+import { bigUint64Array } from '../../bigUint64Array.js';
 import { date } from '../../date.js';
 import { float32Array } from '../../float32Array.js';
 import { float64Array } from '../../float64Array.js';
@@ -42,7 +44,7 @@ function dictOf<U>(
 }
 
 /** @internal */
-function typedArray(constraints: { maxLength: number | undefined; size: SizeForArbitrary }) {
+function typedArray(constraints: { maxLength: number | undefined; size: SizeForArbitrary }, withBigInt: boolean) {
   return oneof(
     int8Array(constraints),
     uint8Array(constraints),
@@ -53,6 +55,7 @@ function typedArray(constraints: { maxLength: number | undefined; size: SizeForA
     uint32Array(constraints),
     float32Array(constraints),
     float64Array(constraints),
+    ...(withBigInt ? [bigInt64Array(constraints), bigUint64Array(constraints)] : []),
   );
 }
 
@@ -79,7 +82,7 @@ export function anyArbitraryBuilder(constraints: QualifiedObjectConstraints): Ar
       ...(constraints.withMap ? [tie('map')] : []),
       ...(constraints.withSet ? [tie('set')] : []),
       ...(constraints.withObjectString ? [tie('anything').map((o) => stringify(o))] : []),
-      ...(constraints.withTypedArray ? [typedArray({ maxLength: maxKeys, size })] : []),
+      ...(constraints.withTypedArray ? [typedArray({ maxLength: maxKeys, size }, constraints.withBigInt)] : []),
       ...(constraints.withSparseArray
         ? [sparseArray(tie('anything'), { maxNumElements: maxKeys, size, depthIdentifier })]
         : []),

--- a/packages/fast-check/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/QualifiedObjectConstraints.ts
@@ -92,8 +92,8 @@ export interface ObjectConstraints {
    */
   withDate?: boolean;
   /**
-   * Also generate typed arrays in: (Uint|Int)(8|16|32)Array and Float(32|64)Array
-   * Remark: no typed arrays made of bigint
+   * Also generate typed arrays in: (Uint|Int)(8|16|32)Array and Float(32|64)Array.
+   * When combined with `withBigInt`, BigInt64Array and BigUint64Array are also generated.
    * @defaultValue false
    * @remarks Since 2.9.0
    */

--- a/packages/fast-check/test/e2e/GenerateAllValues.spec.ts
+++ b/packages/fast-check/test/e2e/GenerateAllValues.spec.ts
@@ -98,6 +98,8 @@ describe(`Generate all values (seed: ${seed})`, () => {
     checkCanProduce('Uint32Array', 'object', '[object Uint32Array]');
     checkCanProduce('Float32Array', 'object', '[object Float32Array]');
     checkCanProduce('Float64Array', 'object', '[object Float64Array]');
+    checkCanProduce('BigInt64Array', 'object', '[object BigInt64Array]');
+    checkCanProduce('BigUint64Array', 'object', '[object BigUint64Array]');
     checkCanProduce('null prototype object', 'object', '[object Object]', (instance: unknown) => {
       return Object.getPrototypeOf(instance) === null;
     });

--- a/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/builders/AnyArbitraryBuilder.spec.ts
@@ -44,6 +44,21 @@ describe('anyArbitraryBuilder (integration)', () => {
     );
   });
 
+  it('should be able to produce bigint typed arrays (when both withBigInt and withTypedArray are set)', () => {
+    assertProduceSomeSpecificValues(
+      () => anyArbitraryBuilder(toQualifiedObjectConstraints({ maxDepth: 1, withBigInt: true, withTypedArray: true })),
+      isBigIntTypedArray,
+    );
+  });
+
+  it('should not produce bigint typed arrays when withTypedArray is set without withBigInt', () => {
+    assertProduceCorrectValues(
+      () => anyArbitraryBuilder(toQualifiedObjectConstraints({ maxDepth: 1, withTypedArray: true })),
+      (v) => expect(isBigIntTypedArray(v)).toBe(false),
+      {},
+    );
+  });
+
   it('should be able to produce sparse array (when asked to)', () => {
     assertProduceSomeSpecificValues(
       () => anyArbitraryBuilder(toQualifiedObjectConstraints({ maxDepth: 1, withSparseArray: true })),
@@ -216,8 +231,13 @@ function isTypedArray(v: unknown): boolean {
     v instanceof Int32Array ||
     v instanceof Uint32Array ||
     v instanceof Float32Array ||
-    v instanceof Float64Array
+    v instanceof Float64Array ||
+    isBigIntTypedArray(v)
   );
+}
+
+function isBigIntTypedArray(v: unknown): boolean {
+  return v instanceof BigInt64Array || v instanceof BigUint64Array;
 }
 
 function isSparseArray(v: unknown): boolean {


### PR DESCRIPTION
## Description

Closes #6293

Generates `BigInt64Array` and `BigUint64Array` from `fc.anything({ withBigInt: true, withTypedArray: true })`. The bigint typed arrays are only added to the pool when both flags are enabled, so existing behaviour for either flag alone is preserved.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)
