### PR TITLE
♻️ Simplify `requiredKeys` handling in `record`

### DIFF
--- a/.changeset/wise-otters-tidy.md
+++ b/.changeset/wise-otters-tidy.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+♻️ Simplify `requiredKeys` handling in `record`

--- a/packages/fast-check/src/arbitrary/record.ts
+++ b/packages/fast-check/src/arbitrary/record.ts
@@ -63,16 +63,11 @@ function record<T>(
   constraints?: RecordConstraints<keyof T>,
 ): unknown {
   const noNullPrototype = constraints !== undefined && !!constraints.noNullPrototype;
-  if (constraints === undefined) {
+  const requiredKeys = constraints !== undefined ? constraints.requiredKeys : undefined;
+  if (requiredKeys === undefined) {
     return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
   }
 
-  const requireDeletedKeys = 'requiredKeys' in constraints && constraints.requiredKeys !== undefined;
-  if (!requireDeletedKeys) {
-    return buildPartialRecordArbitrary(recordModel, undefined, noNullPrototype);
-  }
-
-  const requiredKeys = ('requiredKeys' in constraints ? constraints.requiredKeys : undefined) || [];
   for (let idx = 0; idx !== requiredKeys.length; ++idx) {
     const descriptor = Object.getOwnPropertyDescriptor(recordModel, requiredKeys[idx]);
     if (descriptor === undefined) {


### PR DESCRIPTION
## Description

No behavior change for users: `record` keeps accepting and validating `requiredKeys` exactly as before.

This PR removes defensive re-checks in `record` that could never fire: once the code had established that `constraints.requiredKeys` was defined, it re-tested `'requiredKeys' in constraints` a second time and appended a `|| []` fallback on a value that was already known to be defined. The three-step control flow (undefined constraints, then `requireDeletedKeys`, then the re-read) collapses into a single read of `constraints.requiredKeys`.

Note on scope: unlike its siblings from the #7153 family, the two runtime `throw`s are intentionally kept. With index-signature models (e.g. `Record<string, Arbitrary<unknown>>`), `keyof` degrades to `string`, so TypeScript cannot rule out non-own (e.g. `toString`) or non-enumerable keys in `requiredKeys` — those checks are genuinely load-bearing and covered by existing tests.

Impact flagged as patch through a changeset. The PR is focused on this single concern. Existing `record` tests (including the rejection ones) still pass unchanged; no new test was needed since no behavior changes.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_