### PR TITLE
⚡️ Drop defensive checks from `FrequencyArbitrary`

### DIFF
--- a/.changeset/nine-crabs-drive.md
+++ b/.changeset/nine-crabs-drive.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `FrequencyArbitrary`

--- a/packages/fast-check/src/arbitrary/_internals/FrequencyArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/FrequencyArbitrary.ts
@@ -18,10 +18,6 @@ export class FrequencyArbitrary<T> extends Arbitrary<T> {
     }
     let totalWeight = 0;
     for (let idx = 0; idx !== warbs.length; ++idx) {
-      const currentArbitrary = warbs[idx].arbitrary;
-      if (currentArbitrary === undefined) {
-        throw new Error(`${label} expects arbitraries to be specified`);
-      }
       const currentWeight = warbs[idx].weight;
       totalWeight += currentWeight;
       if (!Number.isInteger(currentWeight)) {

--- a/packages/fast-check/test/unit/arbitrary/_internals/FrequencyArbitrary.part2.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/_internals/FrequencyArbitrary.part2.spec.ts
@@ -122,13 +122,6 @@ describe('FrequencyArbitrary', () => {
       ).toThrowError(/expects weights to be integer values/);
     });
 
-    it('should reject calls without arbitrary', () => {
-      // Arrange / Act / Assert
-      expect(() => FrequencyArbitrary.from([{ arbitrary: undefined!, weight: 1 }], {}, 'test')).toThrowError(
-        /expects arbitraries to be specified/,
-      );
-    });
-
     it('should reject calls including at least one strictly negative weight', async () =>
       await fc.assert(
         fc.asyncProperty(


### PR DESCRIPTION
## Description

Typings of `FrequencyArbitrary.from` already ensure us that every weighted arbitrary comes with an arbitrary: `_WeightedArbitrary<T>.arbitrary` is a required `Arbitrary<T>`, and the public entry point feeding it (`oneof`, via `MaybeWeightedArbitrary`/`WeightedArbitrary`) carries the same guarantee.

As such there is no legitimate reason to re-check `arbitrary === undefined` for every entry at runtime. This check ran on every `oneof` construction — a hot path for recursive structures. This spot was originally identified in #6806; this PR ports that part of it onto the current codebase in the spirit of #7153.

Note on scope: the weight-related checks (integer, non-negative, strictly positive sum) are intentionally kept — `weight: number` cannot express any of that.

Impact flagged as patch through a changeset. The PR is focused on this single concern. The single test covering the removed check (`should reject calls without arbitrary`, which had to force `undefined!` past the compiler) is removed with it; the remaining `FrequencyArbitrary` and `oneof` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_