### PR TITLE
💥 Drop string-based PRNG in runner parameters

### DIFF
--- a/.changeset/proud-taxis-refuse.md
+++ b/.changeset/proud-taxis-refuse.md
@@ -1,0 +1,5 @@
+---
+"fast-check": major
+---
+
+💥 Drop support for string-based `randomType`, only accept factory functions

--- a/packages/fast-check/src/check/runner/configuration/Parameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/Parameters.ts
@@ -1,4 +1,3 @@
-import type { RandomType } from './RandomType.js';
 import type { VerbosityLevel } from './VerbosityLevel.js';
 import type { RunDetails } from '../reporter/RunDetails.js';
 import type { RandomGenerator } from '../../../random/generator/RandomGenerator.js';
@@ -24,15 +23,13 @@ export interface Parameters<T = void> {
    * Random number generator: `xorshift128plus` by default
    *
    * Random generator is the core element behind the generation of random values - changing it might directly impact the quality and performances of the generation of random values.
-   * It can be one of: 'mersenne', 'congruential', 'congruential32', 'xorshift128plus', 'xoroshiro128plus'
-   * Or any function able to build a `RandomGenerator` based on a seed
+   * It can be any function able to build a `RandomGenerator` based on a seed.
    *
-   * As required since pure-rand v6.0.0, when passing a builder for {@link RandomGenerator},
-   * the random number generator must generate values between -0x80000000 and 0x7fffffff.
+   * As required since pure-rand v6.0.0, the random number generator must generate values between -0x80000000 and 0x7fffffff.
    *
    * @remarks Since 1.6.0
    */
-  randomType?: RandomType | ((seed: number) => RandomGenerator);
+  randomType?: (seed: number) => RandomGenerator;
   /**
    * Number of runs before success: 100 by default
    * @remarks Since 1.0.0

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -1,10 +1,7 @@
 import type { Parameters } from './Parameters.js';
 import { VerbosityLevel } from './VerbosityLevel.js';
 import type { RunDetails } from '../reporter/RunDetails.js';
-import { congruential32 } from 'pure-rand/generator/congruential32';
-import { mersenne } from 'pure-rand/generator/mersenne';
 import { xorshift128plus } from 'pure-rand/generator/xorshift128plus';
-import { xoroshiro128plus } from 'pure-rand/generator/xoroshiro128plus';
 import { adaptRandomGenerator } from '../../../random/generator/RandomGenerator.js';
 
 import type { RandomGenerator, RandomGeneratorInternal } from '../../../random/generator/RandomGenerator.js';
@@ -125,20 +122,8 @@ function readSeed<T>(p: Parameters<T>): number {
 /** @internal */
 function readRandomType<T>(p: Parameters<T>): (seed: number) => QualifiedRandomGenerator {
   if (p.randomType === undefined) return xorshift128plus as (seed: number) => QualifiedRandomGenerator;
-  if (typeof p.randomType === 'string') {
-    switch (p.randomType) {
-      case 'mersenne':
-        return createQualifiedRandomGenerator(mersenne);
-      case 'congruential':
-      case 'congruential32':
-        return createQualifiedRandomGenerator(congruential32);
-      case 'xorshift128plus':
-        return xorshift128plus as (seed: number) => QualifiedRandomGenerator;
-      case 'xoroshiro128plus':
-        return xoroshiro128plus as (seed: number) => QualifiedRandomGenerator;
-      default:
-        throw new Error(`Invalid random specified: '${p.randomType}'`);
-    }
+  if (typeof p.randomType !== 'function') {
+    throw new Error(`Invalid random specified: '${String(p.randomType)}'`);
   }
   const mrng = p.randomType(0);
   if ('min' in mrng && mrng.min !== -0x80000000) {

--- a/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
+++ b/packages/fast-check/src/check/runner/configuration/QualifiedParameters.ts
@@ -122,9 +122,6 @@ function readSeed<T>(p: Parameters<T>): number {
 /** @internal */
 function readRandomType<T>(p: Parameters<T>): (seed: number) => QualifiedRandomGenerator {
   if (p.randomType === undefined) return xorshift128plus as (seed: number) => QualifiedRandomGenerator;
-  if (typeof p.randomType !== 'function') {
-    throw new Error(`Invalid random specified: '${String(p.randomType)}'`);
-  }
   const mrng = p.randomType(0);
   if ('min' in mrng && mrng.min !== -0x80000000) {
     throw new Error(`Invalid random number generator: min must equal -0x80000000, got ${String(mrng.min)}`);

--- a/packages/fast-check/src/check/runner/configuration/RandomType.ts
+++ b/packages/fast-check/src/check/runner/configuration/RandomType.ts
@@ -1,7 +1,0 @@
-/**
- * Random generators automatically recognized by the framework
- * without having to pass a builder function
- * @remarks Since 2.2.0
- * @public
- */
-export type RandomType = 'mersenne' | 'congruential' | 'congruential32' | 'xorshift128plus' | 'xoroshiro128plus';

--- a/packages/fast-check/src/fast-check.ts
+++ b/packages/fast-check/src/fast-check.ts
@@ -173,7 +173,6 @@ export { scheduler, schedulerFor } from './arbitrary/scheduler.js';
 export { defaultReportMessage, asyncDefaultReportMessage } from './check/runner/utils/RunDetailsFormatter.js';
 export type { CommandsContraints } from './check/model/commands/CommandsContraints.js';
 export { PreconditionFailure } from './check/precondition/PreconditionFailure.js';
-export type { RandomType } from './check/runner/configuration/RandomType.js';
 export type { IntArrayConstraints } from './arbitrary/int8Array.js';
 export { int8Array } from './arbitrary/int8Array.js';
 export { int16Array } from './arbitrary/int16Array.js';

--- a/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
@@ -70,7 +70,6 @@ describe('QualifiedParameters', () => {
             if (randomTypeName === undefined) {
               expect(qparams.randomType).toBe(xorshift128plus);
             } else {
-              // all pure-rand generators are jumpable, so the factory is passed through as-is
               expect(qparams.randomType).toBe(prand[randomTypeName]);
             }
           },

--- a/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
@@ -76,12 +76,6 @@ describe('QualifiedParameters', () => {
           },
         ),
       ));
-    it('Should throw on non-function randomType', async () =>
-      await fc.assert(
-        fc.asyncProperty(parametersArbitrary, (params) => {
-          expect(() => read({ ...params, randomType: 'xoroshiro128plus' as never })).toThrowError();
-        }),
-      ));
     describe('Seeds outside of 32 bits range', () => {
       const seedsOutsideRangeArb = fc.oneof(
         fc.double(),

--- a/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/configuration/QualifiedParameters.spec.ts
@@ -6,7 +6,6 @@ import { xoroshiro128plus } from 'pure-rand/generator/xoroshiro128plus';
 import { xorshift128plus } from 'pure-rand/generator/xorshift128plus';
 
 import { read } from '../../../../../src/check/runner/configuration/QualifiedParameters.js';
-import type { RandomType } from '../../../../../src/check/runner/configuration/RandomType.js';
 import { VerbosityLevel } from '../../../../../src/check/runner/configuration/VerbosityLevel.js';
 
 const prand = { mersenne, congruential32, xorshift128plus, xoroshiro128plus };
@@ -35,13 +34,7 @@ const parametersArbitrary = fc.record(
   { requiredKeys: [] },
 );
 
-const hardCodedRandomTypeWithJump = fc.constantFrom(
-  'mersenne',
-  'congruential',
-  'congruential32',
-  'xorshift128plus',
-  'xoroshiro128plus',
-) as fc.Arbitrary<RandomType>;
+const randomTypeName = fc.constantFrom(...(Object.keys(prand) as (keyof typeof prand)[]));
 
 describe('QualifiedParameters', () => {
   describe('read', () => {
@@ -66,30 +59,27 @@ describe('QualifiedParameters', () => {
           return qparams.verbose === expectedVerbosityLevel;
         }),
       ));
-    it('Should transform correctly hardcoded randomType', async () =>
+    it('Should transform correctly randomType factories', async () =>
       await fc.assert(
         fc.asyncProperty(
           parametersArbitrary,
-          fc.option(hardCodedRandomTypeWithJump, { nil: undefined }),
-          (params, randomType) => {
+          fc.option(randomTypeName, { nil: undefined }),
+          (params, randomTypeName) => {
+            const randomType = randomTypeName !== undefined ? prand[randomTypeName] : undefined;
             const qparams = read({ ...params, randomType });
-            const resolvedRandomType = randomType === 'congruential' ? 'congruential32' : randomType;
-            const defaultRandomType = xorshift128plus;
-            if (resolvedRandomType === undefined) {
-              expect(qparams.randomType).toBe(defaultRandomType);
-            } else if (resolvedRandomType === 'congruential32' || resolvedRandomType === 'mersenne') {
-              expect(qparams.randomType).not.toBe(defaultRandomType);
-              expect(qparams.randomType).not.toBe(prand[resolvedRandomType]); // re-wrapped so not fully the same
+            if (randomTypeName === undefined) {
+              expect(qparams.randomType).toBe(xorshift128plus);
             } else {
-              expect(qparams.randomType).toBe(prand[resolvedRandomType]);
+              // all pure-rand generators are jumpable, so the factory is passed through as-is
+              expect(qparams.randomType).toBe(prand[randomTypeName]);
             }
           },
         ),
       ));
-    it('Should throw on invalid randomType', async () =>
+    it('Should throw on non-function randomType', async () =>
       await fc.assert(
         fc.asyncProperty(parametersArbitrary, (params) => {
-          expect(() => read({ ...params, randomType: 'invalid' as RandomType })).toThrowError();
+          expect(() => read({ ...params, randomType: 'xoroshiro128plus' as never })).toThrowError();
         }),
       ));
     describe('Seeds outside of 32 bits range', () => {


### PR DESCRIPTION
## Description

`randomType` no longer accepts one of the hardcoded strings (`'mersenne'`, `'congruential'`, `'congruential32'`, `'xorshift128plus'`, `'xoroshiro128plus'`): it now only accepts a factory function building a `RandomGenerator` from a seed. The `RandomType` type is no longer exported. **Breaking change**: users relying on a string value should pass the corresponding factory from pure-rand instead — flagged as major via a changeset.

Keeping a single way to customize the generator removes the string-to-factory switch and three pure-rand imports from the runner configuration. Tests were updated to cover the factory path (factories are now passed through as-is since all pure-rand generators are jumpable) and the throw on non-function values.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->