### PR TITLE
💥 Drop methods from `Random`

### DIFF
--- a/.changeset/tidy-panthers-vanish.md
+++ b/.changeset/tidy-panthers-vanish.md
@@ -1,0 +1,5 @@
+---
+"fast-check": major
+---
+
+💥 Drop `Random#next(n)`, no-argument `Random#nextInt()` and `Random#nextBoolean()`

--- a/packages/fast-check/src/random/generator/Random.ts
+++ b/packages/fast-check/src/random/generator/Random.ts
@@ -53,8 +53,8 @@ export class Random {
    * Generate a random floating point number between 0.0 (included) and 1.0 (excluded)
    */
   nextDouble(): number {
-    const a = uniformInt(this.internalRng, 0, (1 << 26) - 1);
-    const b = uniformInt(this.internalRng, 0, (1 << 27) - 1);
+    const a = uniformInt(this.internalRng, 0, 0x3ffffff);
+    const b = uniformInt(this.internalRng, 0, 0x7ffffff);
     return (a * DBL_FACTOR + b) * DBL_DIVISOR;
   }
 

--- a/packages/fast-check/src/random/generator/Random.ts
+++ b/packages/fast-check/src/random/generator/Random.ts
@@ -3,8 +3,6 @@ import { uniformInt } from 'pure-rand/distribution/uniformInt';
 import { adaptRandomGenerator } from './RandomGenerator.js';
 import type { RandomGenerator, RandomGeneratorInternal } from './RandomGenerator.js';
 
-const MIN_INT: number = 0x80000000 | 0;
-const MAX_INT: number = 0x7fffffff | 0;
 const DBL_FACTOR: number = Math.pow(2, 27);
 const DBL_DIVISOR: number = Math.pow(2, -53);
 
@@ -34,36 +32,12 @@ export class Random {
   }
 
   /**
-   * Generate an integer having `bits` random bits
-   * @param bits - Number of bits to generate
-   * @deprecated Prefer {@link nextInt} with explicit bounds: `nextInt(0, (1 << bits) - 1)`
-   */
-  next(bits: number): number {
-    return uniformInt(this.internalRng, 0, (1 << bits) - 1);
-  }
-
-  /**
-   * Generate a random boolean
-   */
-
-  nextBoolean(): boolean {
-    return uniformInt(this.internalRng, 0, 1) === 1;
-  }
-
-  /**
-   * Generate a random integer (32 bits)
-   * @deprecated Prefer {@link nextInt} with explicit bounds: `nextInt(-2147483648, 2147483647)`
-   */
-  nextInt(): number;
-
-  /**
    * Generate a random integer between min (included) and max (included)
    * @param min - Minimal integer value
    * @param max - Maximal integer value
    */
-  nextInt(min: number, max: number): number;
-  nextInt(min?: number, max?: number): number {
-    return uniformInt(this.internalRng, min === undefined ? MIN_INT : min, max === undefined ? MAX_INT : max);
+  nextInt(min: number, max: number): number {
+    return uniformInt(this.internalRng, min, max);
   }
 
   /**
@@ -79,8 +53,8 @@ export class Random {
    * Generate a random floating point number between 0.0 (included) and 1.0 (excluded)
    */
   nextDouble(): number {
-    const a = this.next(26);
-    const b = this.next(27);
+    const a = uniformInt(this.internalRng, 0, (1 << 26) - 1);
+    const b = uniformInt(this.internalRng, 0, (1 << 27) - 1);
     return (a * DBL_FACTOR + b) * DBL_DIVISOR;
   }
 

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
@@ -4,18 +4,15 @@ import { Random } from '../../../../src/random/generator/Random.js';
 
 export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, 'internalRng' | 'uniformIn'> {
   const clone = vi.fn();
-  const next = vi.fn();
-  const nextBoolean = vi.fn();
   const nextInt = vi.fn();
   const nextBigInt = vi.fn();
   const nextDouble = vi.fn();
   const getState = vi.fn();
   class MyRandom extends Random {
     clone = clone;
-    next = next;
-    nextBoolean = nextBoolean;
     nextInt = nextInt;
     nextBigInt = nextBigInt;
+    nextDouble = nextDouble;
     getState = getState;
   }
 
@@ -23,5 +20,5 @@ export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, '
   // As we don't use anything from this base class, we just pass the ctor with a value that looks ok for it.
   const buildInternal = () => ({ clone: () => buildInternal() });
   const instance = new MyRandom(buildInternal() as any);
-  return { instance, clone, next, nextBoolean, nextInt, nextBigInt, nextDouble, getState };
+  return { instance, clone, nextInt, nextBigInt, nextDouble, getState };
 }

--- a/packages/fast-check/test/unit/arbitrary/func.spec.ts
+++ b/packages/fast-check/test/unit/arbitrary/func.spec.ts
@@ -103,7 +103,9 @@ describe('func (integration)', () => {
         return Object.defineProperty([value, 1], cloneMethod, { value: () => this.instance(value, cloneable) });
       }
       generate(mrng: Random): Value<number[]> {
-        return new Value(this.instance(mrng.nextInt(), mrng.nextBoolean()), { shrunkOnce: false });
+        return new Value(this.instance(mrng.nextInt(-0x80000000, 0x7fffffff), mrng.nextInt(0, 1) === 1), {
+          shrunkOnce: false,
+        });
       }
       canShrinkWithoutContext(_value: unknown): _value is number[] {
         throw new Error('No call expected in that scenario');

--- a/packages/fast-check/test/unit/check/runner/Runner.spec.ts
+++ b/packages/fast-check/test/unit/check/runner/Runner.spec.ts
@@ -274,7 +274,7 @@ describe('Runner', () => {
           const buildPropertyFor = function (runOn: number[]) {
             const p: Property<[number]> = {
               generate: (rng: Random) => {
-                return new Value([rng.nextInt()], undefined);
+                return new Value([rng.nextInt(-0x80000000, 0x7fffffff)], undefined);
               },
               shrink: () => nil,
               runBeforeEach: () => {},

--- a/packages/fast-check/test/unit/random/generator/Random.spec.ts
+++ b/packages/fast-check/test/unit/random/generator/Random.spec.ts
@@ -6,19 +6,6 @@ import { Random } from '../../../../src/random/generator/Random.js';
 
 const MAX_SIZE = 2048;
 describe('Random', () => {
-  describe('next', () => {
-    it('Should produce values within 0 and 2 ** n - 1', async () =>
-      await fc.assert(
-        fc.asyncProperty(fc.integer(), fc.nat(31), fc.nat(MAX_SIZE), (seed, n, num) => {
-          const mrng = new Random(xorshift128plus(seed));
-          for (let idx = 0; idx !== num; ++idx) {
-            const v = mrng.next(n);
-            if (v < 0 || v > (((1 << n) - 1) | 0)) return false;
-          }
-          return true;
-        }),
-      ));
-  });
   describe('nextInt', () => {
     it('Should produce values within the range', async () =>
       await fc.assert(
@@ -38,7 +25,8 @@ describe('Random', () => {
         fc.asyncProperty(fc.integer(), fc.nat(MAX_SIZE), (seed, num) => {
           const mrng1 = new Random(xorshift128plus(seed));
           const mrng2 = new Random(xorshift128plus(seed));
-          for (let idx = 0; idx !== num; ++idx) if (mrng1.nextInt() !== mrng2.nextInt()) return false;
+          for (let idx = 0; idx !== num; ++idx)
+            if (mrng1.nextInt(-0x80000000, 0x7fffffff) !== mrng2.nextInt(-0x80000000, 0x7fffffff)) return false;
           return true;
         }),
       ));
@@ -62,7 +50,8 @@ describe('Random', () => {
         fc.asyncProperty(fc.integer(), fc.nat(MAX_SIZE), (seed, num) => {
           const mrng1 = new Random(xorshift128plus(seed));
           const mrng2 = mrng1.clone();
-          for (let idx = 0; idx !== num; ++idx) if (mrng1.nextInt() !== mrng2.nextInt()) return false;
+          for (let idx = 0; idx !== num; ++idx)
+            if (mrng1.nextInt(-0x80000000, 0x7fffffff) !== mrng2.nextInt(-0x80000000, 0x7fffffff)) return false;
           return true;
         }),
       ));

--- a/packages/fast-check/test/unit/stubs/arbitraries.ts
+++ b/packages/fast-check/test/unit/stubs/arbitraries.ts
@@ -37,7 +37,7 @@ class ForwardArbitrary extends Arbitrary<number> {
     super();
   }
   generate(rng: Random): Value<number> {
-    return new Value(rng.nextInt(), undefined);
+    return new Value(rng.nextInt(-0x80000000, 0x7fffffff), undefined);
   }
   canShrinkWithoutContext(_value: unknown): _value is number {
     return false;
@@ -59,7 +59,7 @@ class ForwardArrayArbitrary extends Arbitrary<number[]> {
   generate(mrng: Random): Value<number[]> {
     const out = [];
     for (let idx = 0; idx !== this.num; ++idx) {
-      out.push(mrng.nextInt());
+      out.push(mrng.nextInt(-0x80000000, 0x7fffffff));
     }
     return new Value(out, undefined);
   }

--- a/packages/worker/test/internals/worker-property/WorkerPropertyFromWorker.spec.ts
+++ b/packages/worker/test/internals/worker-property/WorkerPropertyFromWorker.spec.ts
@@ -79,15 +79,15 @@ describe('WorkerPropertyFromWorker', () => {
 
     mrngStates.push(mrng.getState());
     const value1 = property.generate(mrng, 0);
-    mrng.nextInt();
+    mrng.nextInt(-0x80000000, 0x7fffffff);
 
     mrngStates.push(mrng.getState());
     const value2 = property.generate(mrng, 0);
-    mrng.nextInt();
+    mrng.nextInt(-0x80000000, 0x7fffffff);
 
     mrngStates.push(mrng.getState());
     const value3 = property.generate(mrng, 0);
-    mrng.nextInt();
+    mrng.nextInt(-0x80000000, 0x7fffffff);
 
     const stringified2 = fc.stringify(value2.value_);
     const stringified3 = fc.stringify(value3.value_);


### PR DESCRIPTION
## Description

`Random` no longer exposes the no-argument overload of `nextInt()` nor the `next(bits)` method — both deprecated since 4.6.0 (#6687) — and drops `nextBoolean()` as well, which was not used anywhere in the codebase, the documentation, or the website. **Breaking change**: any caller of these methods must switch to `nextInt(min, max)` with explicit bounds — `nextInt(-2147483648, 2147483647)` replaces `nextInt()`, `nextInt(0, (1 << bits) - 1)` replaces `next(bits)`, and `nextInt(0, 1) === 1` replaces `nextBoolean()`. Flagged as major via a changeset.

Generated values are not impacted: `nextDouble` now draws its two integers directly through `uniformInt` with the exact bounds previously used by `next(26)`/`next(27)`, so random sequences stay bit-for-bit identical.

The motivation is to keep a single way to draw integers from `Random` and finish the cleanup started with the deprecations of #6687. Every other method was checked for usage before deciding its fate: `clone`, `nextInt(min, max)`, `nextBigInt` and `getState` are all used by production code (arbitraries, worker package), and `nextDouble` is used by e2e tests and documented integrations (e.g. the faker randomizer pattern from the blog) — they all stay. The PR is focused on this single concern.

On the tests side, specs relying on the dropped methods (`Random.spec.ts`, `Runner.spec.ts`, `func.spec.ts`, stubs and the worker property spec) were switched to `nextInt` with explicit bounds — they would fail to compile against the new signature otherwise — and the `fakeRandom()` helper no longer exposes mocks for the removed methods while now properly overriding `nextDouble`.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL9nDkBv45rMBMvqTHQZFm