### PR TITLE
🐛 Fix TypeDoc entry point for website build

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -220,7 +220,7 @@ const config: Config = {
     [
       'docusaurus-plugin-typedoc',
       {
-        entryPoints: ['../packages/fast-check/src/fast-check-default.ts'],
+        entryPoints: ['../packages/fast-check/src/fast-check.ts'],
         tsconfig: '../packages/fast-check/tsconfig.typedoc.json',
         out: 'docs/api',
         readme: 'none',


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

The website build fails on #7143 with `[error] Unable to find any entry points`, followed by a broken-link error for every page referencing `/docs/api/...`. The TypeDoc plugin configuration in `website/docusaurus.config.ts` still points to `../packages/fast-check/src/fast-check-default.ts`, which #7143 removes when dropping the default export. TypeDoc therefore generates no API pages at all, and the Docusaurus broken-links check fails the whole build.

This PR updates the TypeDoc `entryPoints` to `../packages/fast-check/src/fast-check.ts`, which after #7143 directly holds all the named exports. There is no end-user visible change beyond restoring the generated API reference: the generated pages keep the same URLs (`/docs/api/functions/...`, `/docs/api/interfaces/...`, ...), so no documentation links need to change.

Verified locally by running `pnpm run build` in `website/` on top of `move-to-star-import`: TypeDoc regenerates the full API reference (functions, classes, interfaces, type aliases) and the build completes with `[SUCCESS] Generated static files` and no broken links; the previously reported targets such as `/docs/api/functions/constant/`, `/docs/api/interfaces/Scheduler/` and `/docs/api/classes/Arbitrary/` are generated again.

Impact: website-only change, no package code touched, so no changeset is needed. The PR is focused on this single concern. No tests apply — the website build itself is the check that would have failed without this change.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vFCNsCYYqgc1yqH4VuwBU

---
_Generated by [Claude Code](https://claude.ai/code/session_014vFCNsCYYqgc1yqH4VuwBU)_