### PR TITLE
🔧 Replace `pnpm dlx` with `pnpm exec` for `pkg-pr-new`

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -212,10 +212,10 @@ jobs:
         run: node --run unpack:all
       - name: Preview (no comment)
         if: github.event_name != 'pull_request'
-        run: pnpm dlx pkg-pr-new publish --compact './packages/*' --template './examples' --comment=off
+        run: pnpm exec pkg-pr-new publish --compact './packages/*' --template './examples' --comment=off
       - name: Preview
         if: github.event_name == 'pull_request'
-        run: pnpm dlx pkg-pr-new publish --compact './packages/*' --template './examples'
+        run: pnpm exec pkg-pr-new publish --compact './packages/*' --template './examples'
   test:
     name: 'Test'
     needs:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,7 @@
 rules:
   use-trusted-publishing:
     ignore:
-      # These are not real npm publish commands, but pnpm dlx pkg-pr-new publish
+      # These are not real npm publish commands, but pnpm exec pkg-pr-new publish
       # pkg-pr-new is a tool for creating preview deployments, not for publishing to npm
       - build-status.yml:213
       - build-status.yml:216


### PR DESCRIPTION
## Description

Replace `pnpm dlx` with `pnpm exec` for running the `pkg-pr-new` publish command in the build workflow. This change updates the command invocation method while maintaining the same functionality for creating preview deployments.

The change also updates the corresponding comment in the zizmor configuration file to reflect the new command syntax.

## Checklist

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

https://claude.ai/code/session_011u2bUhxU6dCwc3FCt1uhzb