### PR TITLE
🐛 Make float/double/typed-array NaN generation non-canonical

### DIFF
--- a/.changeset/noncanonical-nan-generation.md
+++ b/.changeset/noncanonical-nan-generation.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+🐛 Make float/double/typed-array NaN generation non-canonical

--- a/packages/fast-check/src/arbitrary/_internals/helpers/DoubleHelpers.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/DoubleHelpers.ts
@@ -20,6 +20,42 @@ function bitCastDoubleToUInt64(f: number): [number, number] {
   f64[0] = f;
   return [u32[1], u32[0]];
 }
+/** @internal */
+function bitCastUInt64ToDouble(hi: number, lo: number): number {
+  u32[1] = hi;
+  u32[0] = lo;
+  return f64[0];
+}
+
+/**
+ * 64-bit floating point NaN bit patterns that fast-check is able to produce, expressed as [hi, lo] pairs of
+ * 32-bit unsigned integers (hi holding the sign, exponent and top mantissa bits, lo the low mantissa bits).
+ *
+ * All the values below are indistinguishable from each other -and from any other NaN- as soon as they hit the
+ * language level: `Number.isNaN`, `===`, `Object.is`... never let any difference show up. The only way to
+ * observe the difference is to look at their raw bits, for instance by copying the value into a `Float64Array`
+ * and reading it back as a `Uint32Array` (see #6532).
+ *
+ * NAN_64_BIT_PATTERNS[0] is the canonical one: it is the pattern used whenever JavaScript itself has to
+ * produce a NaN (for instance as the result of `0/0`, or as `Number.NaN`).
+ *
+ * @internal
+ */
+export const NAN_64_BIT_PATTERNS: readonly [number, number][] = [
+  [0x7ff80000, 0x00000000], // Canonical quiet NaN (positive)
+  [0x7ff00000, 0x00000001], // Signaling NaN (positive, smallest payload)
+  [0x7fffffff, 0xffffffff], // Quiet NaN with all mantissa bits set
+  [0xfff80000, 0x00000000], // Quiet NaN (negative)
+  [0xfff00000, 0x00000001], // Signaling NaN (negative, smallest payload)
+];
+
+/**
+ * 64-bit floating point NaN values that fast-check is able to produce, derived from {@link NAN_64_BIT_PATTERNS}.
+ * NAN_64_VALUES[0] is the canonical one.
+ *
+ * @internal
+ */
+export const NAN_64_VALUES: readonly number[] = NAN_64_BIT_PATTERNS.map(([hi, lo]) => bitCastUInt64ToDouble(hi, lo));
 
 /**
  * Decompose a 64-bit floating point number into its interpreted parts:

--- a/packages/fast-check/src/arbitrary/_internals/helpers/FloatHelpers.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/FloatHelpers.ts
@@ -21,6 +21,40 @@ function bitCastFloatToUInt32(f: number): number {
   f32[0] = f;
   return u32[0];
 }
+/** @internal */
+function bitCastUInt32ToFloat(n: number): number {
+  u32[0] = n;
+  return f32[0];
+}
+
+/**
+ * 32-bit floating point NaN bit patterns that fast-check is able to produce.
+ *
+ * All the values below are indistinguishable from each other -and from any other NaN- as soon as they
+ * hit the language level: `Number.isNaN`, `===`, `Object.is`... never let any difference show up.
+ * The only way to observe the difference is to look at their raw bits, for instance by copying the value
+ * into a `Float32Array` and reading it back as a `Uint32Array` (see #6532).
+ *
+ * NAN_32_BIT_PATTERNS[0] is the canonical one: it is the pattern used whenever JavaScript itself has to
+ * produce a NaN (for instance as the result of `0/0`, or as `Number.NaN`).
+ *
+ * @internal
+ */
+export const NAN_32_BIT_PATTERNS: readonly number[] = [
+  0x7fc00000, // Canonical quiet NaN (positive)
+  0x7f800001, // Signaling NaN (positive, smallest payload)
+  0x7fffffff, // Quiet NaN with all mantissa bits set
+  0xffc00000, // Quiet NaN (negative)
+  0xff800001, // Signaling NaN (negative, smallest payload)
+];
+
+/**
+ * 32-bit floating point NaN values that fast-check is able to produce, derived from {@link NAN_32_BIT_PATTERNS}.
+ * NAN_32_VALUES[0] is the canonical one.
+ *
+ * @internal
+ */
+export const NAN_32_VALUES: readonly number[] = NAN_32_BIT_PATTERNS.map(bitCastUInt32ToFloat);
 
 /**
  * Decompose a 32-bit floating point number into its interpreted parts:

--- a/packages/fast-check/src/arbitrary/double.ts
+++ b/packages/fast-check/src/arbitrary/double.ts
@@ -1,5 +1,5 @@
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
-import { doubleToIndex, indexToDouble } from './_internals/helpers/DoubleHelpers.js';
+import { doubleToIndex, indexToDouble, NAN_64_VALUES } from './_internals/helpers/DoubleHelpers.js';
 import {
   doubleOnlyMapper,
   doubleOnlyUnmapper,
@@ -14,7 +14,15 @@ const safeNumberIsNaN = Number.isNaN;
 const safeNegativeInfinity = Number.NEGATIVE_INFINITY;
 const safePositiveInfinity = Number.POSITIVE_INFINITY;
 const safeMaxValue = Number.MAX_VALUE;
-const safeNaN = Number.NaN;
+
+// NAN_64_VALUES[2] and NAN_64_VALUES[3] are two distinct, non-canonical, 64-bit NaN bit patterns (see
+// DoubleHelpers.ts for the full list). We deliberately do not use NAN_64_VALUES[0] (the canonical NaN) below:
+// see the comment next to their usage in anyDouble for the rationale. We also avoid the signaling patterns
+// (index 1 and 4): some engines quiet signaling NaNs (flipping their quiet bit) when they transit through a
+// TypedArray, which would silently turn them into yet another (still non-canonical, but unplanned) pattern.
+// Patterns 2 and 3 are already quiet, so they are not affected by that.
+const nonCanonicalNaNAfterMax = NAN_64_VALUES[2];
+const nonCanonicalNaNBeforeMin = NAN_64_VALUES[3];
 
 /**
  * Constraints to be applied on {@link double}
@@ -122,12 +130,25 @@ function anyDouble(constraints: Omit<DoubleConstraints, 'noInteger'>): Arbitrary
   //               or [min, ..., max, NaN] if min > +0
   // Otherwise,
   //   values will be [NaN, min, ..., max] with max <= +0
+  //
+  // We keep a single extra index dedicated to NaN, exactly as before: widening it to host several possible NaN
+  // bit patterns would mean drawing extra randomness for it, which showed to destabilize the shrinker of the
+  // underlying bigInt arbitrary on arrays of doubles (see #6532 discussion for details, and in particular the
+  // existing "shrink without any initial context" contract that float32Array/float64Array rely on).
+  //
+  // Instead, we reuse this single index to surface a non-canonical NaN bit pattern (rather than the canonical
+  // Number.NaN that used to be hardcoded here): NaN values are indistinguishable from each other at the
+  // language level (Number.isNaN, ===, Object.is...) so nothing that inspects the produced value the "normal"
+  // way can ever notice this change - it only becomes observable when writing the value into a Float64Array,
+  // which is exactly the scenario reported in #6532. We use two different bit patterns (one for each side of
+  // the range) so that, depending on their constraints, users can stumble upon more than a single pattern.
   const positiveMaxIdx = maxIndex > BigInt(0);
   const minIndexWithNaN = positiveMaxIdx ? minIndex : minIndex - BigInt(1);
   const maxIndexWithNaN = positiveMaxIdx ? maxIndex + BigInt(1) : maxIndex;
+  const nanForRange = positiveMaxIdx ? nonCanonicalNaNAfterMax : nonCanonicalNaNBeforeMin;
   return bigInt({ min: minIndexWithNaN, max: maxIndexWithNaN }).map(
     (index) => {
-      if (maxIndex < index || index < minIndex) return safeNaN;
+      if (maxIndex < index || index < minIndex) return nanForRange;
       else return indexToDouble(index);
     },
     (value) => {

--- a/packages/fast-check/src/arbitrary/float.ts
+++ b/packages/fast-check/src/arbitrary/float.ts
@@ -1,6 +1,6 @@
 import { integer } from './integer.js';
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
-import { floatToIndex, indexToFloat, MAX_VALUE_32 } from './_internals/helpers/FloatHelpers.js';
+import { floatToIndex, indexToFloat, MAX_VALUE_32, NAN_32_VALUES } from './_internals/helpers/FloatHelpers.js';
 import {
   floatOnlyMapper,
   floatOnlyUnmapper,
@@ -13,7 +13,15 @@ const safeMathFround = Math.fround;
 
 const safeNegativeInfinity = Number.NEGATIVE_INFINITY;
 const safePositiveInfinity = Number.POSITIVE_INFINITY;
-const safeNaN = Number.NaN;
+
+// NAN_32_VALUES[2] and NAN_32_VALUES[3] are two distinct, non-canonical, 32-bit NaN bit patterns (see
+// FloatHelpers.ts for the full list). We deliberately do not use NAN_32_VALUES[0] (the canonical NaN) below: see
+// the comment next to their usage in anyFloat for the rationale. We also avoid the signaling patterns
+// (index 1 and 4): some engines quiet signaling NaNs (flipping their quiet bit) when they transit through a
+// TypedArray, which would silently turn them into yet another (still non-canonical, but unplanned) pattern.
+// Patterns 2 and 3 are already quiet, so they are not affected by that.
+const nonCanonicalNaNAfterMax = NAN_32_VALUES[2];
+const nonCanonicalNaNBeforeMin = NAN_32_VALUES[3];
 
 /**
  * Constraints to be applied on {@link float}
@@ -122,11 +130,24 @@ function anyFloat(constraints: Omit<FloatConstraints, 'noInteger'>): Arbitrary<n
   //               or [min, ..., max, NaN] if min > +0
   // Otherwise,
   //   values will be [NaN, min, ..., max] with max <= +0
+  //
+  // We keep a single extra index dedicated to NaN, exactly as before: widening it to host several possible NaN
+  // bit patterns would mean drawing extra randomness for it, which showed to destabilize the shrinker of the
+  // underlying integer arbitrary on arrays of floats (see #6532 discussion for details, and in particular the
+  // existing "shrink without any initial context" contract that float32Array/float64Array rely on).
+  //
+  // Instead, we reuse this single index to surface a non-canonical NaN bit pattern (rather than the canonical
+  // Number.NaN that used to be hardcoded here): NaN values are indistinguishable from each other at the
+  // language level (Number.isNaN, ===, Object.is...) so nothing that inspects the produced value the "normal"
+  // way can ever notice this change - it only becomes observable when writing the value into a Float32Array,
+  // which is exactly the scenario reported in #6532. We use two different bit patterns (one for each side of
+  // the range) so that, depending on their constraints, users can stumble upon more than a single pattern.
   const minIndexWithNaN = maxIndex > 0 ? minIndex : minIndex - 1;
   const maxIndexWithNaN = maxIndex > 0 ? maxIndex + 1 : maxIndex;
+  const nanForRange = maxIndex > 0 ? nonCanonicalNaNAfterMax : nonCanonicalNaNBeforeMin;
   return integer({ min: minIndexWithNaN, max: maxIndexWithNaN }).map(
     (index) => {
-      if (index > maxIndex || index < minIndex) return safeNaN;
+      if (index > maxIndex || index < minIndex) return nanForRange;
       else return indexToFloat(index);
     },
     (value) => {

--- a/packages/fast-check/test/unit/arbitrary/double.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/double.spec.ts
@@ -252,6 +252,10 @@ describe('double', () => {
 
             // Assert
             expect(f).toBe(Number.NaN);
+            // Regression test for #6532: the bit pattern backing that NaN must not be the canonical one so that
+            // it can be told apart from Number.NaN once written into a Float64Array. NaN values are otherwise
+            // indistinguishable from each other at the language level (Number.isNaN, ===, Object.is...).
+            expect(isCanonicalNaN64(f)).toBe(false);
           },
         ),
       );
@@ -395,4 +399,17 @@ function spyBigIntWithValue(value: () => bigint) {
   const bigInt = vi.spyOn(BigIntMock, 'bigInt');
   bigInt.mockReturnValue(instance);
   return bigInt;
+}
+
+// Important: we deliberately assign into a re-used Float64Array (a direct bit-level re-interpretation) instead of
+// going through `new Float64Array([value])`. The later goes through a generic, per-element ToNumber-based
+// conversion path that some engines are allowed to (and, under JIT optimization, actually do) normalize NaN
+// payloads on, making it an unreliable way to observe the underlying bit pattern of a NaN.
+const nan64Scratch = new Float64Array(1);
+const nan64ScratchBytes = new Uint8Array(nan64Scratch.buffer);
+nan64Scratch[0] = Number.NaN;
+const canonicalNaN64Bytes = Uint8Array.from(nan64ScratchBytes);
+function isCanonicalNaN64(value: number): boolean {
+  nan64Scratch[0] = value;
+  return nan64ScratchBytes.every((byte, index) => byte === canonicalNaN64Bytes[index]);
 }

--- a/packages/fast-check/test/unit/arbitrary/float.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float.spec.ts
@@ -256,6 +256,10 @@ describe('float', () => {
 
             // Assert
             expect(f).toBe(Number.NaN);
+            // Regression test for #6532: the bit pattern backing that NaN must not be the canonical one so that
+            // it can be told apart from Number.NaN once written into a Float32Array. NaN values are otherwise
+            // indistinguishable from each other at the language level (Number.isNaN, ===, Object.is...).
+            expect(isCanonicalNaN32(f)).toBe(false);
           },
         ),
       ));
@@ -366,4 +370,17 @@ function spyIntegerWithValue(value: () => number) {
   const integer = vi.spyOn(IntegerMock, 'integer');
   integer.mockReturnValue(instance);
   return integer;
+}
+
+// Important: we deliberately assign into a re-used Float32Array (a direct bit-level re-interpretation) instead of
+// going through `new Float32Array([value])`. The later goes through a generic, per-element ToNumber-based
+// conversion path that some engines are allowed to (and, under JIT optimization, actually do) normalize NaN
+// payloads on, making it an unreliable way to observe the underlying bit pattern of a NaN.
+const nan32Scratch = new Float32Array(1);
+const nan32ScratchBytes = new Uint8Array(nan32Scratch.buffer);
+nan32Scratch[0] = Number.NaN;
+const canonicalNaN32Bytes = Uint8Array.from(nan32ScratchBytes);
+function isCanonicalNaN32(value: number): boolean {
+  nan32Scratch[0] = value;
+  return nan32ScratchBytes.every((byte, index) => byte === canonicalNaN32Bytes[index]);
 }

--- a/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float32Array.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
+import { xorshift128plus } from 'pure-rand/generator/xorshift128plus';
 import type { Float32ArrayConstraints } from '../../../src/arbitrary/float32Array.js';
 import { float32Array } from '../../../src/arbitrary/float32Array.js';
+import { Random } from '../../../src/random/generator/Random.js';
 
 import {
   assertProduceCorrectValues,
@@ -61,6 +63,30 @@ describe('float32Array (integration)', () => {
 
   it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(float32ArrayBuilder, { extraParameters });
+  });
+
+  it('should be able to produce non-canonical NaN bit patterns (see #6532)', () => {
+    // Regression test for https://github.com/dubzzz/fast-check/issues/6532
+    // NaN values are indistinguishable from each other at the language level (Number.isNaN, ===, Object.is...).
+    // The only way to observe a difference is to look at the raw bytes once copied into the Float32Array.
+    const canonicalNaNBytes = new Uint8Array(new Float32Array([Number.NaN]).buffer);
+    const hasNonCanonicalNaN = (value: Float32Array): boolean => {
+      const nanIndex = value.findIndex((v) => Number.isNaN(v));
+      if (nanIndex === -1) return false;
+      const nanBytes = new Uint8Array(value.slice(nanIndex, nanIndex + 1).buffer);
+      return nanBytes.some((byte, index) => byte !== canonicalNaNBytes[index]);
+    };
+    // A non-canonical NaN only shows up on a single, boundary-adjacent index out of the whole range covered by
+    // float32Array, so we sample generously and with a strong bias (biasFactor=2, fast-check's most aggressive
+    // corner-case bias) to make sure we reliably stumble upon at least one.
+    const arb = float32Array();
+    let foundNonCanonicalNaN = false;
+    for (let seed = 0; seed < 20_000 && !foundNonCanonicalNaN; ++seed) {
+      const mrng = new Random(xorshift128plus(seed));
+      const { value } = arb.generate(mrng, 2);
+      foundNonCanonicalNaN = hasNonCanonicalNaN(value);
+    }
+    expect(foundNonCanonicalNaN).toBe(true);
   });
 });
 

--- a/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/float64Array.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
+import { xorshift128plus } from 'pure-rand/generator/xorshift128plus';
 import type { Float64ArrayConstraints } from '../../../src/arbitrary/float64Array.js';
 import { float64Array } from '../../../src/arbitrary/float64Array.js';
+import { Random } from '../../../src/random/generator/Random.js';
 
 import {
   assertProduceCorrectValues,
@@ -61,6 +63,30 @@ describe('float64Array (integration)', () => {
 
   it('should be able to shrink to the same values without initial context', () => {
     assertShrinkProducesSameValueWithoutInitialContext(float64ArrayBuilder, { extraParameters });
+  });
+
+  it('should be able to produce non-canonical NaN bit patterns (see #6532)', () => {
+    // Regression test for https://github.com/dubzzz/fast-check/issues/6532
+    // NaN values are indistinguishable from each other at the language level (Number.isNaN, ===, Object.is...).
+    // The only way to observe a difference is to look at the raw bytes once copied into the Float64Array.
+    const canonicalNaNBytes = new Uint8Array(new Float64Array([Number.NaN]).buffer);
+    const hasNonCanonicalNaN = (value: Float64Array): boolean => {
+      const nanIndex = value.findIndex((v) => Number.isNaN(v));
+      if (nanIndex === -1) return false;
+      const nanBytes = new Uint8Array(value.slice(nanIndex, nanIndex + 1).buffer);
+      return nanBytes.some((byte, index) => byte !== canonicalNaNBytes[index]);
+    };
+    // A non-canonical NaN only shows up on a single, boundary-adjacent index out of the whole range covered by
+    // float64Array, so we sample generously and with a strong bias (biasFactor=2, fast-check's most aggressive
+    // corner-case bias) to make sure we reliably stumble upon at least one.
+    const arb = float64Array();
+    let foundNonCanonicalNaN = false;
+    for (let seed = 0; seed < 20_000 && !foundNonCanonicalNaN; ++seed) {
+      const mrng = new Random(xorshift128plus(seed));
+      const { value } = arb.generate(mrng, 2);
+      foundNonCanonicalNaN = hasNonCanonicalNaN(value);
+    }
+    expect(foundNonCanonicalNaN).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #6532

`fc.float()`, `fc.double()`, `fc.float32Array()` and `fc.float64Array()` always hardcoded `Number.NaN` as their "extra" NaN value. Since all NaN values are indistinguishable from each other at the JS language level (`Number.isNaN`, `===`, `Object.is`...), these arbitraries could never surface the non-canonical NaN bit patterns (signaling NaNs, alternate payloads, negative NaNs...) that only become observable once a value is copied into a `Float32Array`/`Float64Array` — exactly the scenario @cschanhniem described in the issue.

Root cause and fix approach per @cschanhniem's analysis on the issue: reuse the single index that `anyFloat`/`anyDouble` already dedicate to NaN, but map it to a fixed non-canonical bit pattern instead of `Number.NaN`, rather than drawing extra randomness for a NaN "variant" index. The latter was tried first and reliably destabilized `float32Array`/`float64Array`'s "shrink without initial context" contract (`ArrayArbitrary` drops per-element context, and `IntegerArbitrary`'s context-free shrink target depends on the exact index range), so it was discarded in favor of this zero-extra-entropy design.

Two already-quiet, non-canonical 32/64-bit patterns are used (one for ranges extending past +0, one for ranges below it), avoiding signaling patterns since some engines quiet them when written into a TypedArray.

Impact: patch — no public API changes, only the underlying bit pattern of an already-produced NaN sentinel value changes (which is unobservable except via raw byte inspection, as described above).

## Checklist

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

## Test plan

Ran locally on a fresh fork/clone against current `main`:

```
pnpm install
pnpm exec vitest run --project fast-check \
  packages/fast-check/test/unit/arbitrary/float.spec.ts \
  packages/fast-check/test/unit/arbitrary/double.spec.ts \
  packages/fast-check/test/unit/arbitrary/float32Array.spec.ts \
  packages/fast-check/test/unit/arbitrary/float64Array.spec.ts \
  packages/fast-check/test/unit/arbitrary/_internals/helpers/FloatHelpers.spec.ts \
  packages/fast-check/test/unit/arbitrary/_internals/helpers/FloatOnlyHelpers.spec.ts \
  packages/fast-check/test/unit/arbitrary/_internals/helpers/DoubleOnlyHelpers.spec.ts \
  packages/fast-check/test/unit/arbitrary/_internals/helpers/DoubleHelpers.spec.ts \
  packages/fast-check/test/e2e/arbitraries/FloatArbitrary.spec.ts \
  packages/fast-check/test/e2e/arbitraries/DoubleArbitrary.spec.ts \
  packages/fast-check/test/e2e/NoRegression.spec.ts
# → Test Files 11 passed (11), Tests 229 passed (229)

cd packages/fast-check && pnpm run typecheck   # → passes, no errors
pnpm run lint:check                            # → passes (pre-existing warnings only, none touch changed files)
pnpm run format:check                          # → passes, no diffs
```

I also confirmed the 4 new regression tests actually catch the bug: reverting only `src/arbitrary/double.ts`, `src/arbitrary/float.ts`, and their `_internals/helpers/{Double,Float}Helpers.ts` back to the pre-fix `Number.NaN` hardcoding (while keeping the new tests) makes exactly those 4 tests fail, confirming they would have failed without this PR:
- `float32Array.spec.ts > should be able to produce non-canonical NaN bit patterns (see #6532)`
- `float64Array.spec.ts > should be able to produce non-canonical NaN bit patterns (see #6532)`
- `float.spec.ts > should properly convert the extra value to NaN`
- `double.spec.ts > should properly convert the extra value to NaN`

The `NoRegression` e2e snapshot suite passes unchanged, confirming the index topology (and thus shrink behavior) is unaffected — only the sentinel's underlying bit pattern changed.


---

### AI-assistance disclosure

In keeping with this project's contributing guidance: this contribution was prepared with AI assistance and was **reviewed, run, and approved by me** before submission — I understand the change and take responsibility for it.

**What it does, in my words:** the float/double/typed-array generators only ever emitted the *canonical* NaN bit pattern, so property tests could never exercise non-canonical NaNs (#6532). This maps the existing single NaN sentinel index to a fixed non-canonical bit pattern with **zero additional entropy**, so the value-index topology — and therefore all shrinking behaviour and the `NoRegression` snapshots — stays identical; only the sentinel's underlying bits change.

**What I verified myself:** the full test-plan above (229/229 targeted + NoRegression, typecheck/lint/format clean), plus the revert-confirms-fail check on the 4 new tests. Root-cause credit to @cschanhniem.

Happy to adjust anything to fit your preferences.
