### PR TITLE
👷 Announce on Bluesky when drafting the release

### DIFF
--- a/.github/workflows/announce-release-bluesky.yml
+++ b/.github/workflows/announce-release-bluesky.yml
@@ -1,11 +1,19 @@
 name: Announce Release on Bluesky
 
 on:
-  # Only fires if the release was published with RELEASE_PAT (see the
-  # "Update GitHub Release" steps in build-status.yml): events created
-  # with the default GITHUB_TOKEN never trigger workflows.
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag of the release to announce'
+        required: true
+        type: string
+    secrets:
+      BLUESKY_URL:
+        required: true
+      BLUESKY_IDENTIFIER:
+        required: true
+      BLUESKY_APP_PASSWORD:
+        required: true
 
 permissions:
   contents: read
@@ -32,6 +40,6 @@ jobs:
           BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
           BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag }}
         run: node .github/workflows/scripts/post-bluesky.mjs

--- a/.github/workflows/announce-release-bluesky.yml
+++ b/.github/workflows/announce-release-bluesky.yml
@@ -1,8 +1,19 @@
 name: Announce Release on Bluesky
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tags:
+        description: 'Space-separated list of release tags to announce'
+        required: true
+        type: string
+    secrets:
+      BLUESKY_URL:
+        required: true
+      BLUESKY_IDENTIFIER:
+        required: true
+      BLUESKY_APP_PASSWORD:
+        required: true
 
 permissions:
   contents: read
@@ -10,7 +21,6 @@ permissions:
 jobs:
   announce:
     name: 'Post release announcement on Bluesky'
-    if: github.event.release.discussion_url != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -25,11 +35,13 @@ jobs:
           package-manager-cache: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Post release announcement to Bluesky
+      - name: Post release announcements to Bluesky
         env:
           BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
           BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-        run: node .github/workflows/scripts/post-bluesky.mjs
+          RELEASE_TAGS: ${{ inputs.tags }}
+        run: |
+          for tag in $RELEASE_TAGS; do
+            RELEASE_TAG="$tag" RELEASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$tag" node .github/workflows/scripts/post-bluesky.mjs
+          done

--- a/.github/workflows/announce-release-bluesky.yml
+++ b/.github/workflows/announce-release-bluesky.yml
@@ -1,19 +1,11 @@
 name: Announce Release on Bluesky
 
 on:
-  workflow_call:
-    inputs:
-      tags:
-        description: 'Space-separated list of release tags to announce'
-        required: true
-        type: string
-    secrets:
-      BLUESKY_URL:
-        required: true
-      BLUESKY_IDENTIFIER:
-        required: true
-      BLUESKY_APP_PASSWORD:
-        required: true
+  # Only fires if the release was published with RELEASE_PAT (see the
+  # "Update GitHub Release" steps in build-status.yml): events created
+  # with the default GITHUB_TOKEN never trigger workflows.
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -35,13 +27,11 @@ jobs:
           package-manager-cache: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Post release announcements to Bluesky
+      - name: Post release announcement to Bluesky
         env:
           BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
           BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-          RELEASE_TAGS: ${{ inputs.tags }}
