### PR TITLE
💥 Drop `Random#nextDouble()`

### DIFF
--- a/.changeset/lucky-owls-repeat.md
+++ b/.changeset/lucky-owls-repeat.md
@@ -1,0 +1,5 @@
+---
+"fast-check": major
+---
+
+💥 Drop `Random#nextDouble()`

--- a/packages/fast-check/src/random/generator/Random.ts
+++ b/packages/fast-check/src/random/generator/Random.ts
@@ -3,9 +3,6 @@ import { uniformInt } from 'pure-rand/distribution/uniformInt';
 import { adaptRandomGenerator } from './RandomGenerator.js';
 import type { RandomGenerator, RandomGeneratorInternal } from './RandomGenerator.js';
 
-const DBL_FACTOR: number = Math.pow(2, 27);
-const DBL_DIVISOR: number = Math.pow(2, -53);
-
 /**
  * Wrapper around an instance of a `pure-rand`'s random number generator
  * offering a simpler interface to deal with random with impure patterns
@@ -47,15 +44,6 @@ export class Random {
    */
   nextBigInt(min: bigint, max: bigint): bigint {
     return uniformBigInt(this.internalRng, min, max);
-  }
-
-  /**
-   * Generate a random floating point number between 0.0 (included) and 1.0 (excluded)
-   */
-  nextDouble(): number {
-    const a = uniformInt(this.internalRng, 0, 0x3ffffff);
-    const b = uniformInt(this.internalRng, 0, 0x7ffffff);
-    return (a * DBL_FACTOR + b) * DBL_DIVISOR;
   }
 
   /**

--- a/packages/fast-check/test/e2e/ReplayCommands.spec.ts
+++ b/packages/fast-check/test/e2e/ReplayCommands.spec.ts
@@ -40,7 +40,7 @@ describe(`ReplayCommands (seed: ${seed})`, () => {
       (cmds) => {
         if (alreadyFailed && mrng !== undefined) {
           // Simulate the behaviour of skipAllAfterTimeLimit
-          skipAllRuns = skipAllRuns || mrng.nextDouble() < 0.05;
+          skipAllRuns = skipAllRuns || mrng.nextInt(1, 20) === 1; // 5% chance to skip all runs
           fc.pre(!skipAllRuns);
         }
         try {

--- a/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
+++ b/packages/fast-check/test/unit/arbitrary/__test-helpers__/RandomHelpers.ts
@@ -6,13 +6,11 @@ export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, '
   const clone = vi.fn();
   const nextInt = vi.fn();
   const nextBigInt = vi.fn();
-  const nextDouble = vi.fn();
   const getState = vi.fn();
   class MyRandom extends Random {
     clone = clone;
     nextInt = nextInt;
     nextBigInt = nextBigInt;
-    nextDouble = nextDouble;
     getState = getState;
   }
 
@@ -20,5 +18,5 @@ export function fakeRandom(): { instance: Random } & Omit<MaybeMocked<Random>, '
   // As we don't use anything from this base class, we just pass the ctor with a value that looks ok for it.
   const buildInternal = () => ({ clone: () => buildInternal() });
   const instance = new MyRandom(buildInternal() as any);
-  return { instance, clone, nextInt, nextBigInt, nextDouble, getState };
+  return { instance, clone, nextInt, nextBigInt, getState };
 }

--- a/packages/fast-check/test/unit/random/generator/Random.spec.ts
+++ b/packages/fast-check/test/unit/random/generator/Random.spec.ts
@@ -31,19 +31,6 @@ describe('Random', () => {
         }),
       ));
   });
-  describe('nextDouble', () => {
-    it('Should produce values within 0 and 1', async () =>
-      await fc.assert(
-        fc.asyncProperty(fc.integer(), fc.nat(MAX_SIZE), (seed, num) => {
-          const mrng = new Random(xorshift128plus(seed));
-          for (let idx = 0; idx !== num; ++idx) {
-            const v = mrng.nextDouble();
-            if (v < 0 || v >= 1) return false;
-          }
-          return true;
-        }),
-      ));
-  });
   describe('clone', () => {
     it('Should produce the same sequences', async () =>
       await fc.assert(

--- a/skills/javascript-testing-expert/SKILL.md
+++ b/skills/javascript-testing-expert/SKILL.md
@@ -303,7 +303,8 @@ class FakerBuilder<TValue> extends fc.Arbitrary<TValue> {
   }
   generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<TValue> {
     const randomizer: Randomizer = {
-      next: (): number => mrng.nextDouble(),
+      // Build a double in [0, 1) out of two integer draws: 26 bits then 27 bits, for 53 bits of randomness
+      next: (): number => (mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53,
       seed: () => {}, // no-op, no support for updates of the seed, could even throw
     };
     const customFaker = new Faker({ locale: base, randomizer });

--- a/skills/javascript-testing-expert/SKILL.md
+++ b/skills/javascript-testing-expert/SKILL.md
@@ -303,7 +303,6 @@ class FakerBuilder<TValue> extends fc.Arbitrary<TValue> {
   }
   generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<TValue> {
     const randomizer: Randomizer = {
-      // Build a double in [0, 1) out of two integer draws: 26 bits then 27 bits, for 53 bits of randomness
       next: (): number => (mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53,
       seed: () => {}, // no-op, no support for updates of the seed, could even throw
     };

--- a/website/blog/2024-07-18-integrating-faker-with-fast-check/index.md
+++ b/website/blog/2024-07-18-integrating-faker-with-fast-check/index.md
@@ -5,6 +5,9 @@ tags: [tips, integration]
 image: /img/blog/2024-07-18-integrating-faker-with-fast-check--social.png
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 [Faker](https://fakerjs.dev) is a well-known and powerful library for generating fake data. It provides a wide range of random but realistic-looking data generators. However, testing with purely random data can be risky, which is why property-based testing is valuable. While using fake but realistic data in tests can be beneficial, it is essential to integrate it properly. fast-check offers a robust solution for this integration.
 
 {/* truncate */}
