### PR TITLE
🐛 Fix `fc.option` throwing for `freq: Infinity`

### DIFF
--- a/.changeset/six-plums-decide.md
+++ b/.changeset/six-plums-decide.md
@@ -1,0 +1,5 @@
+---
+'fast-check': patch
+---
+
+Fix `fc.option` throwing when `freq` is `Number.POSITIVE_INFINITY`

--- a/packages/fast-check/src/arbitrary/option.ts
+++ b/packages/fast-check/src/arbitrary/option.ts
@@ -14,6 +14,10 @@ import { safeHasOwnProperty } from '../utils/globals.js';
 export interface OptionConstraints<TNil = null> {
   /**
    * The probability to build a nil value is of `1 / freq`.
+   *
+   * `Number.POSITIVE_INFINITY` is accepted as a way to request a probability of nil equal to zero:
+   * the arbitrary will never produce nil on its own. Nil may still be produced when other constraints
+   * force it — for instance once `maxDepth` has been reached (see below).
    * @defaultValue 6
    * @remarks Since 1.17.0
    */
@@ -63,10 +67,16 @@ export function option<T, TNil = null>(
 ): Arbitrary<T | TNil> {
   const freq = constraints.freq === undefined ? 6 : constraints.freq;
   const nilValue = safeHasOwnProperty(constraints, 'nil') ? constraints.nil : (null as any);
+  // `freq: Number.POSITIVE_INFINITY` is the only non-finite value we special-case: it means
+  // "probability of nil is zero" so we swap in a {nil: 0, arb: 1} weighting instead of computing
+  // `freq - 1` (which would be +Infinity, rejected by FrequencyArbitrary as a non-integer weight).
+  // Every other value (including NaN and -Infinity) keeps going through `freq - 1` unchanged, so it
+  // is rejected by FrequencyArbitrary exactly as it always has been.
+  const isNeverNil = freq === Number.POSITIVE_INFINITY;
   const nilArb = constant(nilValue);
   const weightedArbs = [
-    { arbitrary: nilArb, weight: 1, fallbackValue: { default: nilValue } },
-    { arbitrary: arb, weight: freq - 1 },
+    { arbitrary: nilArb, weight: isNeverNil ? 0 : 1, fallbackValue: { default: nilValue } },
+    { arbitrary: arb, weight: isNeverNil ? 1 : freq - 1 },
   ];
   const frequencyConstraints: FrequencyConstraints = {
     withCrossShrink: true,

--- a/packages/fast-check/test/unit/arbitrary/option.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/option.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import type { OptionConstraints } from '../../../src/arbitrary/option.js';
 import { option } from '../../../src/arbitrary/option.js';
+import { letrec } from '../../../src/arbitrary/letrec.js';
+import { tuple } from '../../../src/arbitrary/tuple.js';
 import { FakeIntegerArbitrary, fakeArbitrary } from './__test-helpers__/ArbitraryHelpers.js';
 import * as FrequencyArbitraryMock from '../../../src/arbitrary/_internals/FrequencyArbitrary.js';
 import * as ConstantMock from '../../../src/arbitrary/constant.js';
@@ -65,6 +67,37 @@ describe('option', () => {
       ),
     ));
 
+  it('should call FrequencyArbitrary.from with weights {nil: 0, arb: 1} when called with freq = Number.POSITIVE_INFINITY', () => {
+    // Arrange
+    const expectedArb = fakeArbitrary().instance;
+    const from = vi.spyOn(FrequencyArbitraryMock.FrequencyArbitrary, 'from');
+    from.mockReturnValue(expectedArb);
+    const expectedConstantArb = fakeArbitrary().instance;
+    const constant = vi.spyOn(ConstantMock, 'constant');
+    constant.mockReturnValue(expectedConstantArb);
+    const { instance: arb } = fakeArbitrary();
+
+    // Act
+    const out = option(arb, { freq: Number.POSITIVE_INFINITY });
+
+    // Assert
+    expect(constant).toHaveBeenCalledWith(null);
+    expect(from).toHaveBeenCalledWith(
+      [
+        { arbitrary: expectedConstantArb, weight: 0, fallbackValue: { default: null } },
+        { arbitrary: arb, weight: 1 },
+      ],
+      {
+        withCrossShrink: true,
+        depthSize: undefined,
+        maxDepth: undefined,
+        depthIdentifier: undefined,
+      },
+      'fc.option',
+    );
+    expect(out).toBe(expectedArb);
+  });
+
   it('should call FrequencyArbitrary.from with the right parameters when called without constraints', () => {
     // Arrange
     const expectedArb = fakeArbitrary().instance;
@@ -127,6 +160,45 @@ describe('option (integration)', () => {
       () => option(constant(true), { freq: 1 }),
       (o) => {
         expect(o).toBe(null);
+      },
+    );
+  });
+
+  it('should never return nil when freq = Number.POSITIVE_INFINITY', () => {
+    assertProduceCorrectValues(
+      () => option(constant(true), { freq: Number.POSITIVE_INFINITY }),
+      (o) => {
+        expect(o).toBe(true);
+      },
+    );
+  });
+
+  it('should always return nil when freq = Number.POSITIVE_INFINITY but maxDepth has been reached', () => {
+    assertProduceCorrectValues(
+      () => option(constant(true), { freq: Number.POSITIVE_INFINITY, maxDepth: 0 }),
+      (o) => {
+        expect(o).toBe(null);
+      },
+    );
+  });
+
+  it('should still terminate a recursive structure when freq = Number.POSITIVE_INFINITY once maxDepth has been reached', () => {
+    // With freq=Infinity, `data` never opts for nil on its own: the only thing forcing
+    // termination of the recursion is maxDepth. This test asserts that boundary still works
+    // by checking that generated trees never exceed the requested depth.
+    const maxDepth = 3;
+    const depthOf = (v: unknown): number => (Array.isArray(v) ? 1 + Math.max(...v.map(depthOf)) : 0);
+    assertProduceCorrectValues(
+      () =>
+        letrec((tie) => ({
+          data: option(tuple(tie('data'), tie('data')), {
+            freq: Number.POSITIVE_INFINITY,
+            nil: null,
+            maxDepth,
+          }),
+        })).data,
+      (data) => {
+        expect(depthOf(data)).toBeLessThanOrEqual(maxDepth);
       },
     );
   });


### PR DESCRIPTION
## Description

Fixes #6062

`fc.option(arb, { freq })` builds `weight = freq - 1` for the value arbitrary and hands it, together
with the nil arbitrary, to `FrequencyArbitrary.from()` ([`option.ts:67-70`](https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/src/arbitrary/option.ts#L67-L70)), which requires **integer, non-negative weights** ([`FrequencyArbitrary.ts:35-39`](https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/src/arbitrary/_internals/FrequencyArbitrary.ts#L35-L39)).

The docs say the probability of nil is `1 / freq` ([`option.ts:16`](https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/src/arbitrary/option.ts#L16)), so `freq: Number.POSITIVE_INFINITY` should mean "never nil" — i.e. a 100%-defined `Option`, per the issue title. Instead:

- `freq: Number.POSITIVE_INFINITY` → `weight = Infinity - 1 = Infinity`, which fails the integer check and throws `"fc.option expects weights to be integer values"`.
- `freq: 0` → `weight = 0 - 1 = -1`, which fails the non-negative check and throws `"fc.option expects weights to be superior or equal to 0"`.

This made it impossible to build an always-defined `Option`, exactly as reported.

**Fix**: when `freq === Number.POSITIVE_INFINITY`, `option` still goes through
`FrequencyArbitrary.from()` — it just swaps in the weight pair `{ nil: 0, arb: 1 }` instead of
computing `freq - 1`. Every other value of `freq` (including `Number.MAX_SAFE_INTEGER`, `NaN`, and
`-Infinity`) takes the exact same `weight: freq - 1` path as before this PR, byte for byte.

I initially implemented this differently — bypassing `FrequencyArbitrary` entirely and returning
`arb` unchanged whenever `freq >= Number.MAX_SAFE_INTEGER` — but a review caught that this silently
breaks `fc.option`'s documented depth contract: "[o]nce [`maxDepth`] has been reached only nil will
be used" ([`option.ts:40-41`](https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/src/arbitrary/option.ts#L40-L41)). Returning `arb` directly meant `maxDepth`,
`depthSize`, and `depthIdentifier` were silently dropped, which would have broken termination of
recursive structures built with `fc.letrec`/`fc.memo` when `freq: Infinity` is used at every level.
The `{ nil: 0, arb: 1 }` weighting keeps `FrequencyArbitrary`'s depth machinery intact — including
`mustGenerateFirst()`, which forces index 0 (nil) once `maxDepth` is reached regardless of its
weight — so `freq: Infinity` now means "never nil, except where depth constraints force it," which
matches the existing documented contract instead of silently overriding it. That threshold was also
too broad on its own terms: `>= Number.MAX_SAFE_INTEGER` changed behavior for `freq:
Number.MAX_SAFE_INTEGER` itself, which previously worked fine (nil probability `1 /
Number.MAX_SAFE_INTEGER`, indistinguishable from never in practice, but going through the real
weighted path). This PR narrows the special case to exactly `Number.POSITIVE_INFINITY`, so
`Number.MAX_SAFE_INTEGER` and all other finite values are completely unaffected.

**`freq: 0` is intentionally left as an error.** `1 / freq` is undefined at `freq = 0`, and the
existing documented/tested contract already assumes `freq >= 1` — see the pre-existing `'should
always return nil when freq = 1'` test and the integration tests' `fc.integer({ min: 1 })`
generator for `freq`. The original issue also asks for better `freq: 0` ergonomics; I'm
intentionally keeping this PR scoped to the well-defined `freq: Infinity` case only and leaving
`freq: 0` for a follow-up, since "should `freq <= 0` also mean never-nil" is a product decision a
maintainer should weigh in on rather than something I should decide unilaterally in a bugfix PR.

One behavior worth naming explicitly: with `weight: 0` on nil, `FrequencyArbitrary`'s existing
zero-weight rules mean the Infinity path also disables cross-shrink-to-nil and the `depthSize` bias
(both would reintroduce nil into a "never nil" arbitrary, so this is consistent) — a fully-expanded
recursive tree built with `freq: Infinity` + `maxDepth` can therefore have an empty shrink stream.
Since `freq: Infinity` threw before this PR, there is no prior shrink baseline to regress; fixing
shrink quality for that combination would mean changing `FrequencyArbitrary` itself, which I kept
out of scope for this bugfix.

Root-cause credit: @dubzzz confirmed the bug ("✔️ Bug Confirmed") and asked for a fix suggestion;
the root-cause analysis (the `weight = freq - 1` / integer-weight interaction) was first identified
by the `claude` GitHub Actions bot in [this comment](https://github.com/dubzzz/fast-check/issues/6062#issuecomment-4166053614), triggered by @dubzzz. That comment's *suggested fix* (a
`Number.MAX_SAFE_INTEGER` threshold that returns `arb` directly) is the design I started with, then
abandoned for the reasons above — the root-cause diagnosis was correct and useful, the proposed fix
was not depth-safe. I independently re-verified every claim in the root-cause analysis against the
current `main` before implementing (reproduced both failures, confirmed the exact thrown error
strings and their source lines, and confirmed the JSDoc's `1 / freq` semantics and the `maxDepth`
contract in `FrequencyArbitrary.ts` before choosing the final fix).

Impact: **patch**. This fixes a previously-throwing input (`freq: Infinity`); finite `freq` values
are byte-for-byte unaffected — the diff only adds a new branch that finite values never enter. The
public `OptionConstraints.freq` JSDoc is expanded to document the `freq: Infinity` behavior, which
is a documentation addition, not a breaking change to any existing documented behavior.

## Checklist

- [x] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [x] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [x] I kept this PR focused on a single concern and did not bundle unrelated changes
- [x] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [x] I added relevant tests and they would have failed without my PR (when applicable)

## Test plan

Ran locally against this branch:

```
pnpm exec vitest run --project fast-check packages/fast-check/test/unit/arbitrary/option.spec.ts
# → Test Files  1 passed (1) / Tests  11 passed (11)
#   (7 pre-existing + 1 pre-existing-but-reworked ["freq = Infinity never nil"] + 3 new:
#   spy assertion for {nil:0, arb:1} weights, "freq=Infinity + maxDepth:0 always nil",
#   and a letrec-based recursive-termination check. The old, now-invalid
#   "freq=MAX_SAFE_INTEGER never nil" test was removed, since that semantic no longer exists.)

pnpm exec vitest run --project fast-check
# → Test Files  206 passed (206) / Tests  2438 passed | 1 skipped (2439)

pnpm exec oxlint packages/fast-check/src/arbitrary/option.ts packages/fast-check/test/unit/arbitrary/option.spec.ts
# → clean (exit 0)

pnpm exec prettier --experimental-cli --cache --list-different .changeset/six-plums-decide.md packages/fast-check/src/arbitrary/option.ts packages/fast-check/test/unit/arbitrary/option.spec.ts
# → clean, no diffs

cd packages/fast-check && pnpm exec tsc --noEmit
# → clean (exit 0)
```

Revert-proof check: reverted only `src/arbitrary/option.ts` back to `main` (keeping the new/reworked
tests) and reran `option.spec.ts`. All 4 tests that exercise `freq: Infinity` failed as expected —
2 with the original `"fc.option expects weights to be integer values"` throw (the never-nil test and
the letrec-termination test, since `letrec` propagates the throw from the inner `option()` call), 1
with a failed property assertion (`maxDepth: 0` case — same throw, surfaced through
`assertProduceCorrectValues`), and 1 with a spy-assertion mismatch (`from` was never called with
`{nil: 0, arb: 1}` because `main` doesn't have that branch at all). Restored the fix afterward;
`option.spec.ts` and the full suite were both reconfirmed green (11/11 and 206 files / 2438 passed,
respectively).

Note: `pnpm --filter fast-check build` fails on this machine (macOS `sed` in
`build:post-build` is BSD sed, the script needs GNU sed) — this is a pre-existing,
environment-specific issue unrelated to this change; `vitest` runs against `src/` directly and does
not depend on the build step, which is what's reported above.

---

### AI-assistance disclosure

In keeping with this project's contributing guidance: this contribution was prepared with AI
assistance and was **reviewed, run, and approved by me** before submission — I understand the
change and take responsibility for it. AI-assisted, human-reviewed.

**What it does, in my words:** `fc.option`'s `freq` constraint feeds `FrequencyArbitrary`, which
demands integer weights; `freq: Infinity` (and `freq: 0`) broke that invariant and threw instead of
producing the documented `1 / freq` nil probability. This special-cases exactly
`freq === Number.POSITIVE_INFINITY` to use the weight pair `{nil: 0, arb: 1}` through the normal
`FrequencyArbitrary` path, instead of short-circuiting around it — so `maxDepth`/`depthSize`/
`depthIdentifier` keep working for `freq: Infinity` the same way they do for every other `freq`. All
finite `freq` values (including `Number.MAX_SAFE_INTEGER`) take the exact same code path as on
`main`, unchanged.

**What I verified myself:** the full test plan above, plus the revert-confirms-fail check on all 4
tests that exercise `freq: Infinity`, plus re-deriving the root cause from the actual thrown error
and `FrequencyArbitrary.ts` source rather than trusting the linked bot comment at face value — and,
after an adversarial review flagged that my first implementation (a `Number.MAX_SAFE_INTEGER`
threshold returning `arb` directly) silently broke the `maxDepth` depth-termination contract, I
re-read `FrequencyArbitrary.ts`'s `mustGenerateFirst()`/`computeNegDepthBenefit()` myself to confirm
the `{nil: 0, arb: 1}` weighting preserves it, rather than taking the review's suggested fix on
faith.