-        run: |
-          for tag in $RELEASE_TAGS; do
-            RELEASE_TAG="$tag" RELEASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$tag" node .github/workflows/scripts/post-bluesky.mjs
-          done
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: node .github/workflows/scripts/post-bluesky.mjs

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -728,6 +728,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_fc.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -800,6 +802,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_ava.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -872,6 +876,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_jest.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -944,6 +950,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_packaged.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1016,6 +1024,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_poisoning.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1088,6 +1098,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_vitest.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1160,6 +1172,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_worker.outputs.tag}}
+          # PAT so 'release: published' triggers announce-release-bluesky.yml
+          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1170,46 +1184,3 @@ jobs:
           body: |
 
             [View attestation](${{steps.attest.outputs.attestation-url}}) • [Documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
-  announce_releases_bluesky:
-    name: Announce releases on Bluesky
-    needs:
-      - check_publish_fc
-      - publish_package_fc
-      - check_publish_ava
-      - publish_package_ava
-      - check_publish_jest
-      - publish_package_jest
-      - check_publish_packaged
-      - publish_package_packaged
-      - check_publish_poisoning
-      - publish_package_poisoning
-      - check_publish_vitest
-      - publish_package_vitest
-      - check_publish_worker
-      - publish_package_worker
-    if: >-
-      ${{ !cancelled() && (
-        needs.publish_package_fc.result == 'success' ||
-        needs.publish_package_ava.result == 'success' ||
-        needs.publish_package_jest.result == 'success' ||
-        needs.publish_package_packaged.result == 'success' ||
-        needs.publish_package_poisoning.result == 'success' ||
-        needs.publish_package_vitest.result == 'success' ||
-        needs.publish_package_worker.result == 'success'
-      ) }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/announce-release-bluesky.yml
-    with:
-      tags: >-
-        ${{needs.publish_package_fc.result == 'success' && needs.check_publish_fc.outputs.tag || ''}}
-        ${{needs.publish_package_ava.result == 'success' && needs.check_publish_ava.outputs.tag || ''}}
-        ${{needs.publish_package_jest.result == 'success' && needs.check_publish_jest.outputs.tag || ''}}
-        ${{needs.publish_package_packaged.result == 'success' && needs.check_publish_packaged.outputs.tag || ''}}
-        ${{needs.publish_package_poisoning.result == 'success' && needs.check_publish_poisoning.outputs.tag || ''}}
-        ${{needs.publish_package_vitest.result == 'success' && needs.check_publish_vitest.outputs.tag || ''}}
-        ${{needs.publish_package_worker.result == 'success' && needs.check_publish_worker.outputs.tag || ''}}
-    secrets:
-      BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
-      BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
-      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -1170,3 +1170,46 @@ jobs:
           body: |
 
             [View attestation](${{steps.attest.outputs.attestation-url}}) • [Documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+  announce_releases_bluesky:
+    name: Announce releases on Bluesky
+    needs:
+      - check_publish_fc
+      - publish_package_fc
+      - check_publish_ava
+      - publish_package_ava
+      - check_publish_jest
+      - publish_package_jest
+      - check_publish_packaged
+      - publish_package_packaged
+      - check_publish_poisoning
+      - publish_package_poisoning
+      - check_publish_vitest
+      - publish_package_vitest
+      - check_publish_worker
+      - publish_package_worker
+    if: >-
+      ${{ !cancelled() && (
+        needs.publish_package_fc.result == 'success' ||
+        needs.publish_package_ava.result == 'success' ||
+        needs.publish_package_jest.result == 'success' ||
+        needs.publish_package_packaged.result == 'success' ||
+        needs.publish_package_poisoning.result == 'success' ||
+        needs.publish_package_vitest.result == 'success' ||
+        needs.publish_package_worker.result == 'success'
+      ) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/announce-release-bluesky.yml
+    with:
+      tags: >-
+        ${{needs.publish_package_fc.result == 'success' && needs.check_publish_fc.outputs.tag || ''}}
+        ${{needs.publish_package_ava.result == 'success' && needs.check_publish_ava.outputs.tag || ''}}
+        ${{needs.publish_package_jest.result == 'success' && needs.check_publish_jest.outputs.tag || ''}}
+        ${{needs.publish_package_packaged.result == 'success' && needs.check_publish_packaged.outputs.tag || ''}}
+        ${{needs.publish_package_poisoning.result == 'success' && needs.check_publish_poisoning.outputs.tag || ''}}
+        ${{needs.publish_package_vitest.result == 'success' && needs.check_publish_vitest.outputs.tag || ''}}
+        ${{needs.publish_package_worker.result == 'success' && needs.check_publish_worker.outputs.tag || ''}}
+    secrets:
+      BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
+      BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -728,8 +728,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_fc.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -802,8 +800,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_ava.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -876,8 +872,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_jest.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -950,8 +944,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_packaged.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1024,8 +1016,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_poisoning.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1098,8 +1088,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_vitest.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true
@@ -1172,8 +1160,6 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: ${{needs.check_publish_worker.outputs.tag}}
-          # PAT so 'release: published' triggers announce-release-bluesky.yml
-          token: ${{secrets.RELEASE_PAT || github.token}}
           draft: false
           append_body: true
           fail_on_unmatched_files: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.changelog.outputs.tag }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -67,3 +69,16 @@ jobs:
           git push origin "refs/tags/$TAG"
         env:
           TAG: ${{ steps.changelog.outputs.tag }}
+  announce-release:
+    name: 'Announce release'
+    needs: create-release
+    if: ${{ github.event.inputs.dry_run != 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/announce-release-bluesky.yml
+    with:
+      tag: ${{ needs.create-release.outputs.tag }}
+    secrets:
+      BLUESKY_URL: ${{ secrets.BLUESKY_URL }}
+      BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,8 +73,6 @@ jobs:
     name: 'Announce release'
     needs: create-release
     if: ${{ github.event.inputs.dry_run != 'true' }}
-    permissions:
-      contents: read
     uses: ./.github/workflows/announce-release-bluesky.yml
     with:
       tag: ${{ needs.create-release.outputs.tag }}

--- a/.github/workflows/scripts/post-bluesky.mjs
+++ b/.github/workflows/scripts/post-bluesky.mjs
@@ -11,7 +11,7 @@ const session = new CredentialSession(new URL(url));
 await session.login({ identifier, password });
 const agent = new Agent(session);
 
-const text = `🚀 New release: ${formatReleaseLabel(releaseTag)}\n\nSneak peek at the release notes: ${releaseUrl}`;
+const text = `🚀 New release on its way: ${formatReleaseLabel(releaseTag)}\n\nRelease notes will land shortly at: ${releaseUrl}`;
 const richText = new RichText({ text });
 await richText.detectFacets(agent);
 


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

Releases of fast-check and its sibling packages will now actually be announced on Bluesky: the "Announce Release on Bluesky" workflow added in #6959 has never fired once. The announcement now goes out when the maintainer dispatches the Create Release workflow, right after the draft release is created and the tag pushed, and the wording is adjusted to match that timing — `🚀 New release on its way: fast-check v4.9.0`, followed by a link to the release notes. The linked release page goes live a few minutes later, once the publish pipeline flips the draft to published. Dry runs of Create Release skip the post.

Why it never fired: the workflow listened to `release: published`, but releases are flipped from draft to published by `softprops/action-gh-release` inside the publish jobs using the default `GITHUB_TOKEN`, and GitHub suppresses events created with that token from triggering other workflows. Its `discussion_url != ''` guard was dead too, since #6975 dropped discussion creation on releases.

Design: `announce-release-bluesky.yml` becomes a reusable `workflow_call` taking the release tag, invoked from a new `announce-release` job in `create-release.yml` — which now re-exports the tag computed by its changelog-extract step as a job output. Alternatives considered and rejected: publishing releases with a PAT so `release: published` fires (a new long-lived secret to manage), or wiring the announcement into the seven publish jobs of `build-status.yml` (couples the social post to the publish pipeline). Anchoring on the human-dispatched Create Release needs no new secret and leaves `build-status.yml` untouched. The Bluesky secrets are declared and passed explicitly to the called workflow rather than via `secrets: inherit`, so only the three `BLUESKY_*` secrets are in its reach.

Impact level: patch, CI-only — no published package changes, hence no changeset. The PR stays focused on a single concern: making the Bluesky announcement flow fire. No automated tests were added: the change is workflow glue around the existing, already smoke-tested `post-bluesky.mjs`; YAML validity and the tag→URL/label mapping (including slashed tags like `packaged/v0.7.1`) were verified locally.

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->