### PR TITLE
💥 Merge `asyncToStringMethod` into `toStringMethod`

### DIFF
--- a/.changeset/merge-tostring-symbols.md
+++ b/.changeset/merge-tostring-symbols.md
@@ -1,0 +1,5 @@
+---
+"fast-check": major
+---
+
+💥 Merge `asyncToStringMethod` into `toStringMethod`

--- a/packages/fast-check/src/arbitrary/_internals/StreamArbitrary.ts
+++ b/packages/fast-check/src/arbitrary/_internals/StreamArbitrary.ts
@@ -3,7 +3,7 @@ import { Value } from '../../check/arbitrary/definition/Value.js';
 import { cloneMethod } from '../../check/symbols.js';
 import type { Random } from '../../random/generator/Random.js';
 import { nil } from '../../utils/iterator.js';
-import { asyncStringify, asyncToStringMethod, stringify, toStringMethod } from '../../utils/stringify.js';
+import { possiblyAsyncStringify, stringify, toStringMethod } from '../../utils/stringify.js';
 
 /** @internal */
 function prettyPrint(numSeen: number, seenValuesStrings?: string[]): string {
@@ -41,14 +41,17 @@ export class StreamArbitrary<T> extends Arbitrary<IteratorObject<T, never>> {
           value: () => prettyPrint(numSeenValues, seenValues !== null ? seenValues.map(stringify) : undefined),
         },
         [toStringMethod]: {
-          value: () => prettyPrint(numSeenValues, seenValues !== null ? seenValues.map(stringify) : undefined),
-        },
-        [asyncToStringMethod]: {
-          value: async () =>
-            prettyPrint(
-              numSeenValues,
-              seenValues !== null ? await Promise.all(seenValues.map(asyncStringify)) : undefined,
-            ),
+          value: () => {
+            if (seenValues === null) {
+              return prettyPrint(numSeenValues, undefined);
+            }
+            const stringifiedValues = seenValues.map((value) => possiblyAsyncStringify(value));
+            return stringifiedValues.every((s): s is string => typeof s === 'string')
+              ? prettyPrint(numSeenValues, stringifiedValues)
+              : Promise.all(stringifiedValues.map((s) => Promise.resolve(s))).then((values) =>
+                  prettyPrint(numSeenValues, values),
+                );
+          },
         },
         // We allow reconfiguration of the [cloneMethod] as caller might want to enforce its own
         [cloneMethod]: { value: enrichedProducer, enumerable: true },

--- a/packages/fast-check/src/arbitrary/func.ts
+++ b/packages/fast-check/src/arbitrary/func.ts
@@ -1,5 +1,5 @@
 import { hash } from '../utils/hash.js';
-import { asyncStringify, asyncToStringMethod, stringify, toStringMethod } from '../utils/stringify.js';
+import { possiblyAsyncStringify, stringify, toStringMethod } from '../utils/stringify.js';
 import { cloneMethod, hasCloneMethod } from '../check/symbols.js';
 import { array } from './array.js';
 import type { Arbitrary } from '../check/arbitrary/definition/Arbitrary.js';
@@ -39,8 +39,14 @@ export function func<TArgs extends any[], TOut>(arb: Arbitrary<TOut>): Arbitrary
       }
       return Object.defineProperties(f, {
         toString: { value: () => prettyPrint(stringify(outs)) },
-        [toStringMethod]: { value: () => prettyPrint(stringify(outs)) },
-        [asyncToStringMethod]: { value: async () => prettyPrint(await asyncStringify(outs)) },
+        [toStringMethod]: {
+          value: () => {
+            const stringifiedOuts = possiblyAsyncStringify(outs);
+            return typeof stringifiedOuts === 'string'
+              ? prettyPrint(stringifiedOuts)
+              : stringifiedOuts.then(prettyPrint);
+          },
+        },
         // We allow reconfiguration of the [cloneMethod] as caller might want to enforce its own
         [cloneMethod]: { value: producer, configurable: true },
       });

