### PR TITLE
👷 Run independent CI steps concurrently

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -164,10 +164,10 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       - parallel:
           - name: Typecheck
             run: node --run typecheck:all
@@ -199,10 +199,10 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       # These are not real npm publish commands, but pnpm exec pkg-pr-new publish
       # pkg-pr-new is a tool for creating preview deployments, not for publishing to npm
       - name: Preview (no comment) # zizmor: ignore[use-trusted-publishing]
@@ -273,6 +273,8 @@ jobs:
         with:
           name: bundles
           path: packages/
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Unpack production packages
         if: matrix.os != 'windows-latest'
         run: pnpm run unpack:all
@@ -280,8 +282,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         # untar seems to fail on Windows when untaring already existing files
         run: pnpm run unpack:all || true
-      - name: Wait for dependencies to be installed
-        wait: install
       - name: Unit tests
         shell: bash -l {0}
         # The DEFAULT_SEED might be used by some of the packages and might be ignored by others
@@ -353,8 +353,6 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Get date cache buster
         id: get-date
         shell: bash
@@ -370,6 +368,8 @@ jobs:
           key: assets-${{steps.get-date.outputs.date}}-${{hashFiles('.all-contributorsrc', 'website/prebuild/optimize-images.mjs')}}
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       - name: Generate documentation
         run: pnpm --filter website run build
       - name: Copy raw logo within documentation
