### PR TITLE
👷 Use pnpm version in changelog script

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,6 +19,11 @@ jobs:
           fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Using Node v24.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
       - name: Configure GIT
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,11 +19,6 @@ jobs:
           fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Using Node v24.x
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24.x'
-          cache: 'pnpm'
       - name: Configure GIT
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/scripts/generate-changelog.cjs
+++ b/.github/workflows/scripts/generate-changelog.cjs
@@ -272,7 +272,7 @@ async function run() {
     await execFile('git', ['add', changelogPath]);
 
     // Update the package.json
-    await execFile('npm', ['--no-git-tag-version', '--workspaces-update=false', 'version', releaseKind], {
+    await execFile('pnpm', ['version', releaseKind, '--no-git-tag-version'], {
       cwd: packageLocation,
     });
     const packageJsonPath = path.join(packageLocation, 'package.json');


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated
> agent (Claude Code, claude-opus-4-8) and has not been
> line-by-line reviewed by a human before submission.

The release-automation script `.github/workflows/scripts/generate-changelog.cjs` bumps each impacted package's version while generating changelogs. It did so by shelling out to `npm`:

```js
await execFile('npm', ['--no-git-tag-version', '--workspaces-update=false', 'version', releaseKind], {
  cwd: packageLocation,
});
```

Since the repository migrated to pnpm, `npm` is no longer part of the toolchain, and this command fails at runtime (`Command failed: npm --no-git-tag-version --workspaces-update=false version minor`), breaking changelog/version generation. This PR restores that step by using the pnpm equivalent:

```js
await execFile('pnpm', ['version', releaseKind, '--no-git-tag-version'], {
  cwd: packageLocation,
});
```

For end users there is no runtime or API impact — this is a CI/tooling-only fix that unblocks the release changelog workflow.

Why this design: `pnpm version <kind> --no-git-tag-version` is the direct counterpart of the previous call — it bumps only the local package's `package.json` and creates no git tag. The npm-specific `--workspaces-update=false` flag is intentionally dropped because pnpm's `version` command never rewrites dependent workspace `package.json` files in the first place, so there is no equivalent behavior to disable. I verified this in a scratch pnpm workspace: running the command inside a package subdirectory bumped only that package and left a dependent's `workspace:^` reference untouched.

Scope and impact: the change is limited to a single line in the CI script, touches no published package, and therefore needs no changeset. There are no automated tests around this workflow script, so the fix was validated manually against pnpm's `version` behavior as described above.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUiujUahNvnxraLeegWmqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUiujUahNvnxraLeegWmqy)_