### PR TITLE
⚡️ Faster `fc.webPath`/`fc.webUrl` on `generate`

### DIFF
--- a/.changeset/perf-webpath-segments.md
+++ b/.changeset/perf-webpath-segments.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Faster `fc.webPath`/`fc.webUrl` on `generate`

--- a/packages/fast-check/src/arbitrary/_internals/mappers/SegmentsToPath.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/SegmentsToPath.ts
@@ -1,11 +1,15 @@
-import { safeJoin, safeMap, safeSplice, safeSplit } from '../../../utils/globals.js';
+import { safeSplice, safeSplit } from '../../../utils/globals.js';
 
 /** @internal */
 export function segmentsToPathMapper(segments: string[]): string {
-  return safeJoin(
-    safeMap(segments, (v) => `/${v}`),
-    '',
-  );
+  // Fused equivalent of `safeJoin(safeMap(segments, (v) => `/${v}`), '')`:
+  // building the result in a single pass avoids allocating the intermediate
+  // array of `/segment` strings (and the per-element arrow closure).
+  let path = '';
+  for (let index = 0; index !== segments.length; ++index) {
+    path += '/' + segments[index];
+  }
+  return path;
 }
 
 /** @internal */

--- a/packages/fast-check/src/arbitrary/_internals/mappers/SegmentsToPath.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/SegmentsToPath.ts
@@ -2,9 +2,6 @@ import { safeSplice, safeSplit } from '../../../utils/globals.js';
 
 /** @internal */
 export function segmentsToPathMapper(segments: string[]): string {
-  // Fused equivalent of `safeJoin(safeMap(segments, (v) => `/${v}`), '')`:
-  // building the result in a single pass avoids allocating the intermediate
-  // array of `/segment` strings (and the per-element arrow closure).
   let path = '';
   for (let index = 0; index !== segments.length; ++index) {
     path += '/' + segments[index];


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

This is a **performance-only** change to the path-assembly mapper shared by `fc.webPath` and `fc.webUrl`. Generated values are unchanged — only the speed of `generate` improves. No public API change, no behavior change for end users.

Measured improvement (interleaved separate-process A/B, median of medians):

- `webPath()`: **~−10% ns/op** (≈1376 → ≈1236 ns/op) — the direct beneficiary, and `webPath` is itself public API.
- `webUrl()`: **~−4% ns/op** (≈9515 → ≈9123 ns/op) — a smaller relative gain because most of `webUrl`'s cost is in authority/domain generation; the path-assembly saving is real but a smaller share of the whole.

### Why

`segmentsToPathMapper` assembled the path as:

```js
return safeJoin(safeMap(segments, (v) => `/${v}`), '');
```

That allocates an intermediate array of `/segment` strings and invokes a per-element arrow closure for every segment, then joins. Fusing it into a single accumulating loop removes both the intermediate array and the `map` callback:

```js
let path = '';
for (let index = 0; index !== segments.length; ++index) {
  path += '/' + segments[index];
}
return path;
```

### Scope, correctness and impact

- **Impact: patch.** A changeset (`fast-check: patch`, `⚡️ Faster fc.webPath/fc.webUrl on generate`) is included.
- **Single concern:** one file (`_internals/mappers/SegmentsToPath.ts`) plus the changeset. Only the forward mapper changed; the unmapper is untouched.
- **Blast radius:** `segmentsToPathMapper` is used solely by `buildUriPathArbitrary` → `webPath` → `webUrl`. It does not touch domain/authority/email code paths.
- **Tests:** `webUrl`, `webPath`, `PartsToUrl`, `UriPath`/`SegmentsToPath`, and `emailAddress` specs all pass (25 tests). It is a pure string-assembly refactor producing byte-identical output, so no new test is needed.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRx4yxfDXbBWd5JDy7nrtz)_