@@ -407,10 +407,10 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       - name: Alter internals to behave as if published
         run: pnpm --filter {./packages/**} --parallel exec $(pnpm bin)/packaged --keep node_modules --keep test-bundle
       - parallel:
@@ -473,10 +473,10 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       - name: Alter internals to behave as if published
         run: pnpm --filter {./packages/**} --parallel exec $(pnpm bin)/packaged --keep node_modules --keep test-types
       - name: Switch folder to CommonJS
@@ -518,10 +518,10 @@ jobs:
         with:
           name: bundles
           path: packages/
-      - name: Unpack production packages
-        run: node --run unpack:all
       - name: Wait for dependencies to be installed
         wait: install
+      - name: Unpack production packages
+        run: node --run unpack:all
       - name: Benchmark
         id: bench
         shell: bash -l {0}

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -103,10 +103,11 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm --filter @fast-check/monorepo install --frozen-lockfile --ignore-scripts
-      - name: Check format
-        run: node --run format:check
-      - name: Check lint
-        run: node --run lint:check
+      - parallel:
+          - name: Check format
+            run: node --run format:check
+          - name: Check lint
+            run: node --run lint:check
   production_packages:
     name: 'Build production packages'
     needs: warmup_pnpm_cache

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -155,19 +155,21 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
-      - name: Typecheck
-        run: node --run typecheck:all
-      - name: Check API surface (missing exports, inconsistent visibility, etc.)
-        run: pnpm --filter fast-check run api-extractor
+      - parallel:
+          - name: Typecheck
+            run: node --run typecheck:all
+          - name: Check API surface (missing exports, inconsistent visibility, etc.)
+            run: pnpm --filter fast-check run api-extractor
   preview:
     name: 'Preview'
     needs:
@@ -185,13 +187,14 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       # These are not real npm publish commands, but pnpm exec pkg-pr-new publish
@@ -255,13 +258,14 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         if: matrix.os != 'windows-latest'
         run: pnpm run unpack:all
@@ -331,13 +335,14 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm --filter website install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm --filter website install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Get date cache buster
@@ -381,21 +386,23 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Alter internals to behave as if published
         run: pnpm --filter {./packages/**} --parallel exec $(pnpm bin)/packaged --keep node_modules --keep test-bundle
-      - name: Check publication lint
-        run: node --run publint:all
-      - name: Check bundles
-        run: pnpm --filter {./packages/**} --parallel run test-bundle
+      - parallel:
+          - name: Check publication lint
+            run: node --run publint:all
+          - name: Check bundles
+            run: pnpm --filter {./packages/**} --parallel run test-bundle
       - name: Check legacy bundles
         run: |
           export NODE_VERSION="$(node --version)"
@@ -442,13 +449,14 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Alter internals to behave as if published
@@ -476,20 +484,21 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Restore results from last benchmark execution on main
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: benchmark.json
-          # Non-matching key so restore-keys picks the most recent main cache
-          key: bench-main-will-not-match
-          restore-keys: bench-main-
-      - name: Download production packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bundles
-          path: packages/
+      - parallel:
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile --ignore-scripts
+          - name: Restore results from last benchmark execution on main
+            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+            with:
+              path: benchmark.json
+              # Non-matching key so restore-keys picks the most recent main cache
+              key: bench-main-will-not-match
+              restore-keys: bench-main-
+          - name: Download production packages
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              name: bundles
+              path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Benchmark

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -155,16 +155,19 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
+      - name: Wait for dependencies to be installed
+        wait: install
       - parallel:
           - name: Typecheck
             run: node --run typecheck:all
@@ -187,16 +190,19 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
+      - name: Wait for dependencies to be installed
+        wait: install
       # These are not real npm publish commands, but pnpm exec pkg-pr-new publish
       # pkg-pr-new is a tool for creating preview deployments, not for publishing to npm
       - name: Preview (no comment) # zizmor: ignore[use-trusted-publishing]
@@ -258,14 +264,15 @@ jobs:
         with:
           node-version: ${{matrix.node-version}}
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         if: matrix.os != 'windows-latest'
         run: pnpm run unpack:all
@@ -273,6 +280,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         # untar seems to fail on Windows when untaring already existing files
         run: pnpm run unpack:all || true
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Unit tests
         shell: bash -l {0}
         # The DEFAULT_SEED might be used by some of the packages and might be ignored by others
@@ -335,14 +344,15 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm --filter website install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm --filter website install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Get date cache buster
@@ -358,6 +368,8 @@ jobs:
             website/static/img/**/*.gif
             website/static/img/**/*.png
           key: assets-${{steps.get-date.outputs.date}}-${{hashFiles('.all-contributorsrc', 'website/prebuild/optimize-images.mjs')}}
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Generate documentation
         run: pnpm --filter website run build
       - name: Copy raw logo within documentation
@@ -386,16 +398,19 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Alter internals to behave as if published
         run: pnpm --filter {./packages/**} --parallel exec $(pnpm bin)/packaged --keep node_modules --keep test-bundle
       - parallel:
@@ -449,16 +464,19 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Alter internals to behave as if published
         run: pnpm --filter {./packages/**} --parallel exec $(pnpm bin)/packaged --keep node_modules --keep test-types
       - name: Switch folder to CommonJS
@@ -484,23 +502,26 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - parallel:
-          - name: Install dependencies
-            run: pnpm install --frozen-lockfile --ignore-scripts
-          - name: Restore results from last benchmark execution on main
-            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-            with:
-              path: benchmark.json
-              # Non-matching key so restore-keys picks the most recent main cache
-              key: bench-main-will-not-match
-              restore-keys: bench-main-
-          - name: Download production packages
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: bundles
-              path: packages/
+      - name: Install dependencies
+        id: install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        background: true
+      - name: Restore results from last benchmark execution on main
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: benchmark.json
+          # Non-matching key so restore-keys picks the most recent main cache
+          key: bench-main-will-not-match
+          restore-keys: bench-main-
+      - name: Download production packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundles
+          path: packages/
       - name: Unpack production packages
         run: node --run unpack:all
+      - name: Wait for dependencies to be installed
+        wait: install
       - name: Benchmark
         id: bench
         shell: bash -l {0}


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

No end-user-facing change: this PR only speeds up the Build Status workflow by adopting the native parallel steps support GitHub Actions shipped in June 2026 (`parallel`, `background`, `wait` keywords).

Three kinds of concurrency are introduced in `.github/workflows/build-status.yml`:

- **`parallel` pairs of independent checks** — `Check format` / `Check lint` (format_lint), `Typecheck` / `Check API surface` (typecheck), and `Check publication lint` / `Check bundles` (test_bundle) now run concurrently. Each `parallel` group carries an implicit wait, so a failure in either step still fails the job.
- **Background dependency install** — in the seven jobs that consume the `bundles` artifact (typecheck, preview, test, documentation, test_bundle, test_types, bench), `pnpm install` now runs with `background: true` while pnpm-free steps proceed in the foreground: the `bundles` artifact download everywhere, plus the benchmark-cache restore in bench and the date-cache-buster/asset-cache steps in documentation.
- **Explicit `wait: install`** — placed before the first step that runs any pnpm command. Notably, `Unpack production packages` must stay behind the wait even though it only shells out to `tar`: pnpm 11 verifies dependencies before `pnpm run`/`pnpm exec` and triggers an implicit install when `node_modules` is not up to date, so running it during the backgrounded install raced two concurrent installs and corrupted `node_modules` (chmod ENOENT on freshly linked bins — caught on this PR's first CI run). A failed install still fails the job, at the `wait` step.

Setup time for these jobs drops from `install + download` to roughly `max(install, download)` before unpack.

Deliberately left sequential: the `test_types` CJS/ESM phases (they rename files in the same folders), `Check legacy bundles` (switches Node versions mid-step), the build→pack chain in production_packages, and the tag-only publish jobs.

Impact: no version bump needed — the change is confined to CI configuration and ships nothing to npm. The PR is focused on this single concern. No tests apply; the workflow file passes YAML parsing and `prettier --check` locally.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->