### PR TITLE
📝 Fix MDX build and tags in 4.9.0 release note

### DIFF
--- a/website/blog/2026-07-23-whats-new-in-fast-check-4-9-0/index.md
+++ b/website/blog/2026-07-23-whats-new-in-fast-check-4-9-0/index.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in fast-check 4.9.0?
 authors: [dubzzz]
-tags: [release]
+tags: [release, entityGraph, shrinking, performance]
 ---
 
 Supporting shrink is crucial for the built-in arbitraries in fast-check. For this release, we deeply reworked `entityGraph` to give it built-in shrinking support. But this release is above all about performance. We spent the last few weeks tracking any optimization that we could put into fast-check on its critical and hot code paths.
@@ -94,7 +94,7 @@ But we not only improved the basic runtime of an empty property. We also improve
 | [stringMatching(/^abc$/)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L101)                |       1,974 |        34,751 |       +1661% |
 | [memo(tree)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L70)                              |         309 |           939 |        +204% |
 | [letrec(tree)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L69)                            |         314 |           785 |        +150% |
-| [record({ a: integer() })](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L53)                |       1,031 |         2,406 |        +133% |
+| [record(\{ a: integer() \})](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L53)              |       1,031 |         2,406 |        +133% |
 | [tuple(integer())](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L52)                        |       3,831 |         5,448 |         +42% |
 | [integer()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L34)                               |       9,104 |        12,498 |         +37% |
 | [integer().map(value+1)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L106)                 |       7,098 |         9,478 |         +34% |
@@ -102,7 +102,7 @@ But we not only improved the basic runtime of an empty property. We also improve
 | [maxSafeInteger()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L35)                        |       6,668 |         8,835 |         +33% |
 | [integer().filter(true)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L108)                 |       8,339 |        11,024 |         +32% |
 | [oneof(integer(), integer())](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L60)             |       5,196 |         6,469 |         +25% |
-| [oneof({ weight, arbitrary }, …)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L62)         |       5,262 |         6,482 |         +23% |
+| [oneof(\{ weight, arbitrary \}, …)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L62)       |       5,262 |         6,482 |         +23% |
 | [ipV4()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L98)                                  |       1,123 |         1,377 |         +23% |
 | [array(integer())](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L48)                        |       1,463 |         1,780 |         +22% |
 | [float()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L37)                                 |       4,075 |         4,948 |         +21% |
@@ -124,7 +124,7 @@ But we not only improved the basic runtime of an empty property. We also improve
 | [string()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L42)                                |         935 |         1,002 |          +7% |
 | [uuid()](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L100)                                 |         552 |           587 |          +6% |
 | [mixedCase(string())](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L103)                    |         463 |           489 |  +6% _noise_ |
-| [string({ unit: 'grapheme' })](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L44)            |         647 |           682 |  +5% _noise_ |
+| [string(\{ unit: 'grapheme' \})](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L44)          |         647 |           682 |  +5% _noise_ |
 | [constantFrom(1, 2)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L59)                      |      23,298 |        23,934 |  +3% _noise_ |
 | [constant(1)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L58)                             |      34,475 |        35,099 |  +2% _noise_ |
 | [string(max 100)](https://github.com/dubzzz/fast-check/blob/v4.9.0/packages/fast-check/test/bench/arbitraries.bench.ts#L43)                         |         153 |           154 |  +1% _noise_ |


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

This PR unblocks the "Build documentation" CI job on #7137 so the 4.9.0 release note can actually be published, and improves the discoverability of the post on the blog's tag pages.

- **MDX build fix:** three benchmark-table cells contained unescaped curly braces (`record({ a: integer() })`, `oneof({ weight, arbitrary }, …)`, `string({ unit: 'grapheme' })`). Docusaurus compiles `.md` blog posts as MDX, which parses `{ … }` as a JSX expression, and acorn fails on those snippets — this is exactly the `Could not parse expression with acorn` error at line 97 reported by the failing job. The braces are now escaped as `\{`/`\}`, the same convention already used in the 3.10.0 release note; the rendered output is unchanged.
- **Tags:** extended the front matter from `tags: [release]` to `tags: [release, entityGraph, shrinking, performance]`. All three added tags already exist on the blog (`entityGraph` on the 4.7.0 note, `shrinking` and `performance` on several release notes), and they capture the two key topics of this post: the `entityGraph` rework that unlocked shrinking, and the performance-focused release.

Rationale and verification: escaping was preferred over wrapping the cells in backticks to keep the diff minimal and match the existing convention in this blog. Verified locally by compiling the post with the same `@mdx-js/mdx` version Docusaurus uses — the previous revision reproduces the CI error at the same location, the fixed revision compiles cleanly — and `prettier --check` passes. The change is docs-only (website blog post), so no version bump/changeset applies, and it stays focused on making #7137 green plus the tag enrichment requested for it.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtzZEnTQfUWfEAaRKS3pba

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtzZEnTQfUWfEAaRKS3pba)_