### PR TITLE
✅(jest) Enable babel transform for all generated specs

### DIFF
--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -603,18 +603,15 @@ async function writeToFile(
   const jestConfigPath = path.join(specDirectory, jestConfigName);
   const jestConfig = {
     testMatch: [`<rootDir>/${specFileName}`],
-    transform: {},
+    // fast-check only ships an ES Modules bundle: it has to be transformed into CommonJS
+    // by babel-jest for Jest to be able to require it from CommonJS specs.
+    transform: { '^.+\\.[t|j]sx?$': 'babel-jest' },
     testTimeout: options.testTimeoutConfig,
     testRunner: options.testRunner !== undefined ? 'jest-jasmine2' : undefined,
-    ...(useWorkers
-      ? {
-          transform: { '^.+\\.[t|j]sx?$': 'babel-jest' },
-          transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'],
-        }
-      : {}),
+    ...(useWorkers ? { transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'] } : {}),
   };
 
-  // Prepare babel config (if needed)
+  // Prepare babel config
   const babelConfigPath = path.join(specDirectory, 'babel.config.cjs');
   const babelConfig = `module.exports = { presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]], };`;
 

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -603,9 +603,8 @@ async function writeToFile(
   const jestConfigPath = path.join(specDirectory, jestConfigName);
   const jestConfig = {
     testMatch: [`<rootDir>/${specFileName}`],
-    // fast-check only ships an ES Modules bundle: it has to be transformed into CommonJS
-    // by babel-jest for Jest to be able to require it from CommonJS specs.
     transform: { '^.+\\.[t|j]sx?$': 'babel-jest' },
+    ...(useWorkers ? { transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'] } : {}),
     testTimeout: options.testTimeoutConfig,
     testRunner: options.testRunner !== undefined ? 'jest-jasmine2' : undefined,
     ...(useWorkers ? { transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'] } : {}),

--- a/packages/jest/test/jest-fast-check.spec.ts
+++ b/packages/jest/test/jest-fast-check.spec.ts
@@ -607,7 +607,6 @@ async function writeToFile(
     ...(useWorkers ? { transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'] } : {}),
     testTimeout: options.testTimeoutConfig,
     testRunner: options.testRunner !== undefined ? 'jest-jasmine2' : undefined,
-    ...(useWorkers ? { transformIgnorePatterns: ['/node_modules/(?!(?:@fast-check/worker)/)'] } : {}),
   };
 
   // Prepare babel config


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

<!-- Describe your change and explain what this PR is trying to solve -->

Fixes the `@fast-check/jest` test failures on #7173 (`drop-cjs`). No end-user facing change: this PR only touches the test helpers of `packages/jest`.

Since #7173, fast-check only ships an ES Modules bundle. The CommonJS specs generated by `test/jest-fast-check.spec.ts` start with `require('fast-check')`, and the non-worker configurations ran Jest with `transform: {}`: Jest's CommonJS loader then compiles `packages/fast-check/lib/fast-check.js` as CommonJS and fails with `SyntaxError: Cannot use import statement outside a module` — the failure seen on CI (macOS shard 3/3). The worker configurations already passed because they run babel-jest, and fast-check resolves to the workspace path `packages/fast-check` (not under `node_modules`), so it is not excluded by `transformIgnorePatterns` and gets transformed to CommonJS on the fly.

The fix simply extends the babel-jest transform, previously enabled only for the worker configurations, to every generated Jest config. It builds on the changes already pushed to `drop-cjs` that made the babel config unconditional. Verified locally on top of `drop-cjs`: all 130 tests across the 5 execution variants (`test`, `test (worker)`, `test (jasmine)`, `test (jasmine)(worker)`, `it`) fail without this change and pass with it.

About considering a more recent Jest instead: Jest 30.4.2 — already the latest published release and the version in use — does support `require(esm)` natively, but only when Node exposes the synchronous vm module APIs, i.e. running Jest under `--experimental-vm-modules` on Node ≥ 24.9 (`vm.SourceTextModule.prototype.hasAsyncGraph`). The CI test matrix still covers Node 22.x, so the babel-based transform is the portable option; switching these specs to native `require(esm)` can be revisited once the minimal tested Node version reaches 24.9+.

No changeset: test-only change, no impact on published packages.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfcxZ5o7kjCMQXg3ebhHsh)_