### PR TITLE
📝(fast-check) Allow sync beforeEach hooks for async properties

### DIFF
--- a/.changeset/async-before-each-void.md
+++ b/.changeset/async-before-each-void.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+Allow asynchronous raw properties to expose synchronous beforeEach hooks.

--- a/packages/fast-check/src/check/property/IRawProperty.ts
+++ b/packages/fast-check/src/check/property/IRawProperty.ts
@@ -72,7 +72,7 @@ export interface IRawProperty<Ts, IsAsync extends boolean = boolean> {
    * Run before each hook
    * @remarks Since 3.4.0
    */
-  runBeforeEach: () => (IsAsync extends true ? Promise<void> : never) | (IsAsync extends false ? void : never);
+  runBeforeEach: () => (IsAsync extends true ? Promise<void> | void : never) | (IsAsync extends false ? void : never);
 
   /**
    * Run after each hook

--- a/packages/fast-check/test-types/main.ts
+++ b/packages/fast-check/test-types/main.ts
@@ -69,6 +69,11 @@ expectTypeOf(
     .beforeEach(() => 123)
     .afterEach(() => 'anything'),
 ).toMatchTypeOf<fc.IAsyncProperty<[number]>>();
+// Asynchronous raw properties may expose synchronous beforeEach hooks
+const asyncRawPropertyWithSynchronousBeforeEach: Pick<fc.IAsyncProperty<unknown>, 'runBeforeEach'> = {
+  runBeforeEach: () => {},
+};
+void asyncRawPropertyWithSynchronousBeforeEach;
 // @ts-expect-error - Types declared in predicate are not compatible with the generators
 fc.asyncProperty(fc.nat(), fc.string(), async (_a: number, _b: number) => {});
 // @ts-expect-error - Enforce users to declare all the generated values as arguments of the predicate


### PR DESCRIPTION
## Description

Relax the `IRawProperty.runBeforeEach` return type for asynchronous properties to also allow synchronous `void` hooks.

This matches the existing `asyncProperty(...).beforeEach(() => ...)` API and allows custom asynchronous raw properties and wrappers to expose a synchronous `runBeforeEach` implementation.

Fixes #7145.

## Changes

- Allow `Promise<void> | void` for asynchronous `runBeforeEach` hooks.
- Add a type regression check.
- Add a patch changeset.

## Validation

- `pnpm --filter fast-check typecheck`
- `pnpm test --project fast-check test/unit/check/property/AsyncProperty.spec.ts test/unit/check/property/UnbiasedProperty.spec.ts`
- Prettier, Oxlint, and `git diff --check`