### PR TITLE
⚡️ Drop defensive checks from `tuple`

### DIFF
--- a/.changeset/brave-donuts-wonder.md
+++ b/.changeset/brave-donuts-wonder.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `tuple`

--- a/.changeset/loose-wings-go.md
+++ b/.changeset/loose-wings-go.md
@@ -1,5 +1,0 @@
----
-"fast-check": patch
----
-
-⚡️ Drop defensive checks from `tuple`

--- a/.changeset/loose-wings-go.md
+++ b/.changeset/loose-wings-go.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `tuple`

--- a/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/TupleArbitrary.ts
@@ -80,11 +80,6 @@ type ValuesArray<Ts extends unknown[]> = { [K in keyof Ts]?: Value<Ts[K]> };
 export class TupleArbitrary<Ts extends unknown[]> extends Arbitrary<Ts> {
   constructor(readonly arbs: ArbsArray<Ts>) {
     super();
-    for (let idx = 0; idx !== arbs.length; ++idx) {
-      const arb = arbs[idx];
-      if (arb === null || arb === undefined || arb.generate === null || arb.generate === undefined)
-        throw new Error(`Invalid parameter encountered at index ${idx}: expecting an Arbitrary`);
-    }
   }
   generate(mrng: Random, biasFactor: number | undefined): Value<Ts> {
     let cloneable = false;


### PR DESCRIPTION
## Description

Typings of `tuple` already ensure us that every received value is an instance of arbitrary.

As such there is no legitimate reason to perform the checks at runtime. Such runtime checks tend to potentially be wrong and above all to cost at runtime while bringing no value for TypeScript users (JavaScript ones neither if they enable type features on their IDEs).

This one is possibly the most impactful instance of the pattern removed by #7153: the dropped loop ran on every construction of a `TupleArbitrary`, which happens for every `fc.tuple(...)` but also for every `fc.property`/`fc.asyncProperty` (they wrap their arbitraries in a tuple) and inside several built-in arbitraries composing through `tuple` (e.g. `uuid`, `webUrl`).

Impact flagged as patch through a changeset. The PR is focused on this single concern. No test was covering the removed checks, so none had to be removed; existing `tuple`/`TupleArbitrary` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_