### PR TITLE
✅ More reliable arbitraries.bench.ts

### DIFF
--- a/packages/fast-check/test/bench/arbitraries.bench.ts
+++ b/packages/fast-check/test/bench/arbitraries.bench.ts
@@ -104,7 +104,9 @@ for (const benchCase of benchCases) {
 describe('generate', () => {
   for (const benchCase of benchCases) {
     bench(benchCase.name, () => {
-      benchCase.arbitrary.generate(mrng, biasFactor);
+      for (let i = 0 ; i !== 1000 ; ++i) {
+        benchCase.arbitrary.generate(mrng, biasFactor);
+      }
     });
   }
 });

--- a/packages/fast-check/test/bench/arbitraries.bench.ts
+++ b/packages/fast-check/test/bench/arbitraries.bench.ts
@@ -104,7 +104,7 @@ for (const benchCase of benchCases) {
 describe('generate', () => {
   for (const benchCase of benchCases) {
     bench(benchCase.name, () => {
-      for (let i = 0 ; i !== 1000 ; ++i) {
+      for (let i = 0; i !== 1000; ++i) {
         benchCase.arbitrary.generate(mrng, biasFactor);
       }
     });


### PR DESCRIPTION
One generate execution can be so different from the next one that it used to make our benchmarks pretty unreliable and hardly usable.

By looping we hope we will erase this variation that makes them inconclusive.