### PR TITLE
👷 Run cache restores in the background too

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -350,6 +350,7 @@ jobs:
         background: true
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        background: true
         with:
           name: bundles
           path: packages/
@@ -359,6 +360,7 @@ jobs:
         run: echo "date=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
       - name: Cache for assets
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        background: true
         with:
           path: |
             website/static/img/sponsors.svg
@@ -366,8 +368,8 @@ jobs:
             website/static/img/**/*.gif
             website/static/img/**/*.png
           key: assets-${{steps.get-date.outputs.date}}-${{hashFiles('.all-contributorsrc', 'website/prebuild/optimize-images.mjs')}}
-      - name: Wait for dependencies to be installed
-        wait: install
+      - name: Wait for background steps to complete
+        wait-all:
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Generate documentation
@@ -508,6 +510,7 @@ jobs:
         background: true
       - name: Restore results from last benchmark execution on main
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        background: true
         with:
           path: benchmark.json
           # Non-matching key so restore-keys picks the most recent main cache
@@ -515,11 +518,12 @@ jobs:
           restore-keys: bench-main-
       - name: Download production packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        background: true
         with:
           name: bundles
           path: packages/
-      - name: Wait for dependencies to be installed
-        wait: install
+      - name: Wait for background steps to complete
+        wait-all:
       - name: Unpack production packages
         run: node --run unpack:all
       - name: Benchmark


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

No end-user-facing change: this is a follow-up to #7192, further shortening the Build Status workflow's setup phases.

In the `documentation` and `bench` jobs, the cache restores are independent of both the dependency install and the `bundles` artifact download, so they now run as background steps too:

- **documentation** — the artifact download and the assets cache restore run in the background alongside the already-backgrounded `pnpm --filter website install`. The `Get date cache buster` step stays in the foreground since the cache key depends on its output, but it is a single `date` invocation. A single `wait-all` then gates `Unpack production packages` (which must not run during the install, as established in #7192) and the docusaurus build.
- **bench** — the benchmark-results cache restore and the artifact download run in the background alongside the install, with the same `wait-all` before unpack.

All backgrounded steps touch disjoint paths (`node_modules`, `packages/`, `website/static/img`, `benchmark.json`), and none of them invokes pnpm, so the pnpm 11 verify-deps race fixed in #7192 cannot resurface. `wait-all` fails the job if any background step failed. The other five artifact-consuming jobs are untouched: the download is their only foreground setup step, so it already fully overlaps the install.

Impact: no version bump needed — CI configuration only, nothing ships to npm. Single concern. No tests apply; the workflow passes YAML parsing and `prettier --check` locally.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcycB5UNjHRjwJAifWLRym)_