### PR TITLE
⚡️ Faster `fc.string` and string-based arbitraries

### DIFF
--- a/.changeset/perf-patterns-to-string.md
+++ b/.changeset/perf-patterns-to-string.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Faster `fc.string` and string-based arbitraries on `generate`

--- a/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
+++ b/packages/fast-check/src/arbitrary/_internals/mappers/PatternsToString.ts
@@ -1,12 +1,19 @@
 import type { Arbitrary } from '../../../check/arbitrary/definition/Arbitrary.js';
 import { MaxLengthUpperBound } from '../helpers/MaxLengthFromMinLength.js';
 import type { StringSharedConstraints } from '../../_shared/StringSharedConstraints.js';
-import { safeJoin, Error } from '../../../utils/globals.js';
+import { Error } from '../../../utils/globals.js';
 import { tokenizeString } from '../helpers/TokenizeString.js';
 
 /** @internal - tab is supposed to be composed of valid entries extracted from the source arbitrary */
 export function patternsToStringMapper(tab: string[]): string {
-  return safeJoin(tab, '');
+  // `tab` is always a genuine Array built internally by the source arbitrary,
+  // so a direct indexed concatenation is safe (no exposure to poisoned prototypes)
+  // and avoids the per-call overhead of Array.prototype.join.
+  let out = '';
+  for (let index = 0; index !== tab.length; ++index) {
+    out += tab[index];
+  }
+  return out;
 }
 
 /** @internal */


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

This is a **performance-only** change to the shared string-assembly mapper that backs **every `fc.string(...)`** — and therefore everything built on it (`emailAddress`, `domain`, `webUrl`, `webAuthority`, `ipV6`, `lorem`, …). Generated values are byte-for-byte unchanged; only the speed of `generate` improves. No public API change, no behavior change for end users. This is the broadest of the recent perf changes, so it's worth a careful look.

Measured improvement (interleaved separate-process A/B, median of medians):

| arbitrary | speedup |
|-----------|---------|
| `string()` | **−11.6%** |
| `string({ maxLength: 100, size: 'max' })` | **−10.1%** |
| `emailAddress()` | **−9.8%** |
| `ipV6()` | **−6.4%** |
| `integer()` (non-string control) | +0.7% — within noise, no regression |

Two independent investigations (of `emailAddress` and of `ipV6`) converged on this same mapper as their #1 self-time hotspot.

### Why

`patternsToStringMapper` assembled the generated unit-array with `safeJoin(tab, '')`. It runs once per generated `string(...)` value, so it is the single hottest mapper on the string path. `safeJoin` pays a per-call cost — the poisoning-safe identity probe plus the generic `Array.prototype.join` — which, for an **empty** separator, is pure overhead: the operation is just concatenation.

```js
// before
return safeJoin(tab, '');
// after
let out = '';
for (let index = 0; index !== tab.length; ++index) {
  out += tab[index];
}
return out;
```

`tab` is always a genuine Array built internally by the source arbitrary (never user-supplied), so the indexed concat is byte-identical to `tab.join('')`. As a bonus it touches **no** `Array.prototype` method at all, making it strictly *more* resistant to prototype poisoning than the previous code.

### Scope, correctness and impact

- **Impact: patch.** A changeset is included.
- **Single concern:** one file (`_internals/mappers/PatternsToString.ts`); only the forward mapper changes — the unmapper and the length-validation helpers are untouched.
- **Blast radius:** broad but benign — it's a shared `string` primitive, but the output is provably identical. It does not overlap any other change in flight (verified none of the sibling perf branches touch this file).
- **Tests:** the string path and its consumers all pass (`PatternsToString`, `string` incl. the `assertNoPoisoning` checks, `emailAddress`, `ipV6`, `domain`, `webUrl` — 444 tests). Output verified byte-identical to `main` across 100k samples (0 mismatches), so the distribution is unchanged and no new test is needed.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRx4yxfDXbBWd5JDy7nrtz)_