### PR TITLE
👷 Allow unclean tree in changelog generation

### DIFF
--- a/.github/workflows/scripts/generate-changelog.cjs
+++ b/.github/workflows/scripts/generate-changelog.cjs
@@ -272,7 +272,7 @@ async function run() {
     await execFile('git', ['add', changelogPath]);
 
     // Update the package.json
-    await execFile('pnpm', ['version', releaseKind, '--no-git-tag-version'], {
+    await execFile('pnpm', ['version', releaseKind, '--no-git-tag-version', '--no-git-checks'], {
       cwd: packageLocation,
     });
     const packageJsonPath = path.join(packageLocation, 'package.json');


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated
> agent (Claude Code) and has not been line-by-line reviewed
> by a human before submission.

The changelog generation GitHub Action fails when bumping package versions:

```
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
Command failed: pnpm version minor --no-git-tag-version
```

The script (`.github/workflows/scripts/generate-changelog.cjs`) stages the updated `CHANGELOG.md` **before** calling `pnpm version`, so the working tree is intentionally dirty at that point. `pnpm version` refuses to run against a dirty tree by default, which aborts the whole changelog job.

This adds the `--no-git-checks` flag to the `pnpm version` invocation, which tells pnpm to skip the clean-working-tree check. The bump still uses `--no-git-tag-version`, so pnpm only edits `package.json` without committing or tagging — the script continues to handle staging, committing and pushing itself.

No behavior changes for end users of fast-check; this only unblocks the automated changelog/release preparation workflow so it can generate the CHANGELOG PR again.

The change is a single-line, single-concern fix scoped to the CI script. No automated test covers this script, so verification was limited to confirming (via `pnpm version --help`) that `--no-git-checks` is the documented flag for bypassing the unclean-working-tree check.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8VYZ1wLtYqJUWof7BigdL)_