### PR TITLE
📝 Fix info box in docs

### DIFF
--- a/website/docs/tutorials/quick-start/our-first-property-based-test.md
+++ b/website/docs/tutorials/quick-start/our-first-property-based-test.md
@@ -41,7 +41,7 @@ A property can be expressed as follow:
 > such that precondition(x, y, ...) holds  
 > predicate(x, y, ...) is true
 
-:::info Property-based tests
+:::info
 You may want to refer to our [Why Property-Based?](/docs/introduction/why-property-based/) section to know more about the benefits and strengths of property-based tests.
 :::
 


### PR DESCRIPTION
## Description

The info box currently renders like this:

<img width="1558" height="429" alt="image" src="https://github.com/user-attachments/assets/a1fd8c65-ef2b-4b69-b51d-d956b3b11253" />

compared to a correctly rendered tip box, e.g. here:

<img width="1523" height="524" alt="image" src="https://github.com/user-attachments/assets/855499fa-8a4d-4f80-bc9b-31a0a04ef134" />


## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)