@@ -113,6 +116,42 @@ Our constraint of reusing the generator passed by fast-check prevents us from re
 
 Here is the implmentation we came up with:
 
+<Tabs>
+  <TabItem value="v5" label="Since v5" default>
+
+```ts
+import { Faker, Randomizer, base } from '@faker-js/faker';
+import * as fc from 'fast-check';
+
+class FakerBuilder<TValue> extends fc.Arbitrary<TValue> {
+  constructor(private readonly generator: (faker: Faker) => TValue) {
+    super();
+  }
+  generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<TValue> {
+    const randomizer: Randomizer = {
+      // Build a double in [0, 1) out of two integer draws: 26 bits then 27 bits, for 53 bits of randomness
+      next: (): number => (mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53,
+      seed: () => {}, // no-op, no support for updates of the seed, could even throw
+    };
+    const customFaker = new Faker({ locale: base, randomizer });
+    return new fc.Value(this.generator(customFaker), undefined);
+  }
+  canShrinkWithoutContext(value: unknown): value is TValue {
+    return false;
+  }
+  shrink(value: TValue, context: unknown): fc.Stream<fc.Value<TValue>> {
+    return fc.Stream.nil();
+  }
+}
+
+function fakerToArb<TValue>(generator: (faker: Faker) => TValue): fc.Arbitrary<TValue> {
+  return new FakerBuilder(generator);
+}
+```
+
+  </TabItem>
+  <TabItem value="v4" label="Until v4">
+
 ```ts
 import { Faker, Randomizer, base } from '@faker-js/faker';
 import * as fc from 'fast-check';
@@ -142,6 +181,9 @@ function fakerToArb<TValue>(generator: (faker: Faker) => TValue): fc.Arbitrary<T
 }
 ```
 
+  </TabItem>
+</Tabs>
+
 This refined implementation addresses most of the issues with the naive approach and provides a more powerful and cleaner integration with Faker.
 
 ## Advanced integration
@@ -151,6 +193,31 @@ The previous implementation does not provide any shrinking capabilities. While b
 ### Simplified version
 
 To incorporate shrinking capabilities, let's simplify the previous snippet to focus on generating first names only:
