### PR TITLE
⚡️ Drop defensive checks from `uuid`

### DIFF
--- a/.changeset/eager-badgers-count.md
+++ b/.changeset/eager-badgers-count.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `uuid`

--- a/packages/fast-check/src/arbitrary/uuid.ts
+++ b/packages/fast-check/src/arbitrary/uuid.ts
@@ -29,13 +29,6 @@ function assertValidVersions(versions: number[]) {
       throw new Error(`Version ${version} has been requested at least twice for uuid`);
     }
     found[version] = true;
-    // Check version
-    if (version < 1 || version > 15) {
-      throw new Error(`Version must be a value in [1-15] for uuid, but received ${version}`);
-    }
-    if (~~version !== version) {
-      throw new Error(`Version must be an integer value for uuid, but received ${version}`);
-    }
   }
   if (versions.length === 0) {
     throw new Error(`Must provide at least one version for uuid`);


### PR DESCRIPTION
## Description

Typings of `uuid` already ensure us that every requested version is one of the literal values `1 | 2 | … | 15`: `UuidConstraints.version` is declared as that literal union (or an array of it), so out-of-range and non-integer versions are rejected at compile time.

As such there is no legitimate reason to re-validate the range (`version < 1 || version > 15`) and integer-ness (`~~version !== version`) at runtime. Such runtime checks cost while bringing no value for TypeScript users (JavaScript ones neither if they enable type features on their IDEs).

Note on scope: the two remaining checks in `assertValidVersions` are intentionally kept — duplicated versions (`[4, 4]`) and empty version arrays (`[]`) both type-check fine, so only the runtime can catch them.

Impact flagged as patch through a changeset. The PR is focused on this single concern. No test was covering the removed checks, so none had to be removed; existing `uuid` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_