### PR TITLE
⚡️ Drop legacy `num_runs` fallback from parameters

### DIFF
--- a/.changeset/tidy-camels-decide.md
+++ b/.changeset/tidy-camels-decide.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop legacy `num_runs` fallback from parameters

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -157,7 +157,6 @@ function readRandomType<T>(p: Parameters<T>): (seed: number) => QualifiedRandomG
 function readNumRuns<T>(p: Parameters<T>): number {
   const defaultValue = 100;
   if (p.numRuns !== undefined) return p.numRuns;
-  if ((p as { num_runs?: number }).num_runs !== undefined) return (p as { num_runs: number }).num_runs;
   return defaultValue;
 }
 


### PR DESCRIPTION
## Description

Typings of `Parameters` already ensure us that the number of runs comes from `numRuns`: the legacy `num_runs` property is not part of the type at all — the code even needed a cast just to read it.

As such there is no legitimate reason to keep probing for it at runtime. This fallback dates back to the pre-1.x parameter naming and only benefits JavaScript users still relying on an alias that has been out of the documented API for years, while costing an extra lookup on every `check`, `assert`, `sample` and `statistics` call.

Note for the reviewer: strictly speaking this changes observable behavior for anyone still passing `num_runs` (it will now be silently ignored, falling back to the default of 100). The impact is flagged as patch in line with the philosophy of #7153, but feel free to ask for a higher bump if you consider the alias still supported.

The PR is focused on this single concern. No test was covering the `num_runs` fallback, so none had to be removed; existing `QualifiedParameters` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_