### PR TITLE
✅ Refresh NoRegression snapshots for stringMatching fix

### DIFF
--- a/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
+++ b/packages/fast-check/test/e2e/__snapshots__/NoRegression.spec.ts.snap
@@ -4685,54 +4685,43 @@ Execution summary:
 exports[`NoRegression > stringMatching 1`] = `
 [Error: Property failed after 3 tests
 { seed: 42, path: "2:1:0:1:1:1:1", endOnFailure: true }
-Counterexample: ["--@a@.a@."]
+Counterexample: ["--@a.a"]
 Shrunk 6 time(s)
 
 Execution summary:
-[32m√[0m ["e@X@.-@."]
-[32m√[0m ["rUCO.8y.9Y2@V-mM3@.i.-0P-M-@."]
-[31m×[0m ["I+---@5r@.prototypeCar@."]
-. [32m√[0m ["-@5r@.prototypeCar@."]
-. [31m×[0m ["---@5r@.prototypeCar@."]
-. . [31m×[0m ["--@5r@.prototypeCar@."]
-. . . [32m√[0m ["-@5r@.prototypeCar@."]
-. . . [31m×[0m ["--@r@.prototypeCar@."]
-. . . . [32m√[0m ["-@r@.prototypeCar@."]
-. . . . [31m×[0m ["--@a@.prototypeCar@."]
-. . . . . [32m√[0m ["-@a@.prototypeCar@."]
-. . . . . [31m×[0m ["--@a@.r@."]
-. . . . . . [32m√[0m ["-@a@.r@."]
-. . . . . . [31m×[0m ["--@a@.a@."]
-. . . . . . . [32m√[0m ["-@a@.a@."]]
+[32m√[0m ["e@X.-"]
+[32m√[0m ["rUCO.8y.9Y2@V-mM3.i.-0P-M-"]
+[31m×[0m ["I+---@5r.prototypeCar"]
+. [32m√[0m ["-@5r.prototypeCar"]
+. [31m×[0m ["---@5r.prototypeCar"]
+. . [31m×[0m ["--@5r.prototypeCar"]
+. . . [32m√[0m ["-@5r.prototypeCar"]
+. . . [31m×[0m ["--@r.prototypeCar"]
+. . . . [32m√[0m ["-@r.prototypeCar"]
+. . . . [31m×[0m ["--@a.prototypeCar"]
+. . . . . [32m√[0m ["-@a.prototypeCar"]
+. . . . . [31m×[0m ["--@a.r"]
+. . . . . . [32m√[0m ["-@a.r"]
+. . . . . . [31m×[0m ["--@a.a"]
+. . . . . . . [32m√[0m ["-@a.a"]]
 `;
 
 exports[`NoRegression > stringMatching({maxLength:10}) 1`] = `
-[Error: Property failed after 14 tests
-{ seed: 42, path: "13:0:0:0:1", endOnFailure: true }
-Counterexample: ["0@a@..a@."]
-Shrunk 4 time(s)
+[Error: Property failed after 2 tests
+{ seed: 42, path: "1:0:0:0:1:0", endOnFailure: true }
+Counterexample: ["0@A.--"]
+Shrunk 5 time(s)
 
 Execution summary:
-[32m√[0m ["5@i6@.Ia@."]
-[32m√[0m ["h@a@.d@."]
-[32m√[0m ["i@p@.k@."]
-[32m√[0m ["2@-@.2ak@."]
-[32m√[0m ["Y@-@.y@."]
-[32m√[0m ["ca@Yb@.W@."]
-[32m√[0m ["_@D2@.6@."]
-[32m√[0m ["l@-@.bS@."]
-[32m√[0m ["3c@5-@.6@."]
-[32m√[0m ["l.@3-@.8@."]
-[32m√[0m ["+-@-2@.2@."]
-[32m√[0m [".+@x0@.k@."]
-[32m√[0m ["T@wz@.V@."]
-[31m×[0m ["9@-b@..v@."]
-. [31m×[0m ["0@-b@..v@."]
-. . [31m×[0m ["0@b@..v@."]
-. . . [31m×[0m ["0@a@..v@."]
-. . . . [32m√[0m ["0@a@.v@."]
-. . . . [31m×[0m ["0@a@..a@."]
-. . . . . [32m√[0m ["0@a@.a@."]]
+[32m√[0m ["5@i6.Ia"]
+[31m×[0m ["7@2B.ref--"]
+. [31m×[0m ["0@2B.ref--"]
+. . [31m×[0m ["0@B.ref--"]
+. . . [31m×[0m ["0@A.ref--"]
+. . . . [32m√[0m ["0@A.-"]
+. . . . [31m×[0m ["0@A.f--"]
+. . . . . [31m×[0m ["0@A.--"]
+. . . . . . [32m√[0m ["0@A.-"]]
 `;
 
 exports[`NoRegression > subarray 1`] = `


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

This PR targets the `faster-stringmatching` branch (PR #7054). The latest commit on that branch resets `pendingAggregatedValue` in `stringMatching.ts`, which corrects the values produced by `fc.stringMatching` for a given seed. This refreshes the `stringMatching` no-regression snapshots so the e2e suite passes on top of that fix.

For end users this carries no behavioral change of its own — it only re-records the expected outputs of `fc.stringMatching`. Notably, the fix brings the generated values back to their correct form: the odd trailing `@.` artifacts that the earlier speedup had introduced are gone, so the two affected snapshots (`stringMatching` and `stringMatching({maxLength:10})` in `test/e2e/NoRegression.spec.ts`) revert to their pre-regression shape. No other no-regression snapshots changed, and `NoRegressionStack.spec.ts` was unaffected.

Impact level: this is a test-only change (no library code), so it does not warrant a changeset of its own — it belongs with the perf PR it stacks on.

Scope is a single concern: regenerating the no-regression snapshots invalidated by the stringMatching fix. Snapshots were produced via `vitest -u` and verified by re-running `test/e2e/NoRegression.spec.ts` (85 passing) and `test/e2e/NoRegressionStack.spec.ts` (6 passing). These snapshots would have failed against the fix without this update — that mismatch is exactly what this PR resolves.

Fixes #issue-number

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

---
_Generated by [Claude Code](https://claude.ai/code/session_011nEBy7JcAAQ1nnYK1hvLhF)_