### PR TITLE
🔨 Skip scripts during `pnpm i` in changelog generation

### DIFF
--- a/.github/workflows/scripts/generate-changelog.cjs
+++ b/.github/workflows/scripts/generate-changelog.cjs
@@ -201,7 +201,7 @@ async function run() {
 
   // Get packages to be bumped via changeset
   const temporaryChangelogFile = 'changelog.json';
-  await execFile('pnpm', ['install']);
+  await execFile('pnpm', ['install', '--ignore-scripts']);
   await execFile('pnpm', ['run', 'changelog', `--output=${temporaryChangelogFile}`]);
   const temporaryChangelogFileContentBuffer = await readFile(temporaryChangelogFile);
   const temporaryChangelogFileContent = JSON.parse(temporaryChangelogFileContentBuffer.toString());
@@ -280,7 +280,7 @@ async function run() {
   }
 
   // Force pnpm reinstall
-  await execFile('pnpm', ['install']);
+  await execFile('pnpm', ['install', '--ignore-scripts']);
   await execFile('git', ['add', 'pnpm-lock.yaml']);
 
   // Drop all changesets

--- a/.github/workflows/scripts/generate-changelog.cjs
+++ b/.github/workflows/scripts/generate-changelog.cjs
@@ -201,7 +201,7 @@ async function run() {
 
   // Get packages to be bumped via changeset
   const temporaryChangelogFile = 'changelog.json';
-  await execFile('pnpm', ['install', '--ignore-scripts']);
+  await execFile('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts']);
   await execFile('pnpm', ['run', 'changelog', `--output=${temporaryChangelogFile}`]);
   const temporaryChangelogFileContentBuffer = await readFile(temporaryChangelogFile);
   const temporaryChangelogFileContent = JSON.parse(temporaryChangelogFileContentBuffer.toString());


### PR DESCRIPTION
## Description

This PR adds the `--ignore-scripts` flag to `pnpm install` commands in the changelog generation workflow script. This prevents lifecycle scripts from running during dependency installation, which can improve performance and avoid potential issues with script execution in CI environments.

The change is applied to both `pnpm install` calls in the `generate-changelog.cjs` script:
1. Initial installation before generating the changelog
2. Reinstallation after updating package versions

## Checklist

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

https://claude.ai/code/session_01KyUzXCJArqwEvJBqiHGaoL