### PR TITLE
🐛 Handle infinite freq in option

### DIFF
--- a/.changeset/option-infinite-frequency.md
+++ b/.changeset/option-infinite-frequency.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+Handle infinite frequency in option arbitrary.

--- a/packages/fast-check/src/arbitrary/option.ts
+++ b/packages/fast-check/src/arbitrary/option.ts
@@ -6,6 +6,8 @@ import type { DepthIdentifier } from './_internals/helpers/DepthContext.js';
 import type { DepthSize } from './_internals/helpers/MaxLengthFromMinLength.js';
 import { safeHasOwnProperty } from '../utils/globals.js';
 
+const safePositiveInfinity = Number.POSITIVE_INFINITY;
+
 /**
  * Constraints to be applied on {@link option}
  * @remarks Since 2.2.0
@@ -63,6 +65,9 @@ export function option<T, TNil = null>(
 ): Arbitrary<T | TNil> {
   const freq = constraints.freq === undefined ? 6 : constraints.freq;
   const nilValue = safeHasOwnProperty(constraints, 'nil') ? constraints.nil : (null as any);
+  if (freq === safePositiveInfinity) {
+    return arb as Arbitrary<T | TNil>;
+  }
   const nilArb = constant(nilValue);
   const weightedArbs = [
     { arbitrary: nilArb, weight: 1, fallbackValue: { default: nilValue } },

--- a/packages/fast-check/test/unit/arbitrary/option.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/option.spec.ts
@@ -95,6 +95,19 @@ describe('option', () => {
     );
     expect(out).toBe(expectedArb);
   });
+
+  it('should not call FrequencyArbitrary.from when freq is +Infinity', () => {
+    // Arrange
+    const from = vi.spyOn(FrequencyArbitraryMock.FrequencyArbitrary, 'from');
+    const { instance: arb } = fakeArbitrary();
+
+    // Act
+    const out = option(arb, { freq: Number.POSITIVE_INFINITY });
+
+    // Assert
+    expect(from).not.toHaveBeenCalled();
+    expect(out).toBe(arb);
+  });
 });
 
 describe('option (integration)', () => {
@@ -127,6 +140,15 @@ describe('option (integration)', () => {
       () => option(constant(true), { freq: 1 }),
       (o) => {
         expect(o).toBe(null);
+      },
+    );
+  });
+
+  it('should never return nil when freq = +Infinity', () => {
+    assertProduceCorrectValues(
+      () => option(constant(true), { freq: Number.POSITIVE_INFINITY }),
+      (o) => {
+        expect(o).toBe(true);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Return the wrapped arbitrary directly when `fc.option` gets `freq: Number.POSITIVE_INFINITY`
- Add unit and integration coverage for the infinite-frequency case

## Tests
- `pnpm exec vitest run packages/fast-check/test/unit/arbitrary/option.spec.ts`
- `pnpm --filter fast-check run typecheck`