### PR TITLE
⚡️ Drop defensive clamping of `verbose`

### DIFF
--- a/.changeset/proud-lamps-argue.md
+++ b/.changeset/proud-lamps-argue.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive clamping of `verbose`

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -167,13 +167,7 @@ function readVerbose<T>(p: Parameters<T>): VerbosityLevel {
   if (typeof p.verbose === 'boolean') {
     return p.verbose === true ? VerbosityLevel.Verbose : VerbosityLevel.None;
   }
-  if (p.verbose <= VerbosityLevel.None) {
-    return VerbosityLevel.None;
-  }
-  if (p.verbose >= VerbosityLevel.VeryVerbose) {
-    return VerbosityLevel.VeryVerbose;
-  }
-  return p.verbose | 0;
+  return p.verbose;
 }
 
 /** @internal */


### PR DESCRIPTION
## Description

Typings of `Parameters` already ensure us that `verbose` is either a `boolean` or a `VerbosityLevel`. With modern TypeScript enum assignability rules, only the enum members (`0 | 1 | 2`) are accepted — out-of-range or fractional numbers are rejected at compile time.

As such there is no legitimate reason to clamp the value at runtime (the `<= None` / `>= VeryVerbose` bounds and the final `| 0` truncation). Such runtime checks cost on every `check`/`assert`/`sample`/`statistics` call while bringing no value for TypeScript users (JavaScript ones neither if they enable type features on their IDEs). The boolean-to-`VerbosityLevel` mapping is genuine behavior and is kept untouched.

Impact flagged as patch through a changeset. The PR is focused on this single concern. No test was covering the removed clamping (existing tests only cover the boolean mapping and enum passthrough, and they still pass).

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_