+
+<Tabs>
+  <TabItem value="v5" label="Since v5" default>
+
+```ts
+class FakerFirstNameBuilder extends fc.Arbitrary<string> {
+  generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<string> {
+    const randomizer = {
+      next: () => (mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53,
+      seed: () => {},
+    };
+    const customFaker = new Faker({ locale: base, randomizer });
+    return new fc.Value(customFaker.person.firstName(), undefined);
+  }
+  canShrinkWithoutContext(value: unknown): value is string {
+    return false;
+  }
+  shrink(value: TValue, context: unknown): fc.Stream<fc.Value<string>> {
+    return fc.Stream.nil();
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value="v4" label="Until v4">
 
 ```ts
 class FakerFirstNameBuilder extends fc.Arbitrary<string> {
@@ -167,6 +234,9 @@ class FakerFirstNameBuilder extends fc.Arbitrary<string> {
   }
 }
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Adding shrinking
 
@@ -214,6 +284,37 @@ class FakerFirstNameBuilder extends fc.Arbitrary<string> {
 
 But, our implementation still makes a subtle assumption. It supposes that an undefined context value is always linked to a value coming from our own `generate` and cannot be something produced by the shrinker of `strArb`. We can make it safer by being able to differentiate our own values from the ones of `strArb`.
 
+<Tabs>
+  <TabItem value="v5" label="Since v5" default>
+
+```ts
+const ctxProbe = Symbol();
+const strArb = fc.string({ minLength: 1 });
+
+class FakerFirstNameBuilder extends fc.Arbitrary<string> {
+  generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<string> {
+    const randomizer = {
+      next: () => (mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53,
+      seed: () => {},
+    };
+    const customFaker = new Faker({ locale: base, randomizer });
+    return new fc.Value(customFaker.person.firstName(), ctxProbe);
+  }
+  canShrinkWithoutContext(value: unknown): value is string {
+    return false;
+  }
+  shrink(value: TValue, context: unknown): fc.Stream<fc.Value<string>> {
+    if (context !== ctxProbe || strArb.canShrinkWithoutContext(value)) {
+      return strArb.shrink(value, context);
+    }
+    return fc.Stream.nil();
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value="v4" label="Until v4">
+
 ```ts
 const ctxProbe = Symbol();
 const strArb = fc.string({ minLength: 1 });
@@ -235,6 +336,9 @@ class FakerFirstNameBuilder extends fc.Arbitrary<string> {
   }
 }
 ```
+
+  </TabItem>
+</Tabs>
 
 :::tip `fc.string()` might not be ideal
 


### PR DESCRIPTION
## Description

`Random` no longer exposes `nextDouble()`. **Breaking change**: users relying on it — typically to bridge `Random` with third-party generators such as faker's `Randomizer` — can rebuild the exact same double in `[0, 1)` from two integer draws: `(mrng.nextInt(0, 0x3ffffff) * 2 ** 27 + mrng.nextInt(0, 0x7ffffff)) / 2 ** 53` (26 upper bits then 27 lower bits, consuming the generator identically, so replayed sequences are unaffected). Flagged as major via a changeset.

The motivation: after #7179, `nextDouble` was the last drawing helper on `Random` with no production usage — no arbitrary relies on it (`fc.double()`/`fc.float()` build their values from integer draws), only tests and documentation snippets did. Dropping it leaves `Random` with a minimal surface: `clone`, `nextInt`, `nextBigInt` and `getState`, each backed by real usage.

Usages were migrated as follows:

- The faker-integration blog post now shows both flavors of the `Randomizer` snippet through Docusaurus tabs — "Since v5" (default) with the two-draw computation, "Until v4" with the historical `nextDouble()` version — and the `javascript-testing-expert` skill was updated to the new snippet. The website builds successfully with the new tabs.
- The `ReplayCommands` e2e spec only used `nextDouble() < 0.05` as a 5% coin flip, where a double adds nothing: it now draws `nextInt(1, 20) === 1`.
- The `nextDouble` unit test was removed and the `fakeRandom()` test helper no longer exposes a mock for it (no spec consumed that mock).

Existing tests would fail to compile against the reduced class otherwise; the full unit suite, the replay e2e spec, typecheck and the website build all pass.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL9nDkBv45rMBMvqTHQZFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WL9nDkBv45rMBMvqTHQZFm)_