### PR TITLE
⚡️ Speed up fc.entityGraph value generation

### DIFF
--- a/.changeset/perf-entitygraph-generation.md
+++ b/.changeset/perf-entitygraph-generation.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Faster value generation in `fc.entityGraph`

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ benchmark.json
 
 # IDE related files
 .idea
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,6 +142,7 @@
     }
   ],
   "ignorePatterns": [
+    ".claude/worktrees/",
     ".github/",
     "node_modules/",
     "coverage/",

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -1,10 +1,15 @@
-import type { Arbitrary } from '../../check/arbitrary/definition/Arbitrary.js';
+import type { Random } from '../../random/generator/Random.js';
+import { Arbitrary } from '../../check/arbitrary/definition/Arbitrary.js';
+import { Value } from '../../check/arbitrary/definition/Value.js';
+import { Stream } from '../../stream/Stream.js';
 import {
   safeAdd,
   safeHas,
   safeMap,
   safeMapGet,
+  safeMapSet,
   safePush,
+  Map as SMap,
   Set as SSet,
   Error as SError,
   String as SString,
@@ -15,8 +20,8 @@ import { constant } from '../constant.js';
 import { integer } from '../integer.js';
 import { noBias } from '../noBias.js';
 import { option } from '../option.js';
-import { tuple } from '../tuple.js';
 import { uniqueArray } from '../uniqueArray.js';
+import { tupleShrink } from './TupleArbitrary.js';
 import { buildInversedRelationsMapping } from './helpers/BuildInversedRelationsMapping.js';
 import { createDepthIdentifier, type DepthIdentifier } from './helpers/DepthContext.js';
 import type {
@@ -143,13 +148,17 @@ type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEn
   readonly nextIndex: number;
 };
 
-/** @internal */
-function draftNextProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+/**
+ * Copy-on-write draft over a {@link ProductionState} able to absorb the edits of SEVERAL entities in a row.
+ * The underlying state is cloned lazily (top-level map and inner structures) only once per batch: edits applied
+ * for one entity of the batch stay visible to the next ones without any extra cloning.
+ * Once `commit` has been called the draft must not be edited anymore: the committed state is immutable.
+ * @internal
+ */
+function draftBatchProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   state: ProductionState<TEntityFields, TEntityRelations>,
-  offset: number,
 ) {
   const { producedLinks, toBeProducedEntities } = state;
-  const nextIndex = state.nextIndex + offset;
 
   const newProducedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectAssign(
     safeObjectCreate(null),
@@ -189,20 +198,30 @@ function draftNextProductionState<TEntityFields, TEntityRelations extends Entity
 
   let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
 
-  const toBeProduced = toBeProducedEntities[nextIndex];
   return {
+    // Read functions
+    countInType: (type: keyof TEntityFields): number => newProducedLinks[type].length,
+    countToBeProduced: (): number =>
+      newToBeProducedEntities !== undefined ? newToBeProducedEntities.length : toBeProducedEntities.length,
+    toBeProducedAt: (entityIndex: number): Readonly<ToBeProducedEntity<TEntityFields>> =>
+      newToBeProducedEntities !== undefined ? newToBeProducedEntities[entityIndex] : toBeProducedEntities[entityIndex],
     // Edit functions
     setOutboundLink: (
+      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
       name: keyof TEntityRelations[keyof TEntityFields],
       value: {
         type: keyof TEntityFields;
         index: number[] | number | undefined;
       },
     ) => {
-      const currentLinks = getOrCreateLinksFor(toBeProduced.type, toBeProduced.indexInType); // All the links going from the current entity to others
+      const currentLinks = getOrCreateLinksFor(currentEntity.type, currentEntity.indexInType); // All the links going from the current entity to others
       currentLinks[name] = value;
     },
-    enqueueNewEntity: (relations: TEntityRelations, targetType: keyof TEntityFields) => {
+    enqueueNewEntity: (
+      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+      relations: TEntityRelations,
+      targetType: keyof TEntityFields,
+    ) => {
       const producedLinksInTargetType = getOrCreateProducedLinksFor(targetType);
       const newEntityIndexInType = producedLinksInTargetType.length;
       if (newToBeProducedEntities === undefined) {
@@ -211,24 +230,34 @@ function draftNextProductionState<TEntityFields, TEntityRelations extends Entity
       safePush(newToBeProducedEntities, {
         type: targetType,
         indexInType: newEntityIndexInType,
-        depth: toBeProduced.depth + 1,
+        depth: currentEntity.depth + 1,
       });
       safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(relations, targetType));
       return newEntityIndexInType;
     },
-    appendBackReference: (targetType: keyof TEntityFields, indexInType: number, property: string) => {
+    appendBackReference: (
+      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+      targetType: keyof TEntityFields,
+      indexInType: number,
+      property: string,
+    ) => {
       const relation = getOrCreateRelationFor(targetType, indexInType, property);
       const knownInversedLinks = relation.index;
-      safePush(knownInversedLinks as Exclude<typeof knownInversedLinks, number | undefined>, toBeProduced.indexInType);
+      safePush(knownInversedLinks as Exclude<typeof knownInversedLinks, number | undefined>, currentEntity.indexInType);
     },
-    // Seal the step into a new immutable state and advance to the next entity.
-    commit: (): ProductionState<TEntityFields, TEntityRelations> => ({
+    // Seal the batch into a new immutable state pointing right after the last entity of the batch.
+    commit: (nextIndex: number): ProductionState<TEntityFields, TEntityRelations> => ({
       producedLinks: newProducedLinks,
       toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
-      nextIndex: nextIndex + 1,
+      nextIndex,
     }),
   };
 }
+
+/** @internal */
+type BatchProductionStateDraft<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> = ReturnType<
+  typeof draftBatchProductionState<TEntityFields, TEntityRelations>
+>;
 
 /** @internal */
 function buildInitialProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
@@ -250,26 +279,72 @@ function buildInitialProductionState<TEntityFields, TEntityRelations extends Ent
 }
 
 /** @internal */
-function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+type EntityLinkContext<TEntityFields> = {
+  name: string;
+  relation: Relationship<keyof TEntityFields>;
+  sentinelLinkIndex: number;
+  inversedProperty: string | undefined;
+};
+
+/** @internal */
+type EntityStepResults = (number[] | number | undefined)[];
+
+/**
+ * Cached set of arbitraries responsible to produce all the outbound links of one single entity.
+ * Two entities sharing the very same parameterization (same type, same counts in target types, same index
+ * within own type) can safely share the very same instance: the only remaining degree of freedom, the depth
+ * of the entity, has to be set onto `depthIdentifier` before any call to generate or shrink.
+ * @internal
+ */
+type EntityLinksArbitrary<TEntityFields> = {
+  subArbitraries: Arbitrary<number[] | number | undefined>[];
+  linkContexts: EntityLinkContext<TEntityFields>[];
+  depthIdentifier: DepthIdentifier;
+};
+
+/**
+ * Build (or fetch from the cache) the arbitraries responsible to produce all the outbound links of one single entity.
+ * Ranges are derived from the current content of the draft: callers must apply the results of an entity
+ * onto the draft before requesting the arbitraries of the next one.
+ * Must only be called for entities having at least one outbound link to produce.
+ * @internal
+ */
+function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
   inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
-  lastState: ProductionState<TEntityFields, TEntityRelations>,
-  offset: number,
-): Arbitrary<ProductionState<TEntityFields, TEntityRelations>> | undefined {
-  const lastProducedLinks = lastState.producedLinks;
-  const currentEntity = lastState.toBeProducedEntities[lastState.nextIndex + offset];
+  cache: Map<string, EntityLinksArbitrary<TEntityFields>>,
+  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+): EntityLinksArbitrary<TEntityFields> {
   const currentRelations = relations[currentEntity.type];
+  // Cache key: full parameterization of the arbitraries except the depth (handled via the mutable depthIdentifier)
+  let cacheKey = currentEntity.type as string;
+  for (const name in currentRelations) {
+    const relation = currentRelations[name];
+    if (relation.arity === 'inverse') {
+      continue;
+    }
+    const countInTargetType = draft.countInType(relation.type);
+    cacheKey +=
+      relation.type === currentEntity.type
+        ? '|' + countInTargetType + ':' + currentEntity.indexInType
+        : '|' + countInTargetType;
+  }
+  const cached = safeMapGet(cache, cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
   const currentEntityDepth = createDepthIdentifier();
   currentEntityDepth.depth = currentEntity.depth;
   const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
-  const linkContexts: { name: string; relation: Relationship<keyof TEntityFields>; sentinelLinkIndex: number }[] = [];
+  const linkContexts: EntityLinkContext<TEntityFields>[] = [];
   for (const name in currentRelations) {
     const relation = currentRelations[name];
     if (relation.arity === 'inverse') {
       continue;
     }
     const targetType = relation.type;
-    const countInTargetType = lastProducedLinks[targetType].length;
+    const countInTargetType = draft.countInType(targetType);
     const linkOrLinksArbitrary = buildLinkIndexArbitrary(
       relation.arity,
       relation.strategy || 'any',
@@ -278,44 +353,272 @@ function buildEntityStepArbitrary<TEntityFields, TEntityRelations extends Entity
       currentEntityDepth,
     );
     safePush(subArbitraries, linkOrLinksArbitrary);
-    safePush(linkContexts, { name, relation, sentinelLinkIndex: countInTargetType });
+    const inversed = safeMapGet(inversedRelations, relation);
+    safePush(linkContexts, {
+      name,
+      relation,
+      sentinelLinkIndex: countInTargetType,
+      inversedProperty: inversed !== undefined ? inversed.property : undefined,
+    });
   }
-  if (subArbitraries.length === 0) {
-    return undefined;
-  }
-  return tuple(...subArbitraries).map((results) => {
-    const state = draftNextProductionState(lastState, offset);
-    for (let resultIndex = 0; resultIndex !== results.length; ++resultIndex) {
-      const linkOrLinks = results[resultIndex];
-      const { name, relation, sentinelLinkIndex } = linkContexts[resultIndex];
+  const entry: EntityLinksArbitrary<TEntityFields> = {
+    subArbitraries,
+    linkContexts,
+    depthIdentifier: currentEntityDepth,
+  };
+  safeMapSet(cache, cacheKey, entry);
+  return entry;
+}
 
+/**
+ * Apply onto the draft the links produced for one entity.
+ * @internal
+ */
+function applyEntityLinks<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+  results: EntityStepResults,
+  linkContexts: EntityLinkContext<TEntityFields>[],
+): void {
+  for (let resultIndex = 0; resultIndex !== results.length; ++resultIndex) {
+    const linkOrLinks = results[resultIndex];
+    const { name, relation, sentinelLinkIndex, inversedProperty } = linkContexts[resultIndex];
+
+    let index: number[] | number | undefined;
+    if (linkOrLinks === undefined) {
+      index = undefined;
+    } else if (typeof linkOrLinks === 'number') {
+      index = resolveOneEntityLink(
+        relations,
+        draft,
+        currentEntity,
+        relation,
+        sentinelLinkIndex,
+        inversedProperty,
+        linkOrLinks,
+      );
+    } else {
       const effectiveLinks: number[] = [];
-      const links = linkOrLinks === undefined ? [] : typeof linkOrLinks === 'number' ? [linkOrLinks] : linkOrLinks;
-      for (const link of links) {
-        let newEntityIndexInType: number;
-        if (link >= sentinelLinkIndex) {
-          // Links at or above sentinelLinkIndex mark "create a new entity"; enqueueNewEntity
-          // allocates one and returns its index-in-type for later links to reuse.
-          // Known limitation of current design: reuse is scoped to the current relation name
-          // two relation names requesting a new entity of the same type get two separate entities.
-          newEntityIndexInType = state.enqueueNewEntity(relations, relation.type);
-        } else {
-          newEntityIndexInType = link;
-        }
-        safePush(effectiveLinks, newEntityIndexInType);
-        const inversed = safeMapGet(inversedRelations, relation);
-        if (inversed !== undefined) {
-          state.appendBackReference(relation.type, newEntityIndexInType, inversed.property);
-        }
+      for (const link of linkOrLinks) {
+        safePush(
+          effectiveLinks,
+          resolveOneEntityLink(relations, draft, currentEntity, relation, sentinelLinkIndex, inversedProperty, link),
+        );
       }
-      state.setOutboundLink(name, {
-        type: relation.type,
-        index:
-          linkOrLinks === undefined ? undefined : typeof linkOrLinks === 'number' ? effectiveLinks[0] : effectiveLinks,
-      });
+      index = effectiveLinks;
     }
-    return state.commit();
-  });
+    draft.setOutboundLink(currentEntity, name, { type: relation.type, index });
+  }
+}
+
+/**
+ * Resolve the effective index targeted by one link and register the back-reference when relevant.
+ * @internal
+ */
+function resolveOneEntityLink<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  relations: TEntityRelations,
+  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+  relation: Relationship<keyof TEntityFields>,
+  sentinelLinkIndex: number,
+  inversedProperty: string | undefined,
+  link: number,
+): number {
+  let newEntityIndexInType: number;
+  if (link >= sentinelLinkIndex) {
+    // Links at or above sentinelLinkIndex mark "create a new entity"; enqueueNewEntity
+    // allocates one and returns its index-in-type for later links to reuse.
+    // Known limitation of current design: reuse is scoped to the current relation name
+    // two relation names requesting a new entity of the same type get two separate entities.
+    newEntityIndexInType = draft.enqueueNewEntity(currentEntity, relations, relation.type);
+  } else {
+    newEntityIndexInType = link;
+  }
+  if (inversedProperty !== undefined) {
+    draft.appendBackReference(currentEntity, relation.type, newEntityIndexInType, inversedProperty);
+  }
+  return newEntityIndexInType;
+}
+
+/**
+ * One processed entity within a batch: enough material to replay or shrink the batch entity per entity.
+ * @internal
+ */
+type EntityBatchRecord<TEntityFields> = {
+  entityIndex: number;
+  entity: Readonly<ToBeProducedEntity<TEntityFields>>;
+  linksArbitrary: EntityLinksArbitrary<TEntityFields>;
+  value: EntityStepResults;
+  context: unknown;
+  clonedMrng: Random;
+};
+
+/** @internal */
+type EntityBatchStepContext<TEntityFields> = {
+  biasFactor: number | undefined;
+  records: EntityBatchRecord<TEntityFields>[];
+  currentShrinkLevel: number;
+};
+
+/**
+ * Arbitrary responsible to produce the links of ALL the entities pending at the time it gets created,
+ * including the ones enqueued while running the batch itself (the whole graph is built in one batch).
+ * It processes the entities sequentially against the very same mrng (each entity may impact the ranges
+ * used by the next ones) but mutates one single shared draft instead of paying one full copy-on-write
+ * clone and commit per entity.
+ * @internal
+ */
+class EntityBatchStepArbitrary<
+  TEntityFields,
+  TEntityRelations extends EntityRelations<TEntityFields>,
+> extends Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
+  constructor(
+    readonly relations: TEntityRelations,
+    readonly inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
+    readonly typesWithOutboundRelations: Set<keyof TEntityFields>,
+    readonly linksArbitraryCache: Map<string, EntityLinksArbitrary<TEntityFields>>,
+    readonly lastState: ProductionState<TEntityFields, TEntityRelations>,
+  ) {
+    super();
+  }
+
+  /**
+   * Produce the links of one single entity by generating all its sub-arbitraries in order against mrng,
+   * apply them onto the draft and append the freshly built record into records
+   */
+  private generateOneEntity(
+    draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+    records: EntityBatchRecord<TEntityFields>[],
+    entityIndex: number,
+    currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+    mrng: Random,
+    biasFactor: number | undefined,
+  ): void {
+    const linksArbitrary = buildEntityLinksArbitrary(
+      this.relations,
+      this.inversedRelations,
+      this.linksArbitraryCache,
+      draft,
+      currentEntity,
+    );
+    linksArbitrary.depthIdentifier.depth = currentEntity.depth;
+    const clonedMrng = mrng.clone();
+    const subArbitraries = linksArbitrary.subArbitraries;
+    // Equivalent of a generate on tuple(...subArbitraries) but without the cost of the wrapper:
+    // sub-values are guaranteed to be numbers or arrays of numbers, they can never be cloneable
+    const subValues: EntityStepResults = [];
+    const subContexts: unknown[] = [];
+    for (let index = 0; index !== subArbitraries.length; ++index) {
+      const generated = subArbitraries[index].generate(mrng, biasFactor);
+      safePush(subValues, generated.value_);
+      safePush(subContexts, generated.context);
+    }
+    applyEntityLinks(this.relations, draft, currentEntity, subValues, linksArbitrary.linkContexts);
+    safePush(records, {
+      entityIndex,
+      entity: currentEntity,
+      linksArbitrary,
+      value: subValues,
+      context: subContexts,
+      clonedMrng,
+    });
+  }
+
+  generate(mrng: Random, biasFactor: number | undefined): Value<ProductionState<TEntityFields, TEntityRelations>> {
+    const lastState = this.lastState;
+    const draft = draftBatchProductionState(lastState);
+    const records: EntityBatchRecord<TEntityFields>[] = [];
+    // The batch covers all the pending entities, including the ones enqueued while running it
+    for (let entityIndex = lastState.nextIndex; entityIndex !== draft.countToBeProduced(); ++entityIndex) {
+      const currentEntity = draft.toBeProducedAt(entityIndex);
+      if (!safeHas(this.typesWithOutboundRelations, currentEntity.type)) {
+        continue; // entity without any outbound link to produce
+      }
+      this.generateOneEntity(draft, records, entityIndex, currentEntity, mrng, biasFactor);
+    }
+    const context: EntityBatchStepContext<TEntityFields> = { biasFactor, records, currentShrinkLevel: 0 };
+    return new Value(draft.commit(draft.countToBeProduced()), context);
+  }
+
+  canShrinkWithoutContext(_value: unknown): _value is ProductionState<TEntityFields, TEntityRelations> {
+    return false;
+  }
+
+  shrink(
+    _value: ProductionState<TEntityFields, TEntityRelations>,
+    context?: unknown,
+  ): Stream<Value<ProductionState<TEntityFields, TEntityRelations>>> {
+    if (!this.isSafeContext(context)) {
+      return Stream.nil();
+    }
+    return new Stream(this.shrinkIterator(context));
+  }
+
+  private *shrinkIterator(
+    context: EntityBatchStepContext<TEntityFields>,
+  ): IterableIterator<Value<ProductionState<TEntityFields, TEntityRelations>>> {
+    const { records, currentShrinkLevel, biasFactor } = context;
+    const lastState = this.lastState;
+
+    for (let level = currentShrinkLevel; level < records.length; ++level) {
+      const record = records[level];
+      record.linksArbitrary.depthIdentifier.depth = record.entity.depth;
+      const shrinks = tupleShrink(record.linksArbitrary.subArbitraries, record.value, record.context as unknown[]);
+
+      for (const shrunkValue of shrinks) {
+        const draft = draftBatchProductionState(lastState);
+        const newRecords: EntityBatchRecord<TEntityFields>[] = safeSlice(records, 0, level);
+
+        // Replay entities before this level unchanged (their stored link contexts stay valid:
+        // the state they were derived from is replayed identically)
+        for (let priorLevel = 0; priorLevel !== level; ++priorLevel) {
+          const prior = records[priorLevel];
+          applyEntityLinks(this.relations, draft, prior.entity, prior.value, prior.linksArbitrary.linkContexts);
+        }
+
+        // Apply the shrunk entity at this level
+        applyEntityLinks(this.relations, draft, record.entity, shrunkValue.value_, record.linksArbitrary.linkContexts);
+        safePush(newRecords, {
+          entityIndex: record.entityIndex,
+          entity: record.entity,
+          linksArbitrary: record.linksArbitrary,
+          value: shrunkValue.value_,
+          context: shrunkValue.context,
+          clonedMrng: record.clonedMrng,
+        });
+
+        // Regenerate the subsequent entities of the batch from the cloned mrng,
+        // ranges being recomputed sequentially exactly as in generate
+        const mrng = record.clonedMrng.clone();
+        for (let entityIndex = record.entityIndex + 1; entityIndex !== draft.countToBeProduced(); ++entityIndex) {
+          const nextEntity = draft.toBeProducedAt(entityIndex);
+          if (!safeHas(this.typesWithOutboundRelations, nextEntity.type)) {
+            continue;
+          }
+          this.generateOneEntity(draft, newRecords, entityIndex, nextEntity, mrng, biasFactor);
+        }
+
+        const newContext: EntityBatchStepContext<TEntityFields> = {
+          biasFactor,
+          records: newRecords,
+          currentShrinkLevel: level,
+        };
+        yield new Value(draft.commit(draft.countToBeProduced()), newContext);
+      }
+    }
+  }
+
+  private isSafeContext(context: unknown): context is EntityBatchStepContext<TEntityFields> {
+    return (
+      context !== null &&
+      context !== undefined &&
+      typeof context === 'object' &&
+      'biasFactor' in (context as any) &&
+      'records' in (context as any) &&
+      'currentShrinkLevel' in (context as any)
+    );
+  }
 }
 
 /** @internal */
@@ -326,21 +629,35 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
   assertAcceptableRelations(relations);
 
   const inversedRelations = buildInversedRelationsMapping(relations);
+  // Types referenced below have at least one outbound link to produce per entity:
+  // entities of any other type can safely be skipped, they consume no randomness at all.
+  const typesWithOutboundRelations = new SSet<keyof TEntityFields>();
+  for (const name in relations) {
+    const relationsForName = relations[name];
+    for (const fieldName in relationsForName) {
+      if (relationsForName[fieldName].arity !== 'inverse') {
+        safeAdd(typesWithOutboundRelations, name as unknown as keyof TEntityFields);
+        break;
+      }
+    }
+  }
+  const linksArbitraryCache = new SMap<string, EntityLinksArbitrary<TEntityFields>>();
   const initialStateArb = constant(buildInitialProductionState(relations, defaultEntities));
   return chainUntil(initialStateArb, (state) => {
-    if (state.nextIndex >= state.toBeProducedEntities.length) {
-      return undefined;
+    const toBeProducedEntities = state.toBeProducedEntities;
+    for (let index = state.nextIndex; index < toBeProducedEntities.length; ++index) {
+      if (safeHas(typesWithOutboundRelations, toBeProducedEntities[index].type)) {
+        // At least one pending entity has links to build: process all currently pending entities in one batch
+        return new EntityBatchStepArbitrary(
+          relations,
+          inversedRelations,
+          typesWithOutboundRelations,
+          linksArbitraryCache,
+          state,
+        );
+      }
     }
-    let offset = 0;
-    let next: ReturnType<typeof buildEntityStepArbitrary<TEntityFields, TEntityRelations>> = undefined;
-    while (next === undefined && state.nextIndex + offset < state.toBeProducedEntities.length) {
-      // Loop until we either:
-      // - find an entity with relevant links to build
-      // - reach the end of the set of entities to be built
-      next = buildEntityStepArbitrary(relations, inversedRelations, state, offset);
-      offset += 1;
-    }
-    return next;
+    return undefined;
   }).map((state) => {
     const readOnlyProducedLinks: ReadonlyProducedLinks<TEntityFields, TEntityRelations> = state.producedLinks;
     return readOnlyProducedLinks as ProducedLinks<TEntityFields, TEntityRelations>;

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -29,7 +29,7 @@ import type {
   EntityLinks,
   EntityRelations,
   ProducedLinks,
-  ReadonlyProducedLinks,
+  ReadonlyEntityLinks,
   Relationship,
   Strategy,
 } from './interfaces/EntityGraphTypes.js';
@@ -88,17 +88,49 @@ function buildLinkIndexArbitrary(
 }
 
 /** @internal */
-function createEmptyLinksInstanceFor<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+type ProductionMeta<TEntityFields> = {
+  /** All the entity type names, in declaration order of `relations` */
+  typeNames: Extract<keyof TEntityFields, string>[];
+  /** Mapping from an entity type name onto its index within `typeNames` (and within per-state arrays) */
+  indexOfType: Map<keyof TEntityFields, number>;
+  /** For each entity type (same indexing as `typeNames`): the inverse relations to pre-fill on any newly created entity */
+  inverseRelationTemplates: { name: string; type: keyof TEntityFields }[][];
+};
+
+/** @internal */
+function buildProductionMeta<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
-  targetType: keyof TEntityFields,
+): ProductionMeta<TEntityFields> {
+  const typeNames: Extract<keyof TEntityFields, string>[] = [];
+  const indexOfType = new SMap<keyof TEntityFields, number>();
+  const inverseRelationTemplates: { name: string; type: keyof TEntityFields }[][] = [];
+  for (const name in relations) {
+    const typeName = name as unknown as Extract<keyof TEntityFields, string>;
+    safeMapSet(indexOfType, typeName, typeNames.length);
+    safePush(typeNames, typeName);
+    const template: { name: string; type: keyof TEntityFields }[] = [];
+    const relationsForType = relations[name];
+    for (const relationName in relationsForType) {
+      const relation = relationsForType[relationName];
+      if (relation.arity === 'inverse') {
+        safePush(template, { name: relationName, type: relation.type });
+      }
+    }
+    safePush(inverseRelationTemplates, template);
+  }
+  return { typeNames, indexOfType, inverseRelationTemplates };
+}
+
+/** @internal */
+function createEmptyLinksInstanceFor<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
+  meta: ProductionMeta<TEntityFields>,
+  targetTypeIndex: number,
 ): EntityLinks<TEntityFields, TEntityRelations> {
   const emptyLinksInstance = safeObjectCreate(null);
-  const relationsForType = relations[targetType];
-  for (const name in relationsForType) {
-    const relation = relationsForType[name];
-    if (relation.arity === 'inverse') {
-      emptyLinksInstance[name] = { type: relation.type, index: [] };
-    }
+  const template = meta.inverseRelationTemplates[targetTypeIndex];
+  for (let templateIndex = 0; templateIndex !== template.length; ++templateIndex) {
+    const entry = template[templateIndex];
+    emptyLinksInstance[entry.name] = { type: entry.type, index: [] };
   }
   return emptyLinksInstance;
 }
@@ -139,52 +171,76 @@ function assertAcceptableRelations<TEntityFields, TEntityRelations extends Entit
 }
 
 /** @internal */
-type ToBeProducedEntity<TEntityFields> = { type: keyof TEntityFields; indexInType: number; depth: number };
+type ToBeProducedEntity<TEntityFields> = {
+  type: keyof TEntityFields;
+  typeIndex: number;
+  indexInType: number;
+  depth: number;
+};
 
 /** @internal */
 type ProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> = {
-  readonly producedLinks: ReadonlyProducedLinks<TEntityFields, TEntityRelations>;
+  /** Per-type produced links, indexed according to `ProductionMeta.typeNames` */
+  readonly producedLinks: ReadonlyArray<ReadonlyArray<ReadonlyEntityLinks<TEntityFields, TEntityRelations>>>;
   readonly toBeProducedEntities: ReadonlyArray<Readonly<ToBeProducedEntity<TEntityFields>>>;
   readonly nextIndex: number;
 };
 
 /**
  * Copy-on-write draft over a {@link ProductionState} able to absorb the edits of SEVERAL entities in a row.
- * The underlying state is cloned lazily (top-level map and inner structures) only once per batch: edits applied
+ * The underlying state is cloned lazily (top-level array and inner structures) only once per batch: edits applied
  * for one entity of the batch stay visible to the next ones without any extra cloning.
  * Once `commit` has been called the draft must not be edited anymore: the committed state is immutable.
  * @internal
  */
-function draftBatchProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  state: ProductionState<TEntityFields, TEntityRelations>,
-) {
-  const { producedLinks, toBeProducedEntities } = state;
+class ProductionDraft<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> {
+  /** Per-type produced links as committed by the previous state — MUST never be mutated */
+  private readonly basedOnProducedLinks: ReadonlyArray<
+    ReadonlyArray<ReadonlyEntityLinks<TEntityFields, TEntityRelations>>
+  >;
+  /** Per-type produced links for the state being drafted — inner containers are copied-on-write from `basedOnProducedLinks` */
+  private readonly producedLinks: EntityLinks<TEntityFields, TEntityRelations>[][];
+  private readonly basedOnToBeProducedEntities: ReadonlyArray<Readonly<ToBeProducedEntity<TEntityFields>>>;
+  private newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined;
 
-  const newProducedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectAssign(
-    safeObjectCreate(null),
-    producedLinks,
-  );
-  function getOrCreateProducedLinksFor(type: keyof TEntityFields) {
-    if (newProducedLinks[type] === producedLinks[type]) {
-      newProducedLinks[type] = safeSlice(producedLinks[type] as (typeof newProducedLinks)[typeof type]);
-    }
-    return newProducedLinks[type];
+  constructor(
+    private readonly meta: ProductionMeta<TEntityFields>,
+    state: ProductionState<TEntityFields, TEntityRelations>,
+  ) {
+    this.basedOnProducedLinks = state.producedLinks;
+    // The top-level container being a simple array, cloning it per batch stays cheap whatever the number of types.
+    this.producedLinks = safeSlice(state.producedLinks as EntityLinks<TEntityFields, TEntityRelations>[][]);
+    this.basedOnToBeProducedEntities = state.toBeProducedEntities;
+    this.newToBeProducedEntities = undefined;
   }
-  function getOrCreateLinksFor(type: keyof TEntityFields, indexInType: number) {
-    const producedLinksForType = getOrCreateProducedLinksFor(type);
-    if (producedLinksForType[indexInType] === producedLinks[type][indexInType]) {
-      producedLinksForType[indexInType] = safeObjectAssign(safeObjectCreate(null), producedLinks[type][indexInType]);
+
+  private getOrCreateProducedLinksFor(typeIndex: number): EntityLinks<TEntityFields, TEntityRelations>[] {
+    let producedLinksForType = this.producedLinks[typeIndex];
+    if (producedLinksForType === this.basedOnProducedLinks[typeIndex]) {
+      producedLinksForType = safeSlice(producedLinksForType);
+      this.producedLinks[typeIndex] = producedLinksForType;
     }
-    return producedLinksForType[indexInType];
+    return producedLinksForType;
   }
-  function getOrCreateRelationFor(
-    type: keyof TEntityFields,
+
+  private getOrCreateLinksFor(typeIndex: number, indexInType: number): EntityLinks<TEntityFields, TEntityRelations> {
+    const producedLinksForType = this.getOrCreateProducedLinksFor(typeIndex);
+    let links = producedLinksForType[indexInType];
+    if (links === this.basedOnProducedLinks[typeIndex][indexInType]) {
+      links = safeObjectAssign(safeObjectCreate(null), links);
+      producedLinksForType[indexInType] = links;
+    }
+    return links;
+  }
+
+  private getOrCreateRelationFor(
+    typeIndex: number,
     indexInType: number,
     property: keyof TEntityRelations[keyof TEntityFields],
   ) {
-    const links = getOrCreateLinksFor(type, indexInType);
-    // `originalEntity` is `undefined` for entities just enqueued in this draft: they only exist in the cloned per-type array, not yet in `producedLinks`.
-    const originalEntity = producedLinks[type][indexInType];
+    const links = this.getOrCreateLinksFor(typeIndex, indexInType);
+    // `originalEntity` is `undefined` for entities just enqueued in this draft: they only exist in the cloned per-type array, not yet in `basedOnProducedLinks`.
+    const originalEntity = this.basedOnProducedLinks[typeIndex][indexInType];
     if (originalEntity !== undefined && links[property] === originalEntity[property]) {
       const sharedRelation = links[property];
       // When `index` is an array, clone it — otherwise we'd keep sharing it (and mutating it) with the previous state.
@@ -196,84 +252,98 @@ function draftBatchProductionState<TEntityFields, TEntityRelations extends Entit
     return links[property];
   }
 
-  let newToBeProducedEntities: ToBeProducedEntity<TEntityFields>[] | undefined = undefined;
+  // Read functions
+  countInType(typeIndex: number): number {
+    return this.producedLinks[typeIndex].length;
+  }
 
-  return {
-    // Read functions
-    countInType: (type: keyof TEntityFields): number => newProducedLinks[type].length,
-    countToBeProduced: (): number =>
-      newToBeProducedEntities !== undefined ? newToBeProducedEntities.length : toBeProducedEntities.length,
-    toBeProducedAt: (entityIndex: number): Readonly<ToBeProducedEntity<TEntityFields>> =>
-      newToBeProducedEntities !== undefined ? newToBeProducedEntities[entityIndex] : toBeProducedEntities[entityIndex],
-    // Edit functions
-    setOutboundLink: (
-      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
-      name: keyof TEntityRelations[keyof TEntityFields],
-      value: {
-        type: keyof TEntityFields;
-        index: number[] | number | undefined;
-      },
-    ) => {
-      const currentLinks = getOrCreateLinksFor(currentEntity.type, currentEntity.indexInType); // All the links going from the current entity to others
-      currentLinks[name] = value;
+  countToBeProduced(): number {
+    return this.newToBeProducedEntities !== undefined
+      ? this.newToBeProducedEntities.length
+      : this.basedOnToBeProducedEntities.length;
+  }
+
+  toBeProducedAt(entityIndex: number): Readonly<ToBeProducedEntity<TEntityFields>> {
+    return this.newToBeProducedEntities !== undefined
+      ? this.newToBeProducedEntities[entityIndex]
+      : this.basedOnToBeProducedEntities[entityIndex];
+  }
+
+  // Edit functions
+  setOutboundLink(
+    currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+    name: keyof TEntityRelations[keyof TEntityFields],
+    value: {
+      type: keyof TEntityFields;
+      index: number[] | number | undefined;
     },
-    enqueueNewEntity: (
-      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
-      relations: TEntityRelations,
-      targetType: keyof TEntityFields,
-    ) => {
-      const producedLinksInTargetType = getOrCreateProducedLinksFor(targetType);
-      const newEntityIndexInType = producedLinksInTargetType.length;
-      if (newToBeProducedEntities === undefined) {
-        newToBeProducedEntities = safeSlice(toBeProducedEntities as (typeof toBeProducedEntities)[number][]);
-      }
-      safePush(newToBeProducedEntities, {
-        type: targetType,
-        indexInType: newEntityIndexInType,
-        depth: currentEntity.depth + 1,
-      });
-      safePush(producedLinksInTargetType, createEmptyLinksInstanceFor(relations, targetType));
-      return newEntityIndexInType;
-    },
-    appendBackReference: (
-      currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
-      targetType: keyof TEntityFields,
-      indexInType: number,
-      property: string,
-    ) => {
-      const relation = getOrCreateRelationFor(targetType, indexInType, property);
-      const knownInversedLinks = relation.index;
-      safePush(knownInversedLinks as Exclude<typeof knownInversedLinks, number | undefined>, currentEntity.indexInType);
-    },
-    // Seal the batch into a new immutable state pointing right after the last entity of the batch.
-    commit: (nextIndex: number): ProductionState<TEntityFields, TEntityRelations> => ({
-      producedLinks: newProducedLinks,
-      toBeProducedEntities: newToBeProducedEntities !== undefined ? newToBeProducedEntities : toBeProducedEntities,
+  ): void {
+    // All the links going from the current entity to others
+    const currentLinks = this.getOrCreateLinksFor(currentEntity.typeIndex, currentEntity.indexInType);
+    currentLinks[name] = value;
+  }
+
+  enqueueNewEntity(
+    currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+    targetType: keyof TEntityFields,
+    targetTypeIndex: number,
+  ): number {
+    const producedLinksInTargetType = this.getOrCreateProducedLinksFor(targetTypeIndex);
+    const newEntityIndexInType = producedLinksInTargetType.length;
+    if (this.newToBeProducedEntities === undefined) {
+      this.newToBeProducedEntities = safeSlice(this.basedOnToBeProducedEntities as ToBeProducedEntity<TEntityFields>[]);
+    }
+    safePush(this.newToBeProducedEntities, {
+      type: targetType,
+      typeIndex: targetTypeIndex,
+      indexInType: newEntityIndexInType,
+      depth: currentEntity.depth + 1,
+    });
+    safePush(
+      producedLinksInTargetType,
+      createEmptyLinksInstanceFor<TEntityFields, TEntityRelations>(this.meta, targetTypeIndex),
+    );
+    return newEntityIndexInType;
+  }
+
+  appendBackReference(
+    currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
+    targetTypeIndex: number,
+    indexInType: number,
+    property: string,
+  ): void {
+    const relation = this.getOrCreateRelationFor(targetTypeIndex, indexInType, property);
+    const knownInversedLinks = relation.index;
+    safePush(knownInversedLinks as Exclude<typeof knownInversedLinks, number | undefined>, currentEntity.indexInType);
+  }
+
+  // Seal the batch into a new immutable state pointing right after the last entity of the batch.
+  commit(nextIndex: number): ProductionState<TEntityFields, TEntityRelations> {
+    return {
+      producedLinks: this.producedLinks,
+      toBeProducedEntities:
+        this.newToBeProducedEntities !== undefined ? this.newToBeProducedEntities : this.basedOnToBeProducedEntities,
       nextIndex,
-    }),
-  };
+    };
+  }
 }
 
 /** @internal */
-type BatchProductionStateDraft<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>> = ReturnType<
-  typeof draftBatchProductionState<TEntityFields, TEntityRelations>
->;
-
-/** @internal */
 function buildInitialProductionState<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  relations: TEntityRelations,
+  meta: ProductionMeta<TEntityFields>,
   defaultEntities: (keyof TEntityFields)[],
 ): ProductionState<TEntityFields, TEntityRelations> {
   // The set of all produced links between entities.
-  const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
-  for (const name in relations) {
-    producedLinks[name as Extract<keyof TEntityFields, string>] = [];
+  const producedLinks: EntityLinks<TEntityFields, TEntityRelations>[][] = [];
+  for (let typeIndex = 0; typeIndex !== meta.typeNames.length; ++typeIndex) {
+    safePush(producedLinks, []);
   }
   // Made of any entity whose links have to be created before building the whole graph.
-  const toBeProducedEntities: { type: keyof TEntityFields; indexInType: number; depth: number }[] = [];
+  const toBeProducedEntities: ToBeProducedEntity<TEntityFields>[] = [];
   for (const name of defaultEntities) {
-    safePush(toBeProducedEntities, { type: name, indexInType: producedLinks[name].length, depth: 0 });
-    safePush(producedLinks[name], createEmptyLinksInstanceFor(relations, name));
+    const typeIndex = safeMapGet(meta.indexOfType, name) as number;
+    safePush(toBeProducedEntities, { type: name, typeIndex, indexInType: producedLinks[typeIndex].length, depth: 0 });
+    safePush(producedLinks[typeIndex], createEmptyLinksInstanceFor<TEntityFields, TEntityRelations>(meta, typeIndex));
   }
   return { producedLinks, toBeProducedEntities, nextIndex: 0 };
 }
@@ -282,6 +352,7 @@ function buildInitialProductionState<TEntityFields, TEntityRelations extends Ent
 type EntityLinkContext<TEntityFields> = {
   name: string;
   relation: Relationship<keyof TEntityFields>;
+  targetTypeIndex: number;
   sentinelLinkIndex: number;
   inversedProperty: string | undefined;
 };
@@ -311,12 +382,14 @@ type EntityLinksArbitrary<TEntityFields> = {
  */
 function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
+  meta: ProductionMeta<TEntityFields>,
   inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
   cache: Map<string, EntityLinksArbitrary<TEntityFields>>,
-  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  draft: ProductionDraft<TEntityFields, TEntityRelations>,
   currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
 ): EntityLinksArbitrary<TEntityFields> {
   const currentRelations = relations[currentEntity.type];
+  const indexOfType = meta.indexOfType;
   // Cache key: full parameterization of the arbitraries except the depth (handled via the mutable depthIdentifier)
   let cacheKey = currentEntity.type as string;
   for (const name in currentRelations) {
@@ -324,7 +397,7 @@ function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends Entit
     if (relation.arity === 'inverse') {
       continue;
     }
-    const countInTargetType = draft.countInType(relation.type);
+    const countInTargetType = draft.countInType(safeMapGet(indexOfType, relation.type) as number);
     cacheKey +=
       relation.type === currentEntity.type
         ? '|' + countInTargetType + ':' + currentEntity.indexInType
@@ -344,7 +417,8 @@ function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends Entit
       continue;
     }
     const targetType = relation.type;
-    const countInTargetType = draft.countInType(targetType);
+    const targetTypeIndex = safeMapGet(indexOfType, targetType) as number;
+    const countInTargetType = draft.countInType(targetTypeIndex);
     const linkOrLinksArbitrary = buildLinkIndexArbitrary(
       relation.arity,
       relation.strategy || 'any',
@@ -357,6 +431,7 @@ function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends Entit
     safePush(linkContexts, {
       name,
       relation,
+      targetTypeIndex,
       sentinelLinkIndex: countInTargetType,
       inversedProperty: inversed !== undefined ? inversed.property : undefined,
     });
@@ -375,40 +450,28 @@ function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends Entit
  * @internal
  */
 function applyEntityLinks<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  relations: TEntityRelations,
-  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  draft: ProductionDraft<TEntityFields, TEntityRelations>,
   currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
   results: EntityStepResults,
   linkContexts: EntityLinkContext<TEntityFields>[],
 ): void {
   for (let resultIndex = 0; resultIndex !== results.length; ++resultIndex) {
     const linkOrLinks = results[resultIndex];
-    const { name, relation, sentinelLinkIndex, inversedProperty } = linkContexts[resultIndex];
+    const linkContext = linkContexts[resultIndex];
 
     let index: number[] | number | undefined;
     if (linkOrLinks === undefined) {
       index = undefined;
     } else if (typeof linkOrLinks === 'number') {
-      index = resolveOneEntityLink(
-        relations,
-        draft,
-        currentEntity,
-        relation,
-        sentinelLinkIndex,
-        inversedProperty,
-        linkOrLinks,
-      );
+      index = resolveOneEntityLink(draft, currentEntity, linkContext, linkOrLinks);
     } else {
       const effectiveLinks: number[] = [];
-      for (const link of linkOrLinks) {
-        safePush(
-          effectiveLinks,
-          resolveOneEntityLink(relations, draft, currentEntity, relation, sentinelLinkIndex, inversedProperty, link),
-        );
+      for (let linkIndex = 0; linkIndex !== linkOrLinks.length; ++linkIndex) {
+        safePush(effectiveLinks, resolveOneEntityLink(draft, currentEntity, linkContext, linkOrLinks[linkIndex]));
       }
       index = effectiveLinks;
     }
-    draft.setOutboundLink(currentEntity, name, { type: relation.type, index });
+    draft.setOutboundLink(currentEntity, linkContext.name, { type: linkContext.relation.type, index });
   }
 }
 
@@ -417,26 +480,32 @@ function applyEntityLinks<TEntityFields, TEntityRelations extends EntityRelation
  * @internal
  */
 function resolveOneEntityLink<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  relations: TEntityRelations,
-  draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+  draft: ProductionDraft<TEntityFields, TEntityRelations>,
   currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
-  relation: Relationship<keyof TEntityFields>,
-  sentinelLinkIndex: number,
-  inversedProperty: string | undefined,
+  linkContext: EntityLinkContext<TEntityFields>,
   link: number,
 ): number {
   let newEntityIndexInType: number;
-  if (link >= sentinelLinkIndex) {
+  if (link >= linkContext.sentinelLinkIndex) {
     // Links at or above sentinelLinkIndex mark "create a new entity"; enqueueNewEntity
     // allocates one and returns its index-in-type for later links to reuse.
     // Known limitation of current design: reuse is scoped to the current relation name
     // two relation names requesting a new entity of the same type get two separate entities.
-    newEntityIndexInType = draft.enqueueNewEntity(currentEntity, relations, relation.type);
+    newEntityIndexInType = draft.enqueueNewEntity(
+      currentEntity,
+      linkContext.relation.type,
+      linkContext.targetTypeIndex,
+    );
   } else {
     newEntityIndexInType = link;
   }
-  if (inversedProperty !== undefined) {
-    draft.appendBackReference(currentEntity, relation.type, newEntityIndexInType, inversedProperty);
+  if (linkContext.inversedProperty !== undefined) {
+    draft.appendBackReference(
+      currentEntity,
+      linkContext.targetTypeIndex,
+      newEntityIndexInType,
+      linkContext.inversedProperty,
+    );
   }
   return newEntityIndexInType;
 }
@@ -475,6 +544,7 @@ class EntityBatchStepArbitrary<
 > extends Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
   constructor(
     readonly relations: TEntityRelations,
+    readonly meta: ProductionMeta<TEntityFields>,
     readonly inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
     readonly typesWithOutboundRelations: Set<keyof TEntityFields>,
     readonly linksArbitraryCache: Map<string, EntityLinksArbitrary<TEntityFields>>,
@@ -488,7 +558,7 @@ class EntityBatchStepArbitrary<
    * apply them onto the draft and append the freshly built record into records
    */
   private generateOneEntity(
-    draft: BatchProductionStateDraft<TEntityFields, TEntityRelations>,
+    draft: ProductionDraft<TEntityFields, TEntityRelations>,
     records: EntityBatchRecord<TEntityFields>[],
     entityIndex: number,
     currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
@@ -497,6 +567,7 @@ class EntityBatchStepArbitrary<
   ): void {
     const linksArbitrary = buildEntityLinksArbitrary(
       this.relations,
+      this.meta,
       this.inversedRelations,
       this.linksArbitraryCache,
       draft,
@@ -514,7 +585,7 @@ class EntityBatchStepArbitrary<
       safePush(subValues, generated.value_);
       safePush(subContexts, generated.context);
     }
-    applyEntityLinks(this.relations, draft, currentEntity, subValues, linksArbitrary.linkContexts);
+    applyEntityLinks(draft, currentEntity, subValues, linksArbitrary.linkContexts);
     safePush(records, {
       entityIndex,
       entity: currentEntity,
@@ -527,7 +598,7 @@ class EntityBatchStepArbitrary<
 
   generate(mrng: Random, biasFactor: number | undefined): Value<ProductionState<TEntityFields, TEntityRelations>> {
     const lastState = this.lastState;
-    const draft = draftBatchProductionState(lastState);
+    const draft = new ProductionDraft<TEntityFields, TEntityRelations>(this.meta, lastState);
     const records: EntityBatchRecord<TEntityFields>[] = [];
     // The batch covers all the pending entities, including the ones enqueued while running it
     for (let entityIndex = lastState.nextIndex; entityIndex !== draft.countToBeProduced(); ++entityIndex) {
@@ -567,18 +638,18 @@ class EntityBatchStepArbitrary<
       const shrinks = tupleShrink(record.linksArbitrary.subArbitraries, record.value, record.context as unknown[]);
 
       for (const shrunkValue of shrinks) {
-        const draft = draftBatchProductionState(lastState);
+        const draft = new ProductionDraft<TEntityFields, TEntityRelations>(this.meta, lastState);
         const newRecords: EntityBatchRecord<TEntityFields>[] = safeSlice(records, 0, level);
 
         // Replay entities before this level unchanged (their stored link contexts stay valid:
         // the state they were derived from is replayed identically)
         for (let priorLevel = 0; priorLevel !== level; ++priorLevel) {
           const prior = records[priorLevel];
-          applyEntityLinks(this.relations, draft, prior.entity, prior.value, prior.linksArbitrary.linkContexts);
+          applyEntityLinks(draft, prior.entity, prior.value, prior.linksArbitrary.linkContexts);
         }
 
         // Apply the shrunk entity at this level
-        applyEntityLinks(this.relations, draft, record.entity, shrunkValue.value_, record.linksArbitrary.linkContexts);
+        applyEntityLinks(draft, record.entity, shrunkValue.value_, record.linksArbitrary.linkContexts);
         safePush(newRecords, {
           entityIndex: record.entityIndex,
           entity: record.entity,
@@ -628,6 +699,7 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
 ): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
   assertAcceptableRelations(relations);
 
+  const meta = buildProductionMeta<TEntityFields, TEntityRelations>(relations);
   const inversedRelations = buildInversedRelationsMapping(relations);
   // Types referenced below have at least one outbound link to produce per entity:
   // entities of any other type can safely be skipped, they consume no randomness at all.
@@ -642,7 +714,7 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
     }
   }
   const linksArbitraryCache = new SMap<string, EntityLinksArbitrary<TEntityFields>>();
-  const initialStateArb = constant(buildInitialProductionState(relations, defaultEntities));
+  const initialStateArb = constant(buildInitialProductionState<TEntityFields, TEntityRelations>(meta, defaultEntities));
   return chainUntil(initialStateArb, (state) => {
     const toBeProducedEntities = state.toBeProducedEntities;
     for (let index = state.nextIndex; index < toBeProducedEntities.length; ++index) {
@@ -650,6 +722,7 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
         // At least one pending entity has links to build: process all currently pending entities in one batch
         return new EntityBatchStepArbitrary(
           relations,
+          meta,
           inversedRelations,
           typesWithOutboundRelations,
           linksArbitraryCache,
@@ -659,7 +732,15 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
     }
     return undefined;
   }).map((state) => {
-    const readOnlyProducedLinks: ReadonlyProducedLinks<TEntityFields, TEntityRelations> = state.producedLinks;
-    return readOnlyProducedLinks as ProducedLinks<TEntityFields, TEntityRelations>;
+    // Materialize the internal per-type arrays into the externally visible dictionary keyed by entity type names.
+    const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
+    const { typeNames } = meta;
+    for (let typeIndex = 0; typeIndex !== typeNames.length; ++typeIndex) {
+      producedLinks[typeNames[typeIndex]] = state.producedLinks[typeIndex] as EntityLinks<
+        TEntityFields,
+        TEntityRelations
+      >[];
+    }
+    return producedLinks;
   });
 }

--- a/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.ts
@@ -30,7 +30,6 @@ import type {
   EntityRelations,
   ProducedLinks,
   ReadonlyEntityLinks,
-  Relationship,
   Strategy,
 } from './interfaces/EntityGraphTypes.js';
 
@@ -87,6 +86,19 @@ function buildLinkIndexArbitrary(
   }
 }
 
+/**
+ * Pre-extracted details for one forward (ie non-inverse) relationship of a given entity type
+ * @internal
+ */
+type ForwardRelationSetup<TEntityFields> = {
+  name: string;
+  arity: Exclude<Arity, 'inverse'>;
+  strategy: Strategy;
+  targetType: keyof TEntityFields;
+  targetTypeIndex: number;
+  inversedProperty: string | undefined;
+};
+
 /** @internal */
 type ProductionMeta<TEntityFields> = {
   /** All the entity type names, in declaration order of `relations` */
@@ -95,30 +107,48 @@ type ProductionMeta<TEntityFields> = {
   indexOfType: Map<keyof TEntityFields, number>;
   /** For each entity type (same indexing as `typeNames`): the inverse relations to pre-fill on any newly created entity */
   inverseRelationTemplates: { name: string; type: keyof TEntityFields }[][];
+  /** For each entity type (same indexing as `typeNames`): the pre-extracted forward relations to produce links for */
+  forwardRelationsPerType: ForwardRelationSetup<TEntityFields>[][];
 };
 
 /** @internal */
 function buildProductionMeta<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
 ): ProductionMeta<TEntityFields> {
+  const inversedRelations = buildInversedRelationsMapping<TEntityFields>(relations);
   const typeNames: Extract<keyof TEntityFields, string>[] = [];
   const indexOfType = new SMap<keyof TEntityFields, number>();
-  const inverseRelationTemplates: { name: string; type: keyof TEntityFields }[][] = [];
   for (const name in relations) {
     const typeName = name as unknown as Extract<keyof TEntityFields, string>;
     safeMapSet(indexOfType, typeName, typeNames.length);
     safePush(typeNames, typeName);
+  }
+  const inverseRelationTemplates: { name: string; type: keyof TEntityFields }[][] = [];
+  const forwardRelationsPerType: ForwardRelationSetup<TEntityFields>[][] = [];
+  for (const name in relations) {
     const template: { name: string; type: keyof TEntityFields }[] = [];
+    const forwardRelations: ForwardRelationSetup<TEntityFields>[] = [];
     const relationsForType = relations[name];
     for (const relationName in relationsForType) {
       const relation = relationsForType[relationName];
       if (relation.arity === 'inverse') {
         safePush(template, { name: relationName, type: relation.type });
+      } else {
+        const inversed = safeMapGet(inversedRelations, relation);
+        safePush(forwardRelations, {
+          name: relationName,
+          arity: relation.arity,
+          strategy: relation.strategy || 'any',
+          targetType: relation.type,
+          targetTypeIndex: safeMapGet(indexOfType, relation.type) as number,
+          inversedProperty: inversed !== undefined ? inversed.property : undefined,
+        });
       }
     }
     safePush(inverseRelationTemplates, template);
+    safePush(forwardRelationsPerType, forwardRelations);
   }
-  return { typeNames, indexOfType, inverseRelationTemplates };
+  return { typeNames, indexOfType, inverseRelationTemplates, forwardRelationsPerType };
 }
 
 /** @internal */
@@ -351,11 +381,28 @@ function buildInitialProductionState<TEntityFields, TEntityRelations extends Ent
 /** @internal */
 type EntityLinkContext<TEntityFields> = {
   name: string;
-  relation: Relationship<keyof TEntityFields>;
+  targetType: keyof TEntityFields;
   targetTypeIndex: number;
   sentinelLinkIndex: number;
   inversedProperty: string | undefined;
 };
+
+/**
+ * Counts (or indexes within own type) at or above this bound do not get their per-entity
+ * link arbitraries cached: they correspond to huge graphs unlikely to share their exact
+ * parameterization again, caching them would only grow the cache forever.
+ * @internal
+ */
+const maxCacheableCountInTargetType = 1024;
+
+/**
+ * Cache of {@link EntityLinksArbitrary} per entity type: nested sparse arrays indexed by the
+ * counts in the target types of every forward relation (plus the index of the entity within its
+ * own type for self-referencing relations), in relation order. Leaves hold the cached entries.
+ * Integer-indexed arrays measured faster than string-keyed maps on this hot path.
+ * @internal
+ */
+type EntityLinksArbitraryCache<TEntityFields> = (EntityLinksArbitrary<TEntityFields> | unknown[] | undefined)[][];
 
 /** @internal */
 type EntityStepResults = (number[] | number | undefined)[];
@@ -381,59 +428,65 @@ type EntityLinksArbitrary<TEntityFields> = {
  * @internal
  */
 function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
-  relations: TEntityRelations,
   meta: ProductionMeta<TEntityFields>,
-  inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
-  cache: Map<string, EntityLinksArbitrary<TEntityFields>>,
+  cache: EntityLinksArbitraryCache<TEntityFields>,
   draft: ProductionDraft<TEntityFields, TEntityRelations>,
   currentEntity: Readonly<ToBeProducedEntity<TEntityFields>>,
 ): EntityLinksArbitrary<TEntityFields> {
-  const currentRelations = relations[currentEntity.type];
-  const indexOfType = meta.indexOfType;
-  // Cache key: full parameterization of the arbitraries except the depth (handled via the mutable depthIdentifier)
-  let cacheKey = currentEntity.type as string;
-  for (const name in currentRelations) {
-    const relation = currentRelations[name];
-    if (relation.arity === 'inverse') {
-      continue;
+  const forwardRelations = meta.forwardRelationsPerType[currentEntity.typeIndex];
+  const lastRelationIndex = forwardRelations.length - 1;
+  // Cache walk: the full parameterization of the arbitraries except the depth (handled via the
+  // mutable depthIdentifier) maps onto a path of integer indexes within nested sparse arrays
+  let node: unknown[] | undefined = cache[currentEntity.typeIndex];
+  let leafKey = 0;
+  for (let relationIndex = 0; relationIndex !== forwardRelations.length; ++relationIndex) {
+    const forwardRelation = forwardRelations[relationIndex];
+    const countInTargetType = draft.countInType(forwardRelation.targetTypeIndex);
+    if (countInTargetType >= maxCacheableCountInTargetType) {
+      node = undefined; // never cached: build a fresh instance below
+      break;
     }
-    const countInTargetType = draft.countInType(safeMapGet(indexOfType, relation.type) as number);
-    cacheKey +=
-      relation.type === currentEntity.type
-        ? '|' + countInTargetType + ':' + currentEntity.indexInType
-        : '|' + countInTargetType;
+    const selfReferencing = forwardRelation.targetTypeIndex === currentEntity.typeIndex;
+    if (relationIndex !== lastRelationIndex) {
+      node = ((node as unknown[])[countInTargetType] ??= []) as unknown[];
+      if (selfReferencing) {
+        node = (node[currentEntity.indexInType] ??= []) as unknown[];
+      }
+    } else if (selfReferencing) {
+      node = ((node as unknown[])[countInTargetType] ??= []) as unknown[];
+      leafKey = currentEntity.indexInType;
+    } else {
+      leafKey = countInTargetType;
+    }
   }
-  const cached = safeMapGet(cache, cacheKey);
-  if (cached !== undefined) {
-    return cached;
+  if (node !== undefined) {
+    const cached = node[leafKey] as EntityLinksArbitrary<TEntityFields> | undefined;
+    if (cached !== undefined) {
+      return cached;
+    }
   }
   const currentEntityDepth = createDepthIdentifier();
   currentEntityDepth.depth = currentEntity.depth;
   const subArbitraries: Arbitrary<number[] | number | undefined>[] = [];
   const linkContexts: EntityLinkContext<TEntityFields>[] = [];
-  for (const name in currentRelations) {
-    const relation = currentRelations[name];
-    if (relation.arity === 'inverse') {
-      continue;
-    }
-    const targetType = relation.type;
-    const targetTypeIndex = safeMapGet(indexOfType, targetType) as number;
+  for (let relationIndex = 0; relationIndex !== forwardRelations.length; ++relationIndex) {
+    const forwardRelation = forwardRelations[relationIndex];
+    const { targetType, targetTypeIndex } = forwardRelation;
     const countInTargetType = draft.countInType(targetTypeIndex);
     const linkOrLinksArbitrary = buildLinkIndexArbitrary(
-      relation.arity,
-      relation.strategy || 'any',
-      targetType === currentEntity.type ? currentEntity.indexInType : undefined,
+      forwardRelation.arity,
+      forwardRelation.strategy,
+      targetTypeIndex === currentEntity.typeIndex ? currentEntity.indexInType : undefined,
       countInTargetType, // upper bound doubles as the "create a new entity" marker — see the link >= countInTargetType branch below
       currentEntityDepth,
     );
     safePush(subArbitraries, linkOrLinksArbitrary);
-    const inversed = safeMapGet(inversedRelations, relation);
     safePush(linkContexts, {
-      name,
-      relation,
+      name: forwardRelation.name,
+      targetType,
       targetTypeIndex,
       sentinelLinkIndex: countInTargetType,
-      inversedProperty: inversed !== undefined ? inversed.property : undefined,
+      inversedProperty: forwardRelation.inversedProperty,
     });
   }
   const entry: EntityLinksArbitrary<TEntityFields> = {
@@ -441,7 +494,9 @@ function buildEntityLinksArbitrary<TEntityFields, TEntityRelations extends Entit
     linkContexts,
     depthIdentifier: currentEntityDepth,
   };
-  safeMapSet(cache, cacheKey, entry);
+  if (node !== undefined) {
+    node[leafKey] = entry;
+  }
   return entry;
 }
 
@@ -471,7 +526,7 @@ function applyEntityLinks<TEntityFields, TEntityRelations extends EntityRelation
       }
       index = effectiveLinks;
     }
-    draft.setOutboundLink(currentEntity, linkContext.name, { type: linkContext.relation.type, index });
+    draft.setOutboundLink(currentEntity, linkContext.name, { type: linkContext.targetType, index });
   }
 }
 
@@ -491,11 +546,7 @@ function resolveOneEntityLink<TEntityFields, TEntityRelations extends EntityRela
     // allocates one and returns its index-in-type for later links to reuse.
     // Known limitation of current design: reuse is scoped to the current relation name
     // two relation names requesting a new entity of the same type get two separate entities.
-    newEntityIndexInType = draft.enqueueNewEntity(
-      currentEntity,
-      linkContext.relation.type,
-      linkContext.targetTypeIndex,
-    );
+    newEntityIndexInType = draft.enqueueNewEntity(currentEntity, linkContext.targetType, linkContext.targetTypeIndex);
   } else {
     newEntityIndexInType = link;
   }
@@ -543,11 +594,8 @@ class EntityBatchStepArbitrary<
   TEntityRelations extends EntityRelations<TEntityFields>,
 > extends Arbitrary<ProductionState<TEntityFields, TEntityRelations>> {
   constructor(
-    readonly relations: TEntityRelations,
     readonly meta: ProductionMeta<TEntityFields>,
-    readonly inversedRelations: ReturnType<typeof buildInversedRelationsMapping<TEntityFields>>,
-    readonly typesWithOutboundRelations: Set<keyof TEntityFields>,
-    readonly linksArbitraryCache: Map<string, EntityLinksArbitrary<TEntityFields>>,
+    readonly linksArbitraryCache: EntityLinksArbitraryCache<TEntityFields>,
     readonly lastState: ProductionState<TEntityFields, TEntityRelations>,
   ) {
     super();
@@ -565,14 +613,7 @@ class EntityBatchStepArbitrary<
     mrng: Random,
     biasFactor: number | undefined,
   ): void {
-    const linksArbitrary = buildEntityLinksArbitrary(
-      this.relations,
-      this.meta,
-      this.inversedRelations,
-      this.linksArbitraryCache,
-      draft,
-      currentEntity,
-    );
+    const linksArbitrary = buildEntityLinksArbitrary(this.meta, this.linksArbitraryCache, draft, currentEntity);
     linksArbitrary.depthIdentifier.depth = currentEntity.depth;
     const clonedMrng = mrng.clone();
     const subArbitraries = linksArbitrary.subArbitraries;
@@ -598,12 +639,13 @@ class EntityBatchStepArbitrary<
 
   generate(mrng: Random, biasFactor: number | undefined): Value<ProductionState<TEntityFields, TEntityRelations>> {
     const lastState = this.lastState;
+    const forwardRelationsPerType = this.meta.forwardRelationsPerType;
     const draft = new ProductionDraft<TEntityFields, TEntityRelations>(this.meta, lastState);
     const records: EntityBatchRecord<TEntityFields>[] = [];
     // The batch covers all the pending entities, including the ones enqueued while running it
     for (let entityIndex = lastState.nextIndex; entityIndex !== draft.countToBeProduced(); ++entityIndex) {
       const currentEntity = draft.toBeProducedAt(entityIndex);
-      if (!safeHas(this.typesWithOutboundRelations, currentEntity.type)) {
+      if (forwardRelationsPerType[currentEntity.typeIndex].length === 0) {
         continue; // entity without any outbound link to produce
       }
       this.generateOneEntity(draft, records, entityIndex, currentEntity, mrng, biasFactor);
@@ -664,7 +706,7 @@ class EntityBatchStepArbitrary<
         const mrng = record.clonedMrng.clone();
         for (let entityIndex = record.entityIndex + 1; entityIndex !== draft.countToBeProduced(); ++entityIndex) {
           const nextEntity = draft.toBeProducedAt(entityIndex);
-          if (!safeHas(this.typesWithOutboundRelations, nextEntity.type)) {
+          if (this.meta.forwardRelationsPerType[nextEntity.typeIndex].length === 0) {
             continue;
           }
           this.generateOneEntity(draft, newRecords, entityIndex, nextEntity, mrng, biasFactor);
@@ -692,46 +734,39 @@ class EntityBatchStepArbitrary<
   }
 }
 
-/** @internal */
+/**
+ * Prepare a builder of arbitraries producing links between entities.
+ *
+ * All the computations only depending on `relations` (validation, inverse relationships mapping
+ * and per entity type pre-extraction of the relationships) are performed once at preparation time,
+ * so that the returned builder can be invoked on every generation without paying for them again.
+ *
+ * @internal
+ */
 export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations extends EntityRelations<TEntityFields>>(
   relations: TEntityRelations,
-  defaultEntities: (keyof TEntityFields)[],
-): Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
+): (defaultEntities: (keyof TEntityFields)[]) => Arbitrary<ProducedLinks<TEntityFields, TEntityRelations>> {
   assertAcceptableRelations(relations);
 
   const meta = buildProductionMeta<TEntityFields, TEntityRelations>(relations);
-  const inversedRelations = buildInversedRelationsMapping(relations);
-  // Types referenced below have at least one outbound link to produce per entity:
-  // entities of any other type can safely be skipped, they consume no randomness at all.
-  const typesWithOutboundRelations = new SSet<keyof TEntityFields>();
-  for (const name in relations) {
-    const relationsForName = relations[name];
-    for (const fieldName in relationsForName) {
-      if (relationsForName[fieldName].arity !== 'inverse') {
-        safeAdd(typesWithOutboundRelations, name as unknown as keyof TEntityFields);
-        break;
-      }
-    }
+  const forwardRelationsPerType = meta.forwardRelationsPerType;
+  const linksArbitraryCache: EntityLinksArbitraryCache<TEntityFields> = [];
+  for (let typeIndex = 0; typeIndex !== meta.typeNames.length; ++typeIndex) {
+    safePush(linksArbitraryCache, []);
   }
-  const linksArbitraryCache = new SMap<string, EntityLinksArbitrary<TEntityFields>>();
-  const initialStateArb = constant(buildInitialProductionState<TEntityFields, TEntityRelations>(meta, defaultEntities));
-  return chainUntil(initialStateArb, (state) => {
+  const nextEntityBatchStepArbitrary = (state: ProductionState<TEntityFields, TEntityRelations>) => {
     const toBeProducedEntities = state.toBeProducedEntities;
     for (let index = state.nextIndex; index < toBeProducedEntities.length; ++index) {
-      if (safeHas(typesWithOutboundRelations, toBeProducedEntities[index].type)) {
+      // Types with at least one forward relation have outbound links to produce per entity:
+      // entities of any other type can safely be skipped, they consume no randomness at all.
+      if (forwardRelationsPerType[toBeProducedEntities[index].typeIndex].length !== 0) {
         // At least one pending entity has links to build: process all currently pending entities in one batch
-        return new EntityBatchStepArbitrary(
-          relations,
-          meta,
-          inversedRelations,
-          typesWithOutboundRelations,
-          linksArbitraryCache,
-          state,
-        );
+        return new EntityBatchStepArbitrary(meta, linksArbitraryCache, state);
       }
     }
     return undefined;
-  }).map((state) => {
+  };
+  const extractProducedLinks = (state: ProductionState<TEntityFields, TEntityRelations>) => {
     // Materialize the internal per-type arrays into the externally visible dictionary keyed by entity type names.
     const producedLinks: ProducedLinks<TEntityFields, TEntityRelations> = safeObjectCreate(null);
     const { typeNames } = meta;
@@ -742,5 +777,11 @@ export function onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations exte
       >[];
     }
     return producedLinks;
-  });
+  };
+  return (defaultEntities) => {
+    const initialStateArb = constant(
+      buildInitialProductionState<TEntityFields, TEntityRelations>(meta, defaultEntities),
+    );
+    return chainUntil(initialStateArb, nextEntityBatchStepArbitrary).map(extractProducedLinks);
+  };
 }

--- a/packages/fast-check/src/arbitrary/_internals/UnlinkedEntitiesForEntityGraph.ts
+++ b/packages/fast-check/src/arbitrary/_internals/UnlinkedEntitiesForEntityGraph.ts
@@ -1,4 +1,5 @@
 import type { Arbitrary } from '../../check/arbitrary/definition/Arbitrary.js';
+import { safePush } from '../../utils/globals.js';
 import { array } from '../array.js';
 import { record } from '../record.js';
 import type { RecordConstraints } from '../record.js';
@@ -9,26 +10,73 @@ import type { Arbitraries, UnlinkedEntities } from './interfaces/EntityGraphType
 const safeObjectCreate = Object.create;
 
 /** @internal */
+type PerEntityTypeSetup<TEntityFields> = {
+  name: Extract<keyof TEntityFields, string>;
+  entityArbitrary: Arbitrary<TEntityFields[keyof TEntityFields]>;
+  unicityConstraints: UniqueArrayConstraintsRecommended<TEntityFields[keyof TEntityFields], unknown>['selector'];
+  // Cache of the arbitraries responsible to produce `count` entities of the type `name`.
+  // Stored onto a null prototype object for fast and safe lookups on the hot path.
+  arbitraryPerCount: Record<number, Arbitrary<TEntityFields[keyof TEntityFields][]> | undefined>;
+};
+
+/**
+ * Prepare a builder of arbitraries producing the entities themselves (without any link).
+ *
+ * All the computations only depending on `arbitraries` and `constraints` (per entity type record
+ * arbitraries and unicity selectors) are performed once at preparation time, so that the returned
+ * builder can be invoked on every generation without paying for them again. Resulting arbitraries
+ * are cached per requested counts (one count per entity type) as only the requested counts may
+ * change across generations: they are fully shareable across generations as they are immutable.
+ *
+ * @internal
+ */
 export function unlinkedEntitiesForEntityGraph<TEntityFields>(
   arbitraries: Arbitraries<TEntityFields>,
-  countFor: (entityName: keyof TEntityFields) => number,
   unicityConstraintsFor: <TEntityName extends keyof TEntityFields>(
     entityName: TEntityName,
   ) => UniqueArrayConstraintsRecommended<TEntityFields[TEntityName], unknown>['selector'],
   constraints: Omit<RecordConstraints, 'requiredKeys'>,
-): Arbitrary<UnlinkedEntities<TEntityFields>> {
-  const recordModel: { [K in keyof TEntityFields]: Arbitrary<TEntityFields[K][]> } = safeObjectCreate(null);
+): (countFor: (entityName: keyof TEntityFields) => number) => Arbitrary<UnlinkedEntities<TEntityFields>> {
+  const perEntityTypeSetups: PerEntityTypeSetup<TEntityFields>[] = [];
   for (const name in arbitraries) {
     const entityRecordModel = arbitraries[name];
-    const entityArbitrary = record(entityRecordModel, constraints);
-    const count = countFor(name);
-    const unicityConstraints = unicityConstraintsFor(name);
-    const arrayConstraints = { minLength: count, maxLength: count };
-    recordModel[name] =
-      unicityConstraints !== undefined
-        ? (uniqueArray(entityArbitrary as any, { ...arrayConstraints, selector: unicityConstraints }) as any)
-        : (array(entityArbitrary, arrayConstraints) as any);
+    safePush(perEntityTypeSetups, {
+      name,
+      entityArbitrary: record(entityRecordModel, constraints) as Arbitrary<TEntityFields[keyof TEntityFields]>,
+      unicityConstraints: unicityConstraintsFor(name),
+      arbitraryPerCount: safeObjectCreate(null),
+    });
   }
-  // @ts-expect-error - We probably have a fishy typing issue in `record`, as we are supposed to produce `UnlinkedEntities<TEntityFields>`
-  return record<UnlinkedEntities<TEntityFields>>(recordModel);
+  const arbitraryPerCountsKey: Record<string, Arbitrary<UnlinkedEntities<TEntityFields>> | undefined> =
+    safeObjectCreate(null);
+  return (countFor) => {
+    let countsKey = '';
+    for (let index = 0; index !== perEntityTypeSetups.length; ++index) {
+      countsKey += countFor(perEntityTypeSetups[index].name) + ',';
+    }
+    const cachedArbitrary = arbitraryPerCountsKey[countsKey];
+    if (cachedArbitrary !== undefined) {
+      return cachedArbitrary;
+    }
+    const recordModel: { [K in keyof TEntityFields]: Arbitrary<TEntityFields[K][]> } = safeObjectCreate(null);
+    for (const { name, entityArbitrary, unicityConstraints, arbitraryPerCount } of perEntityTypeSetups) {
+      const count = countFor(name);
+      let entitiesArbitrary = arbitraryPerCount[count];
+      if (entitiesArbitrary === undefined) {
+        const arrayConstraints = { minLength: count, maxLength: count };
+        entitiesArbitrary =
+          unicityConstraints !== undefined
+            ? (uniqueArray(entityArbitrary as any, { ...arrayConstraints, selector: unicityConstraints }) as any)
+            : array(entityArbitrary, arrayConstraints);
+        arbitraryPerCount[count] = entitiesArbitrary;
+      }
+      recordModel[name] = entitiesArbitrary as any;
+    }
+    // Note: We probably have a fishy typing issue in `record`, as we are supposed to produce `UnlinkedEntities<TEntityFields>`
+    const unlinkedEntitiesArbitrary = record<UnlinkedEntities<TEntityFields>>(
+      recordModel as { [K in keyof UnlinkedEntities<TEntityFields>]: Arbitrary<UnlinkedEntities<TEntityFields>[K]> },
+    ) as unknown as Arbitrary<UnlinkedEntities<TEntityFields>>;
+    arbitraryPerCountsKey[countsKey] = unlinkedEntitiesArbitrary;
+    return unlinkedEntitiesArbitrary;
+  };
 }

--- a/packages/fast-check/src/arbitrary/entityGraph.ts
+++ b/packages/fast-check/src/arbitrary/entityGraph.ts
@@ -118,21 +118,24 @@ export function entityGraph<TEntityFields, TEntityRelations extends EntityRelati
   const initialPoolConstraints = constraints.initialPoolConstraints || safeObjectCreate(null);
   const unicityConstraints = constraints.unicityConstraints || safeObjectCreate(null);
   const unlinkedContraints = { noNullPrototype: constraints.noNullPrototype };
+  // Builders below are prepared once: everything only depending on `arbitraries`, `relations`
+  // and `constraints` is computed eagerly and not at every generation (chains re-run on each one)
+  const onTheFlyLinksFor = onTheFlyLinksForEntityGraph<TEntityFields, TEntityRelations>(relations);
+  const unlinkedEntitiesFor = unlinkedEntitiesForEntityGraph(
+    arbitraries,
+    (name) => unicityConstraints[name],
+    unlinkedContraints,
+  );
 
   return (
     // Step 1, Computing the list of default entities that should take part in the pool
     initialPoolForEntityGraph<keyof TEntityFields>(allKeys, initialPoolConstraints).chain((defaultEntities) =>
       // Step 2, Producing links between entities
-      onTheFlyLinksForEntityGraph(relations, defaultEntities).chain((producedLinks) =>
+      onTheFlyLinksFor(defaultEntities).chain((producedLinks) =>
         // Step 3, Producing entities themselves
         // As the number of entities for each kind requires the links to be produced,
         // it has to be executed as a chained computation
-        unlinkedEntitiesForEntityGraph(
-          arbitraries,
-          (name) => producedLinks[name].length,
-          (name) => unicityConstraints[name],
-          unlinkedContraints,
-        ).map((unlinkedEntities) =>
+        unlinkedEntitiesFor((name) => producedLinks[name].length).map((unlinkedEntities) =>
           // Step 4, Glueing links and entities together
           unlinkedToLinkedEntitiesMapper(unlinkedEntities, producedLinks),
         ),

--- a/packages/fast-check/test/unit/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/OnTheFlyLinksForEntityGraphArbitrary.spec.ts
@@ -175,7 +175,9 @@ describe('onTheFlyLinksForEntityGraph (integration)', () => {
   };
 
   const onTheFlyLinksForEntityGraphBuilder = (extra: Extra) =>
-    onTheFlyLinksForEntityGraph(extra.configurations, extra.defaultEntities);
+    onTheFlyLinksForEntityGraph<EntityFields, EntityRelations<EntityFields>>(extra.configurations)(
+      extra.defaultEntities,
+    );
 
   it('should produce the same values given the same seed', () => {
     assertProduceSameValueGivenSameSeed(onTheFlyLinksForEntityGraphBuilder, { extraParameters });


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

<!-- Describe your change and explain what this PR is trying to solve -->

From the end-user point of view, `fc.entityGraph` generates values significantly faster: on the repository's benchmark case (employee/team graph with a `successor` manager relation and unicity constraints), median generation time drops from 78.50 µs to 65.35 µs per value, i.e. **~16.8% faster** (8 interleaved A/B pairs of 30k generate calls on a quiet machine; an independent measurement series showed 17.2%). A second shape exercising `many`, `inverse` and `exclusive` relations across 3 entity types improved by **~14.6%**. There is no API change and no behavior change: for fixed seeds, generated values are byte-identical to before (verified by stringify-comparing 500-1000 seeded samples per shape against the previous build) and shrinking produces the identical counterexample with the identical number of shrink steps (21). One observable-but-benign timing change: invalid `relations` (e.g. mixing `exclusive` with other strategies) now throw at `fc.entityGraph(...)` construction instead of at first `generate`. Impact level: patch (changeset included).

Why this change: CPU profiling (V8 `--cpu-prof`) of `entityGraph(...).generate(...)` identified three independent overhead sources, each addressed by one commit (each was benchmarked standalone with interleaved A/B runs before being kept):

1. **🚀 Batch entity-link production per `chainUntil` hop** (+11% standalone): previously every entity paid one full `chainUntil` hop — an `mrng.clone()`, an entry record, a fresh `tuple(...).map(...)` arbitrary, and a complete copy-on-write draft + commit. A new internal `EntityBatchStepArbitrary` builds the whole graph in a single hop: it generates each entity's link sub-arbitraries sequentially from the same mrng (ranges stay value-dependent, so draws are identical to before), mutates one shared draft cloned once at batch start and committed once at the end, and implements shrinking by mirroring `chainUntil`'s replay strategy inside the batch (per-entity records with cloned mrngs; shrinking one entity replays the prefix and regenerates the suffix). Naively tupling several entities was not an option since entity B's integer ranges and "create a new entity" sentinel depend on counts entity A may have just changed.
2. **⚡️ Index per-type produced links by type index** (+13% standalone before batching, ~3% incremental on top of it): the per-step copy-on-write clone of the produced-links state was an `Object.assign(Object.create(null), ...)` over a dictionary-mode object; it is now a fast array `slice` over a plain array indexed by a precomputed type index, the seven per-step closures became a prototype-based `ProductionDraft` class, and inverse-relation link templates are precomputed per type. The user-facing null-prototype dictionary keyed by type names is materialized once per generated value, preserving key order and poisoning-safety.
3. **⚡️ Hoist per-generate re-construction out of the chains** (~7% incremental): because `.chain` callbacks run on every generate, `assertAcceptableRelations`, `buildInversedRelationsMapping`, per-type relation pre-extraction and the per-type `record(...)` construction were all re-executed per generated value; the builders are now curried so this happens once per `fc.entityGraph(...)` instance, and link-index/array arbitraries are cached across generates in integer-indexed sparse arrays (string-keyed Map caches were measured as a net regression and avoided; caches are bounded and live per instance, never module-global).

Trade-offs considered: the internal production state is less "obviously" shaped like the public value (arrays + type indexes instead of name-keyed dictionaries) and `OnTheFlyLinksForEntityGraphArbitrary.ts` grew a bespoke batch arbitrary in exchange for removing per-entity plumbing overhead; shrink quality is preserved by replicating `chainUntil`'s replay semantics rather than coarsening shrink granularity. A fourth candidate (micro-optimizing the final linking mapper, +4% standalone) was measured at only +0.3% on top of these and deliberately left out.

Tests: no new tests were added — this is a pure performance refactor whose contract is "same values, same shrinks, just faster", which existing tests pin down: `entityGraph.spec.ts`, `chainUntil.spec.ts`, `OnTheFlyLinksForEntityGraphArbitrary.spec.ts` and `UnlinkedToLinkedEntities.spec.ts` (26 tests, all passing) include same-seed reproducibility checks across randomized relation configurations that would fail on any deviation. The `OnTheFlyLinksForEntityGraphArbitrary` spec received a minimal mechanical update for the curried builder signature; its test intent is unchanged. Typecheck, lint and format checks are clean. Determinism and shrink-equivalence versus the pre-change build were additionally verified out-of-band as described above.

Scope note: the PR is focused on this single performance concern; it carries one tiny infrastructure commit (ignoring `.claude/worktrees/` in `.gitignore`/oxlint, needed to keep repository checks green while benchmark agents ran in worktrees).

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

https://claude.ai/code/session_013Mo8SMgXkpxbkeaiJ6xQgq