### PR TITLE
⚡️ Drop defensive checks from `oneof`

### DIFF
--- a/.changeset/calm-berries-shine.md
+++ b/.changeset/calm-berries-shine.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `oneof`

--- a/packages/fast-check/src/arbitrary/oneof.ts
+++ b/packages/fast-check/src/arbitrary/oneof.ts
@@ -93,7 +93,6 @@ function isOneOfContraints(
   param: OneOfConstraints | MaybeWeightedArbitrary<unknown> | undefined,
 ): param is OneOfConstraints {
   return (
-    param !== null &&
     param !== undefined &&
     typeof param === 'object' &&
     // Arbitrary<unknown>


### PR DESCRIPTION
## Description

Typings of `oneof` already ensure us that the first argument can never be `null`: it is either an `OneOfConstraints`, a `MaybeWeightedArbitrary`, or `undefined` (zero-argument call).

As such there is no legitimate reason for the `param !== null` test inside the constraints detection helper. The `param !== undefined` test is kept — it is the one doing real work for the zero-argument case.

Behavior note for untyped JavaScript callers passing `null` (a call the typings forbid): it crashed before this PR and still crashes after, only earlier — previously `null` was misclassified as an arbitrary and blew up deeper inside `FrequencyArbitrary`, now the `'generate' in param` probe throws a `TypeError` right away.

`oneof` is on a hot construction path, but the win here is admittedly a single comparison — this PR is mostly about consistency with #7153.

Impact flagged as patch through a changeset. The PR is focused on this single concern. No test was covering the removed check, so none had to be removed; existing `oneof` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c