### PR TITLE
👷 Switch release jobs to npm stage publish

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -600,8 +600,6 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       # These are false positives - attestations ensure artifact integrity
       # setup-node actions in publish jobs followed by gh-release for attestation uploads
       - name: Using Node v24.x
@@ -610,6 +608,9 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -623,7 +624,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/fast-check/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/fast-check/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -672,14 +673,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -693,7 +695,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/ava/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/ava/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -742,14 +744,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -763,7 +766,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/jest/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/jest/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -812,14 +815,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -833,7 +837,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/packaged/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/packaged/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -882,14 +886,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -903,7 +908,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/poisoning/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/poisoning/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -952,14 +957,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -973,7 +979,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/vitest/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/vitest/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:
@@ -1022,14 +1028,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Using Node v24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+      - name: Install npm with stage publish support
+        # Run outside the repo so the project's devEngines pin (pnpm) does not block npm
+        run: cd .. && npm install -g npm@latest
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1043,7 +1050,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           PUBLISH_TAG: ${{github.ref == 'refs/heads/main' && 'latest' || startsWith(github.ref, 'refs/heads/next-') && 'next' || 'legacy'}}
-        run: pnpm publish --no-git-checks --access public --tag "$PUBLISH_TAG" "packages/worker/$TGZ_NAME"
+        run: cd .. && npm stage publish --access public --tag "$PUBLISH_TAG" "$GITHUB_WORKSPACE/packages/worker/$TGZ_NAME"
       - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         id: attest
         with:


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

Switches every `publish_package_*` job in `.github/workflows/build-status.yml` from `pnpm publish` to [`npm stage publish`](https://github.com/npm/cli/pull/9201). With staged publishing, CI uploads the tarball into a holding area on the registry instead of releasing it immediately — a maintainer then has to approve the staged version (with 2FA) before it becomes installable. End users still receive the same artifacts on npm, but the release step is no longer fully automated: there is now an explicit approval gate between a tag being pushed and the package going live. This is a follow-up to #7011 (which already removed the OTP prompt from the publish call); together they move the workflow toward npm's recommended staged-release flow.

Each publish job now:

- installs `npm@latest` so the runner-provided npm is upgraded before publishing — the `stage` subcommand landed in npm 11.15.0 and is not yet bundled with Node 24's default npm;
- runs both `npm install -g` and `npm stage publish` from the parent directory (`cd ..`), because the repo's `package.json` pins pnpm via `devEngines` and would otherwise block npm from executing inside the workspace;
- no longer needs the `pnpm/action-setup` step or the pnpm-specific `--no-git-checks` flag, both of which were dropped from the seven affected jobs.

Non-publish jobs were intentionally left alone and still install pnpm — only the release plumbing changes. Because the diff only touches the workflow file, there are no source, dependency, or published-artifact changes, no semver impact to flag, and no changeset to add; the new code path is exercised the next time a `v*` tag is pushed.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)