### PR TITLE
⚡️ Drop defensive checks from random adapters

### DIFF
--- a/.changeset/quick-owls-jump.md
+++ b/.changeset/quick-owls-jump.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from random adapters

--- a/packages/fast-check/src/random/generator/Random.ts
+++ b/packages/fast-check/src/random/generator/Random.ts
@@ -88,9 +88,6 @@ export class Random {
    * Extract the internal state of the internal RandomGenerator backing the current instance of Random
    */
   getState(): readonly number[] | undefined {
-    if ('getState' in this.internalRng && typeof this.internalRng.getState === 'function') {
-      return this.internalRng.getState();
-    }
-    return undefined;
+    return this.internalRng.getState();
   }
 }

--- a/packages/fast-check/src/random/generator/RandomGenerator.ts
+++ b/packages/fast-check/src/random/generator/RandomGenerator.ts
@@ -47,7 +47,7 @@ function adaptRandomGeneratorTo8x(rng: RandomGenerator): RandomGenerator8x | Jum
 
 /** @internal */
 function adaptRandomGeneratorToInternal(rng: RandomGenerator8x | JumpableRandomGenerator8x): RandomGeneratorInternal {
-  if ('jump' in rng && typeof rng.jump === 'function') {
+  if ('jump' in rng) {
     return rng;
   }
   return {


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

Typings of the random generator layer already ensure us two things:

- In `adaptRandomGeneratorToInternal`, once `'jump' in rng` has narrowed the union to `JumpableRandomGenerator`, `jump` is a required method of that interface — so the extra `typeof rng.jump === 'function'` probe can never disagree with the narrowing.
- In `Random.getState`, the internal generator is typed `JumpableRandomGenerator` where `getState(): readonly number[]` is a required method (both in the pure-rand v8 typings and in the v7-compat interface), and every branch of `adaptRandomGenerator` produces an object exposing it — so the `'getState' in … && typeof … === 'function'` guard and its `undefined` fallback are dead paths.

As such there is no legitimate reason to keep those probes at runtime, in line with #7153. The public signature of `Random.getState` is left untouched (`readonly number[] | undefined`) to keep this PR free of any API change.

Note on scope: the `'min' in mrng` / `'max' in mrng` probes of `readRandomType` (QualifiedParameters) are intentionally **not** touched — structural typing does not forbid extra properties, so those detect genuinely incompatible legacy generators.

Impact flagged as patch through a changeset. The PR is focused on this single concern. No test was covering the removed probes, so none had to be removed; random and runner test suites still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_