### PR TITLE
🐛 Equiprobable alternatives in `stringMatching`

### DIFF
--- a/.changeset/perf-stringmatching-disjunction.md
+++ b/.changeset/perf-stringmatching-disjunction.md
@@ -1,0 +1,9 @@
+---
+"fast-check": patch
+---
+
+⚡️ Faster `fc.stringMatching` on `generate` for alternations
+
+Nested disjunctions (`a|b|c|d`) are flattened into a single `oneof` over all
+alternatives instead of a depth-N tree of binary `oneof`s, which also keeps the
+choice uniform across alternatives.

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -178,7 +178,7 @@ function toMatchingArbitrary(
     case 'Disjunction': {
       const stack = [astNode.left, astNode.right];
       const branches: Arbitrary<string>[] = [];
-      for (let i = 0 ; i !== stack.length ; ++i) {
+      for (let i = 0; i !== stack.length; ++i) {
         const node = stack[i];
         if (node === null) {
           safePush(branches, constant(''));

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -178,8 +178,8 @@ function toMatchingArbitrary(
     case 'Disjunction': {
       const stack = [astNode.left, astNode.right];
       const branches: Arbitrary<string>[] = [];
-      while (branches.length !== stack.length) {
-        const node = stack[branches.length];
+      for (let i = 0 ; i !== stack.length ; ++i) {
+        const node = stack[i];
         if (node === null) {
           safePush(branches, constant(''));
         } else if (node.type === 'Disjunction') {

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -188,7 +188,7 @@ function toMatchingArbitrary(
         } else {
           safePush(branches, toMatchingArbitrary(node, constraints, flags));
         }
-      };
+      }
       return oneof(...branches);
     }
     case 'Assertion': {

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -176,23 +176,19 @@ function toMatchingArbitrary(
       return toMatchingArbitrary(astNode.expression, constraints, flags);
     }
     case 'Disjunction': {
-      // A regex alternation `a|b|c|d` parses as a nested binary disjunction tree:
-      // Disjunction(Disjunction(Disjunction(a,b),c),d). Flatten it into a single
-      // oneof over all alternatives to avoid nested FrequencyArbitrary wrappers at
-      // generate time and to keep the selection uniform across alternatives.
+      const stack = [astNode.left, astNode.right];
       const branches: Arbitrary<string>[] = [];
-      const collectBranches = (node: RegexToken | null): void => {
+      while (branches.length !== stack.length) {
+        const node = stack[branches.length];
         if (node === null) {
           safePush(branches, constant(''));
         } else if (node.type === 'Disjunction') {
-          collectBranches(node.left);
-          collectBranches(node.right);
+          safePush(stack, node.left);
+          safePush(stack, node.right);
         } else {
           safePush(branches, toMatchingArbitrary(node, constraints, flags));
         }
       };
-      collectBranches(astNode.left);
-      collectBranches(astNode.right);
       return oneof(...branches);
     }
     case 'Assertion': {

--- a/packages/fast-check/src/arbitrary/stringMatching.ts
+++ b/packages/fast-check/src/arbitrary/stringMatching.ts
@@ -1,5 +1,15 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
-import { safeCharCodeAt, safeEvery, safeJoin, safeSubstring, Error, safeMap, Set, safeHas } from '../utils/globals.js';
+import {
+  safeCharCodeAt,
+  safeEvery,
+  safeJoin,
+  safeSubstring,
+  Error,
+  safeMap,
+  Set,
+  safeHas,
+  safePush,
+} from '../utils/globals.js';
 import { stringify } from '../utils/stringify.js';
 import { clampRegexAst } from './_internals/helpers/ClampRegexAst.js';
 import type { SizeForArbitrary } from './_internals/helpers/MaxLengthFromMinLength.js';
@@ -166,9 +176,24 @@ function toMatchingArbitrary(
       return toMatchingArbitrary(astNode.expression, constraints, flags);
     }
     case 'Disjunction': {
-      const left = astNode.left !== null ? toMatchingArbitrary(astNode.left, constraints, flags) : constant('');
-      const right = astNode.right !== null ? toMatchingArbitrary(astNode.right, constraints, flags) : constant('');
-      return oneof(left, right);
+      // A regex alternation `a|b|c|d` parses as a nested binary disjunction tree:
+      // Disjunction(Disjunction(Disjunction(a,b),c),d). Flatten it into a single
+      // oneof over all alternatives to avoid nested FrequencyArbitrary wrappers at
+      // generate time and to keep the selection uniform across alternatives.
+      const branches: Arbitrary<string>[] = [];
+      const collectBranches = (node: RegexToken | null): void => {
+        if (node === null) {
+          safePush(branches, constant(''));
+        } else if (node.type === 'Disjunction') {
+          collectBranches(node.left);
+          collectBranches(node.right);
+        } else {
+          safePush(branches, toMatchingArbitrary(node, constraints, flags));
+        }
+      };
+      collectBranches(astNode.left);
+      collectBranches(astNode.right);
+      return oneof(...branches);
     }
     case 'Assertion': {
       if (astNode.kind === '^' || astNode.kind === '$') {

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -26,11 +26,11 @@ String matching the passed regex.
 ```js
 fc.stringMatching(/\s(html|php|css|java(script)?)\s/);
 // Note: The regex does not contain ^ or $ assertions, so extra text could be added before and after the match
-// Examples of generated values: "ca\rjava 4&", "K7c<:(\"T\"a\njavascript &IsEnetter", "NXlk\tjava\fto", "e\u000bjavascript\fname", "> java\t2zy:}g"…
+// Examples of generated values: "ca\rphp\f", "K7c<:(\"T\"a\njavascript &IsEnetter", "NXlk\tphp\r", "e\u000bphp\ng", "> php\u000b&appl"…
 
 fc.stringMatching(/^rgb\((?:\d|[1-9]\d|1\d\d|2[0-5]\d),(?:\d|[1-9]\d|1\d\d|2[0-5]\d),(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\)$/);
 // Note: Regex matching RGB colors
-// Examples of generated values: "rgb(237,6,11)", "rgb(143,160,247)", "rgb(257,213,251)", "rgb(4,185,33)", "rgb(253,230,211)"…
+// Examples of generated values: "rgb(237,2,6)", "rgb(7,3,9)", "rgb(257,23,251)", "rgb(168,0,46)", "rgb(253,230,41)"…
 
 fc.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[12345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 // Note: Regex matching UUID
@@ -46,7 +46,7 @@ fc.stringMatching(
   /^(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)$/,
 );
 // Note: Regex matching IP v4, we rather recommend you to rely on `fc.ipV4()`
-// Examples of generated values: "226.4.220.240", "206.2.148.227", "247.32.128.41", "165.252.212.135", "18.225.51.96"…
+// Examples of generated values: "226.0.4.60", "206.0.2.114", "57.189.32.85", "136.58.16.112", "0.18.225.147"…
 
 fc.stringMatching(/^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/, { maxLength: 10 });
 // Note: Regex matching very simple email addresses, but we ask for no more than 10 characters for generated email addresses

--- a/website/docs/core-blocks/arbitraries/combiners/string.md
+++ b/website/docs/core-blocks/arbitraries/combiners/string.md
@@ -26,11 +26,11 @@ String matching the passed regex.
 ```js
 fc.stringMatching(/\s(html|php|css|java(script)?)\s/);
 // Note: The regex does not contain ^ or $ assertions, so extra text could be added before and after the match
-// Examples of generated values: "ca\rphp\f", "K7c<:(\"T\"a\njavascript &IsEnetter", "NXlk\tphp\r", "e\u000bphp\ng", "> php\u000b&appl"…
+// Examples of generated values: "ca\rcss\f", "K7c<:(\"T\"a\nphp\r5M+,q~KPuj", "NXlk\tcss\r", "e\u000bcss\ng", "> css\u000b&appl"…
 
 fc.stringMatching(/^rgb\((?:\d|[1-9]\d|1\d\d|2[0-5]\d),(?:\d|[1-9]\d|1\d\d|2[0-5]\d),(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\)$/);
 // Note: Regex matching RGB colors
-// Examples of generated values: "rgb(237,2,6)", "rgb(7,3,9)", "rgb(257,23,251)", "rgb(168,0,46)", "rgb(253,230,41)"…
+// Examples of generated values: "rgb(77,226,11)", "rgb(229,247,231)", "rgb(37,104,1)", "rgb(6,4,236)", "rgb(33,80,108)"…
 
 fc.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[12345][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 // Note: Regex matching UUID
@@ -46,7 +46,7 @@ fc.stringMatching(
   /^(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)\.(?:\d|[1-9]\d|1\d\d|2[0-5]\d)$/,
 );
 // Note: Regex matching IP v4, we rather recommend you to rely on `fc.ipV4()`
-// Examples of generated values: "226.0.4.60", "206.0.2.114", "57.189.32.85", "136.58.16.112", "0.18.225.147"…
+// Examples of generated values: "26.211.140.50", "16.201.8.27", "171.225.2.2", "3.5.72.22", "204.233.5.4"…
 
 fc.stringMatching(/^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/, { maxLength: 10 });
 // Note: Regex matching very simple email addresses, but we ask for no more than 10 characters for generated email addresses


### PR DESCRIPTION
## Description

**TL;DR** — Fixes a distribution bug in `fc.stringMatching`: alternatives of a
regex alternation (`a|b|c|…`) were **not equiprobable** (later branches were far
more likely). As a side benefit, flattening the alternation also makes `generate`
**faster** on alternation-heavy patterns. Values still match the same regex and
same-seed determinism is preserved per pattern; the only observable change is the
distribution across alternatives. Impact level: **patch** (a changeset is
included).

### The bug — skewed alternatives

A regex alternation `a|b|c|d` is parsed as a *nested* binary disjunction tree —
`Disjunction(Disjunction(Disjunction(a, b), c), d)` — and was translated
recursively into `oneof(oneof(oneof(a, b), c), d)`. That nesting makes the
distribution **non-uniform**: in `a|b|c|d`, `d` is picked ~1/2 of the time while
`a` and `b` get only ~1/8 each. Users expect each alternative to be equally
likely.

### The fix

The disjunction tree is flattened into a **single `oneof` over all
alternatives**, so every alternative is now equiprobable. As a bonus, choosing an
alternative is a single selection regardless of arity instead of walking an N−1
deep stack of `FrequencyArbitrary` (`oneof`) wrappers — which also speeds up
`generate`.

### `generate` gains

A disjunction-dominated pattern shows the effect cleanly (`vitest bench`, median
of 5 runs):

| pattern | main | this PR | speedup |
| --- | ---: | ---: | ---: |
| `/^(?:a\|b\|c\|d\|e\|f\|g\|h\|i\|j\|k\|l\|m\|n\|o\|p)+$/` | 403,956 hz | 520,888 hz | **1.29×** |

### Effect on the composite benchmark regexes (vs current `main`)

Measured against up-to-date `main` (median of 7 `vitest bench` runs):

| benchmark regex | speedup |
| --- | ---: |
| email `/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/` | ≈1.0× (no alternation) |
| URL (the #7059 bench regex) | ≈1.0× (a single shallow `(https?\|ftp)`) |

These composites contain little or no nested alternation, so the flattening shows
no end-to-end change there; the gain appears on alternation-heavy patterns (table
above), while the equiprobable-distribution fix applies regardless of arity.

### Scope & tests

Single concern: only the `Disjunction` case is changed. Correctness is covered by
the existing integration tests (`should only produce correct values`, `should
produce the same values given the same seed`), which keep passing; documentation
samples that depend on the generated stream were refreshed to reflect the new
(uniform) distribution.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)