--- a/packages/fast-check/src/check/model/commands/CommandWrapper.ts
+++ b/packages/fast-check/src/check/model/commands/CommandWrapper.ts
@@ -1,10 +1,5 @@
-import {
-  asyncToStringMethod,
-  hasAsyncToStringMethod,
-  hasToStringMethod,
-  toStringMethod,
-} from '../../../utils/stringify.js';
-import type { WithToStringMethod, WithAsyncToStringMethod } from '../../../utils/stringify.js';
+import { hasToStringMethod, toStringMethod } from '../../../utils/stringify.js';
+import type { WithToStringMethod } from '../../../utils/stringify.js';
 import { cloneMethod, hasCloneMethod } from '../../symbols.js';
 import type { ICommand } from '../command/ICommand.js';
 
@@ -22,16 +17,9 @@ export class CommandWrapper<Model extends object, Real, RunResult, CheckAsync ex
   constructor(readonly cmd: ICommand<Model, Real, RunResult, CheckAsync>) {
     if (hasToStringMethod(cmd)) {
       const method = cmd[toStringMethod];
-      (this as unknown as WithToStringMethod)[toStringMethod] = function toStringMethod(): string {
+      (this as unknown as WithToStringMethod)[toStringMethod] = function toStringMethod(): string | Promise<string> {
         return method.call(cmd);
       };
-    }
-    if (hasAsyncToStringMethod(cmd)) {
-      const method = cmd[asyncToStringMethod];
-      (this as unknown as WithAsyncToStringMethod)[asyncToStringMethod] =
-        function asyncToStringMethod(): Promise<string> {
-          return method.call(cmd);
-        };
     }
   }
   check(m: Readonly<Model>): CheckAsync extends false ? boolean : Promise<boolean> {

--- a/packages/fast-check/src/fast-check.ts
+++ b/packages/fast-check/src/fast-check.ts
@@ -149,15 +149,8 @@ export type { ExecutionTree } from './check/runner/reporter/ExecutionTree.js';
 export type { WithCloneMethod } from './check/symbols.js';
 export { cloneMethod, cloneIfNeeded, hasCloneMethod } from './check/symbols.js';
 export { hash } from './utils/hash.js';
-export type { WithToStringMethod, WithAsyncToStringMethod } from './utils/stringify.js';
-export {
-  stringify,
-  asyncStringify,
-  toStringMethod,
-  hasToStringMethod,
-  asyncToStringMethod,
-  hasAsyncToStringMethod,
-} from './utils/stringify.js';
+export type { WithToStringMethod } from './utils/stringify.js';
+export { stringify, asyncStringify, toStringMethod, hasToStringMethod } from './utils/stringify.js';
 export type {
   Scheduler,
   SchedulerSequenceItem,

--- a/packages/fast-check/src/utils/stringify.ts
+++ b/packages/fast-check/src/utils/stringify.ts
@@ -1,6 +1,10 @@
 /**
  * Use this symbol to define a custom serializer for your instances.
- * Serializer must be a function returning a string (see {@link WithToStringMethod}).
+ * Serializer must be a function returning either a string or a promise of string (see {@link WithToStringMethod}).
+ *
+ * Please note that:
+ * 1. Promise-based outputs will only be exploited by asynchronous properties.
+ * 2. Whenever it returns a promise, this promise has to resolve barely instantly.
  *
  * @remarks Since 2.17.0
  * @public
@@ -12,7 +16,7 @@ export const toStringMethod: unique symbol = Symbol.for('fast-check/toStringMeth
  * @remarks Since 2.17.0
  * @public
  */
-export type WithToStringMethod = { [toStringMethod]: () => string };
+export type WithToStringMethod = { [toStringMethod]: () => string | Promise<string> };
 /**
  * Check if an instance implements {@link WithToStringMethod}
  *
@@ -25,40 +29,6 @@ export function hasToStringMethod<T>(instance: T): instance is T & WithToStringM
     (typeof instance === 'object' || typeof instance === 'function') &&
     toStringMethod in instance &&
     typeof (instance as any)[toStringMethod] === 'function'
-  );
-}
-
-/**
- * Use this symbol to define a custom serializer for your instances.
- * Serializer must be a function returning a promise of string (see {@link WithAsyncToStringMethod}).
- *
- * Please note that:
- * 1. It will only be useful for asynchronous properties.
- * 2. It has to return barely instantly.
- *
- * @remarks Since 2.17.0
- * @public
- */
-export const asyncToStringMethod: unique symbol = Symbol.for('fast-check/asyncToStringMethod');
-/**
- * Interface to implement for {@link asyncToStringMethod}
- *
- * @remarks Since 2.17.0
- * @public
- */
-export type WithAsyncToStringMethod = { [asyncToStringMethod]: () => Promise<string> };
-/**
- * Check if an instance implements {@link WithAsyncToStringMethod}
- *
- * @remarks Since 2.17.0
- * @public
- */
-export function hasAsyncToStringMethod<T>(instance: T): instance is T & WithAsyncToStringMethod {
-  return (
-    instance !== null &&
-    (typeof instance === 'object' || typeof instance === 'function') &&
-    asyncToStringMethod in instance &&
-    typeof (instance as any)[asyncToStringMethod] === 'function'
   );
 }
 
@@ -113,7 +83,7 @@ function isSparseArray(arr: unknown[]): boolean {
 export function stringifyInternal<Ts>(
   value: Ts,
   previousValues: any[],
-  getAsyncContent: (p: Promise<unknown> | WithAsyncToStringMethod) => AsyncContent,
+  getAsyncContent: (p: Promise<unknown> | WithToStringMethod) => AsyncContent,
 ): string {
   const currentValues = [...previousValues, value];
   if (typeof value === 'object') {
@@ -123,17 +93,20 @@ export function stringifyInternal<Ts>(
     }
   }
 
-  if (hasAsyncToStringMethod(value)) {
-    // if user defined custom async serialization function, we use it first
-    const content = getAsyncContent(value);
-    if (content.state === 'fulfilled') {
-      return content.value as string;
-    }
-  }
   if (hasToStringMethod(value)) {
-    // if user defined custom sync serialization function, we use it before next ones
+    // if user defined custom serialization function, we use it before next ones
     try {
-      return value[toStringMethod]();
+      const out = value[toStringMethod]();
+      if (typeof out === 'string') {
+        return out;
+      }
+      // the serializer returned a promise of string: it can only be leveraged in asynchronous contexts
+      // oxlint-disable-next-line no-empty-function
+      out.catch(() => {}); // catching potential errors of out to avoid "Unhandled promise rejection"
+      const content = getAsyncContent(value);
+      if (content.state === 'fulfilled') {
+        return content.value as string;
+      }
     } catch {
       // fallback to defaults...
     }
@@ -365,7 +338,7 @@ export function possiblyAsyncStringify<Ts>(value: Ts): string | Promise<string> 
   }
 
   const unknownState = { state: 'unknown', value: undefined } as const;
-  const getAsyncContent = function getAsyncContent(data: Promise<unknown> | WithAsyncToStringMethod): AsyncContent {
+  const getAsyncContent = function getAsyncContent(data: Promise<unknown> | WithToStringMethod): AsyncContent {
     const cacheKey = data;
     if (cache.has(cacheKey)) {
       // oxlint-disable-next-line typescript/no-non-null-assertion
@@ -374,8 +347,8 @@ export function possiblyAsyncStringify<Ts>(value: Ts): string | Promise<string> 
 
     const delay0 = createDelay0();
     const p: Promise<unknown> =
-      asyncToStringMethod in data
-        ? Promise.resolve().then(() => (data as WithAsyncToStringMethod)[asyncToStringMethod]())
+      toStringMethod in data
+        ? Promise.resolve().then(() => (data as WithToStringMethod)[toStringMethod]())
         : (data as Promise<unknown>);
     // oxlint-disable-next-line no-empty-function
     p.catch(() => {}); // catching potential errors of p to avoid "Unhandled promise rejection"

--- a/packages/fast-check/test/unit/check/model/commands/CommandWrapper.spec.ts
+++ b/packages/fast-check/test/unit/check/model/commands/CommandWrapper.spec.ts
@@ -3,7 +3,7 @@ import { CommandWrapper } from '../../../../../src/check/model/commands/CommandW
 import type { Command } from '../../../../../src/check/model/command/Command.js';
 import type { AsyncCommand } from '../../../../../src/check/model/command/AsyncCommand.js';
 import { cloneMethod } from '../../../../../src/check/symbols.js';
-import { asyncToStringMethod, toStringMethod } from '../../../../../src/utils/stringify.js';
+import { toStringMethod } from '../../../../../src/utils/stringify.js';
 
 type Model = Record<string, unknown>;
 type Real = unknown;
@@ -138,30 +138,18 @@ describe('CommandWrapper', () => {
 
     const wrapper = new CommandWrapper(cmd);
     expect(toStringMethod in wrapper).toBe(true);
-    expect(asyncToStringMethod in wrapper).toBe(false);
     expect((wrapper as any)[toStringMethod]()).toBe('hello');
   });
-  it('Should not define [asyncToStringMethod] if underlying command does not', async () => {
+  it('Should define Promise-based [toStringMethod] if underlying command does', async () => {
     const cmd = new (class implements Command<Model, Real> {
       check = vi.fn();
       run = vi.fn();
       toString = vi.fn();
+      [toStringMethod] = async () => 'world';
     })();
 
     const wrapper = new CommandWrapper(cmd);
-    expect(toStringMethod in wrapper).toBe(false);
-  });
-  it('Should define [asyncToStringMethod] if underlying command does', async () => {
-    const cmd = new (class implements Command<Model, Real> {
-      check = vi.fn();
-      run = vi.fn();
-      toString = vi.fn();
-      [asyncToStringMethod] = async () => 'world';
-    })();
-
-    const wrapper = new CommandWrapper(cmd);
-    expect(asyncToStringMethod in wrapper).toBe(true);
-    expect(toStringMethod in wrapper).toBe(false);
-    expect(await (wrapper as any)[asyncToStringMethod]()).toBe('world');
+    expect(toStringMethod in wrapper).toBe(true);
+    expect(await (wrapper as any)[toStringMethod]()).toBe('world');
   });
 });

--- a/packages/fast-check/test/unit/utils/stringify.spec.ts
+++ b/packages/fast-check/test/unit/utils/stringify.spec.ts
@@ -5,13 +5,7 @@ import * as fc from 'fast-check';
 // Instead we want 'buffer' from our node_modules - the most used polyfill for Buffer on browser-side
 import { Buffer as NotNodeBuffer } from 'not-node-buffer';
 
-import {
-  asyncStringify,
-  asyncToStringMethod,
-  possiblyAsyncStringify,
-  stringify,
-  toStringMethod,
-} from '../../../src/utils/stringify.js';
+import { asyncStringify, possiblyAsyncStringify, stringify, toStringMethod } from '../../../src/utils/stringify.js';
 
 declare function BigInt(n: number | bigint | string): bigint;
 
@@ -508,17 +502,15 @@ describe('stringify', () => {
     const instance5 = { [toStringMethod]: 1 }; // not callable
     expect(stringify(instance5)).toEqual('{[Symbol.for("fast-check/toStringMethod")]:1}');
   });
-  it('Should not be able to rely on the output of [asyncToStringMethod] in sync mode', () => {
-    const instance1 = { [asyncToStringMethod]: () => 'hello1' }; // not even async there
-    expect(stringify(instance1)).toEqual('{[Symbol.for("fast-check/asyncToStringMethod")]:() => "hello1"}'); // fallbacking to default
+  it('Should not be able to rely on Promise-based outputs of [toStringMethod] in sync mode', () => {
+    const instance1 = { [toStringMethod]: async () => 'hello1' };
+    expect(stringify(instance1)).toEqual('{[Symbol.for("fast-check/toStringMethod")]:async () => "hello1"}'); // fallbacking to default
 
-    const instance2 = { [asyncToStringMethod]: () => 'hello2', [toStringMethod]: () => 'world' };
-    expect(stringify(instance2)).toEqual('world'); // fallbacking to [toStringMethod]
-
-    const instance3ProbeFn = vi.fn();
-    const instance3 = { [asyncToStringMethod]: instance3ProbeFn };
-    stringify(instance3);
-    expect(instance3ProbeFn).not.toHaveBeenCalled(); // never calling [asyncToStringMethod] in sync mode
+    const p2 = Promise.resolve('hello2');
+    const instance2ProbeFn = vi.fn().mockImplementation(() => p2);
+    const instance2 = { [toStringMethod]: instance2ProbeFn };
+    expect(stringify(instance2)).not.toEqual('hello2'); // fallbacking to default
+    expect(instance2ProbeFn).toHaveBeenCalled(); // [toStringMethod] gets called even in sync mode, but its Promise-based output cannot be leveraged there
   });
 });
 
@@ -611,53 +603,49 @@ describe('asyncStringify', () => {
       'Promise.resolve({"a":Promise.resolve({"a1":[cyclic]}),"b":{"b1":Promise.resolve({"a1":[cyclic]})}})',
     );
   });
-  it('Should use [asyncToStringMethod] if any on the instance or its prototype', async () => {
-    const instance1 = { [asyncToStringMethod]: async () => 'hello1' };
+  it('Should use Promise-based [toStringMethod] if any on the instance or its prototype', async () => {
+    const instance1 = { [toStringMethod]: async () => 'hello1' };
     expect(await asyncStringify(instance1)).toEqual('hello1');
 
     const instance2 = Object.create(null);
-    Object.defineProperty(instance2, asyncToStringMethod, {
-      value: () => 'hello2',
+    Object.defineProperty(instance2, toStringMethod, {
+      value: async () => 'hello2',
       configurable: false,
       enumerable: false,
       writable: false,
     });
     expect(await asyncStringify(instance2)).toEqual('hello2');
 
-    const instance3 = { [asyncToStringMethod]: async () => 'hello3', [toStringMethod]: () => 'world' };
-    expect(await asyncStringify(instance3)).toEqual('hello3'); // even when [toStringMethod] has been defined
+    const instance3 = { [toStringMethod]: () => 'hello3' }; // not even async there
+    expect(await asyncStringify(instance3)).toEqual('hello3');
 
     // prettier-ignore
-    const instance4 = { [asyncToStringMethod]: async () => { throw new Error('hello4'); } };
+    const instance4 = { [toStringMethod]: async () => { throw new Error('hello4'); } };
     const stringified4 = await asyncStringify(instance4);
     expect(stringified4.replace(/[\s\n]+/g, ' ')).toEqual(
-      '{[Symbol.for("fast-check/asyncToStringMethod")]:async () => { throw new Error("hello4"); }}',
+      '{[Symbol.for("fast-check/toStringMethod")]:async () => { throw new Error("hello4"); }}',
     ); // fallbacking to default
 
     // prettier-ignore
-    const instance5 = { [asyncToStringMethod]: async () => { throw new Error('hello5'); }, [toStringMethod]: () => "world" };
-    expect(await asyncStringify(instance5)).toEqual('world'); // fallbacking to [toStringMethod]
-
-    // prettier-ignore
-    const instance6 = { [asyncToStringMethod]: () => { throw new Error('hello6'); } }; // throw is sync
+    const instance6 = { [toStringMethod]: () => { throw new Error('hello6'); } }; // throw is sync
     const stringified6 = await asyncStringify(instance6);
     expect(stringified6.replace(/[\s\n]+/g, ' ')).toEqual(
-      '{[Symbol.for("fast-check/asyncToStringMethod")]:() => { throw new Error("hello6"); }}',
+      '{[Symbol.for("fast-check/toStringMethod")]:() => { throw new Error("hello6"); }}',
     ); // fallbacking to default
 
     class InProto {
-      async [asyncToStringMethod]() {
+      async [toStringMethod]() {
         return 'hello7';
       }
     }
     const instance7 = new InProto();
     expect(await asyncStringify(instance7)).toEqual('hello7');
 
-    const instance8 = { [asyncToStringMethod]: 1 }; // not callable
-    expect(await asyncStringify(instance8)).toEqual('{[Symbol.for("fast-check/asyncToStringMethod")]:1}');
+    const instance8 = { [toStringMethod]: 1 }; // not callable
+    expect(await asyncStringify(instance8)).toEqual('{[Symbol.for("fast-check/toStringMethod")]:1}');
 
     const instance9 = {
-      [asyncToStringMethod]: async () => {
+      [toStringMethod]: async () => {
         const s1 = await asyncStringify(Promise.resolve('hello9'));
         const s2 = await asyncStringify(Promise.resolve('world9'));
         return `${s1} ${s2}`;
@@ -666,7 +654,7 @@ describe('asyncStringify', () => {
     expect(await asyncStringify(instance9)).toEqual('Promise.resolve("hello9") Promise.resolve("world9")');
 
     const p10 = Promise.resolve('hello10');
-    const instance10 = { [asyncToStringMethod]: () => p10.then((v) => `got: ${v}`) };
+    const instance10 = { [toStringMethod]: () => p10.then((v) => `got: ${v}`) };
     expect(await asyncStringify(instance10)).toEqual('got: hello10');
   });
 });

--- a/website/docs/configuration/custom-reports.md
+++ b/website/docs/configuration/custom-reports.md
@@ -121,10 +121,10 @@ The official documentation explaining how to build CodeSandbox environments from
 
 By default, fast-check serializes generated values using its internal `stringify` helper. Sometimes you may want a better stringified representation of your instances. In such cases, you have several solutions:
 
-1. If your instance defines a `toString` method, it will used to properly report it, unless you've defined one of the following methods, which take precedence.
-2. If defining `toString` method is to intrusive, you can use `toStringMethod` and `asyncToStringMethod`.
+1. If your instance defines a `toString` method, it will used to properly report it, unless you've defined the following method, which takes precedence.
+2. If defining `toString` method is to intrusive, you can use `toStringMethod`.
 
-In most cases, `toStringMethod` is sufficient. This is the serializer method that fast-check uses to serialize your instance in any context: synchronous or asynchronous.
+`toStringMethod` is the serializer method that fast-check uses to serialize your instance in any context: synchronous or asynchronous.
 
 ```ts
 Object.defineProperties(myInstanceWithoutCustomToString, {
@@ -134,11 +134,11 @@ Object.defineProperties(myInstanceWithoutCustomToString, {
 // that will be used by fast-check whenever needed
 ```
 
-However, if you're working with asynchronous values, you may need an async method to retrieve the value. For example:
+However, if you're working with asynchronous values, you may need an async method to retrieve the value. In such cases, `toStringMethod` can return a promise of string instead of a string. For example:
 
 ```ts
 Object.defineProperties(myPromisePossiblyResolved, {
-  [fc.asyncToStringMethod]: {
+  [fc.toStringMethod]: {
     value: async () => {
       const resolved = await myPromisePossiblyResolved;
       return `My value: ${resolved}`;
@@ -147,11 +147,11 @@ Object.defineProperties(myPromisePossiblyResolved, {
 });
 ```
 
-:::info Limitations of async variant
+:::info Limitations of Promise-based outputs
 Note that:
 
-- `asyncToStringMethod` is only used in asynchronous contexts.
-- Although `asyncToStringMethod` is marked as asynchronous, it should resolve almost instantly.
+- Promise-based outputs of `toStringMethod` are only used in asynchronous contexts.
+- Whenever `toStringMethod` returns a promise, this promise should resolve almost instantly.
 
 :::
 


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

<!-- Describe your change and explain what this PR is trying to solve -->

In the past we used to have two symbols to declare a custom serializer on an instance: `toStringMethod` for synchronous contexts and `asyncToStringMethod` for asynchronous ones.

The two got merged into a single one: `toStringMethod`. Its serializer can now return either a string or a promise of string. In other words, users previously relying on `asyncToStringMethod` just have to declare the same serializer on `toStringMethod`.

**Breaking changes** (impact flagged as major via a changeset):

- `asyncToStringMethod`, `WithAsyncToStringMethod` and `hasAsyncToStringMethod` are dropped from the public API. Migration: replace `asyncToStringMethod` by `toStringMethod`.
- `WithToStringMethod` now declares `() => string | Promise<string>` instead of `() => string`.
- `toStringMethod` is now invoked even in synchronous contexts when its output turns out to be a promise (its output simply cannot be leveraged there and fast-check falls back to its default serialization). Previously `asyncToStringMethod` was never called in synchronous contexts.

Promise-based outputs keep the exact same constraints as `asyncToStringMethod` had: they are only exploited by asynchronous properties and must resolve almost instantly.

This PR follows the same direction as previous merges of the sync/async pairs (see the merge of `asyncReporter` into `reporter` in #7178): with asynchronous properties being the sole way to create properties, keeping two symbols for the same concern was no longer justified.

The PR is focused on that single concern. Internal users of the symbols were updated accordingly: `func`, `streamOf` and `commands` now expose a single `toStringMethod` returning a string when serialization can be done synchronously and a promise otherwise. Existing tests on `stringify`/`asyncStringify` and `CommandWrapper` were adapted to the merged symbol — among others they check that Promise-based outputs are used in asynchronous contexts and properly fall back in synchronous ones, and they would have failed without this PR. Documentation (`custom-reports.md`) was updated too.

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H4rz5zF7PTMQK6JCFWh9o

---
_Generated by [Claude Code](https://claude.ai/code/session_019H4rz5zF7PTMQK6JCFWh9o)_