### PR TITLE
⚡️ Drop defensive checks from `constantFrom`

### DIFF
--- a/.changeset/soft-tables-smile.md
+++ b/.changeset/soft-tables-smile.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Drop defensive checks from `constantFrom`

--- a/packages/fast-check/src/arbitrary/constantFrom.ts
+++ b/packages/fast-check/src/arbitrary/constantFrom.ts
@@ -9,7 +9,7 @@ type Elem<T> = T extends any[] ? T[number] : T;
 /**
  * For one `...values` values - all equiprobable
  *
- * **WARNING**: It expects at least one value, otherwise it should throw
+ * **WARNING**: It expects at least one value
  *
  * @param values - Constant values to be produced (all values shrink to the first one)
  *
@@ -21,7 +21,7 @@ function constantFrom<const T = never>(...values: T[]): Arbitrary<T>;
 /**
  * For one `...values` values - all equiprobable
  *
- * **WARNING**: It expects at least one value, otherwise it should throw
+ * **WARNING**: It expects at least one value
  *
  * @param values - Constant values to be produced (all values shrink to the first one)
  *
@@ -31,9 +31,6 @@ function constantFrom<const T = never>(...values: T[]): Arbitrary<T>;
 function constantFrom<TArgs extends any[] | [any]>(...values: TArgs): Arbitrary<TArgs[number]>;
 
 function constantFrom<TArgs extends any[] | [any] | any>(...values: Arrayfy<TArgs>): Arbitrary<Elem<TArgs>> {
-  if (values.length === 0) {
-    throw new Error('fc.constantFrom expects at least one parameter');
-  }
   return new ConstantArbitrary(values) as Arbitrary<Elem<TArgs>>;
 }
 

--- a/packages/fast-check/test/unit/arbitrary/constantFrom.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/constantFrom.spec.ts
@@ -30,13 +30,6 @@ describe('constantFrom', () => {
       }),
     ));
 
-  it('should throw when receiving no parameters', () => {
-    // Arrange / Act / Assert
-    expect(() => constantFrom()).toThrowErrorMatchingInlineSnapshot(
-      `[Error: fc.constantFrom expects at least one parameter]`,
-    );
-  });
-
   it('should not throw on cloneable instance', () => {
     // Arrange
     const cloneable = { [cloneMethod]: () => cloneable };


### PR DESCRIPTION
## Description

Typings of `constantFrom` already discourage the zero-argument call this check was defending against: `constantFrom()` can only resolve to `Arbitrary<never>` (via the `<const T = never>` overload), a type that cannot produce any usable value — type-aware users get the signal at compile time. This spot was originally identified in #6806; this PR ports that part of it onto the current codebase in the spirit of #7153.

As such there is no legitimate reason to pay for the `values.length === 0` check at runtime. Behavior note: a zero-argument call no longer throws at construction; it now builds a degenerate `ConstantArbitrary` over no values (the JSDoc `WARNING` lines were reworded accordingly, dropping the now-incorrect "otherwise it should throw" clause).

To be fully transparent: strictly speaking `constantFrom()` still compiles (yielding `Arbitrary<never>`), so this one leans on "the type system makes it unusable" rather than "the type system forbids it" — flagging it so you can reject if you consider the construction-time throw worth keeping.

Impact flagged as patch through a changeset. The PR is focused on this single concern. The single test covering the removed check (`should throw when receiving no parameters`) is removed with it; the remaining `constantFrom` tests still pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm6hpCLVbSKV2M9LJsxL2c)_