### PR TITLE
🏷️(jest,vitest) Force plugins to undefined

### DIFF
--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+"@fast-check/jest": patch
+"@fast-check/vitest": patch
+---
+
+🔧 Force `plugins` to `undefined` on record-based `.prop`

--- a/packages/jest/src/internals/TestBuilder.ts
+++ b/packages/jest/src/internals/TestBuilder.ts
@@ -99,9 +99,6 @@ function buildTestProp<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
                   ? // oxlint-disable-next-line typescript/no-non-null-assertion
                     (runDetails) => params.asyncReporter!(adaptRunDetailsForRecord(runDetails, params))
                   : undefined,
-              // Plugins are tied to the shape of the values received by the property.
-              // The record-flavour of the runner deals with `[TsParameters]` while the user deals with `TsParameters`,
-              // so we cannot forward them as-is and prefer dropping them for the moment.
               plugins: undefined,
             }
           : undefined;

--- a/packages/jest/src/internals/TestBuilder.ts
+++ b/packages/jest/src/internals/TestBuilder.ts
@@ -29,6 +29,10 @@ function adaptParametersForRecord<Ts>(
     examples: parameters.examples !== undefined ? parameters.examples.map((example) => example[0]) : undefined,
     reporter: originalParamaters.reporter,
     asyncReporter: originalParamaters.asyncReporter,
+    // Plugins are tied to the shape of the values received by the property.
+    // As the record-flavour of the runner deals with `[Ts]` while the user deals with `Ts`,
+    // we cannot forward them as-is and prefer dropping them for the moment.
+    plugins: undefined,
   };
 }
 
@@ -98,6 +102,10 @@ function buildTestProp<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
                   ? // oxlint-disable-next-line typescript/no-non-null-assertion
                     (runDetails) => params.asyncReporter!(adaptRunDetailsForRecord(runDetails, params))
                   : undefined,
+              // Plugins are tied to the shape of the values received by the property.
+              // The record-flavour of the runner deals with `[TsParameters]` while the user deals with `TsParameters`,
+              // so we cannot forward them as-is and prefer dropping them for the moment.
+              plugins: undefined,
             }
           : undefined;
       buildTestWithPropRunner(

--- a/packages/jest/src/internals/TestBuilder.ts
+++ b/packages/jest/src/internals/TestBuilder.ts
@@ -29,9 +29,6 @@ function adaptParametersForRecord<Ts>(
     examples: parameters.examples !== undefined ? parameters.examples.map((example) => example[0]) : undefined,
     reporter: originalParamaters.reporter,
     asyncReporter: originalParamaters.asyncReporter,
-    // Plugins are tied to the shape of the values received by the property.
-    // As the record-flavour of the runner deals with `[Ts]` while the user deals with `Ts`,
-    // we cannot forward them as-is and prefer dropping them for the moment.
     plugins: undefined,
   };
 }

--- a/packages/vitest/src/internals/TestBuilder.ts
+++ b/packages/vitest/src/internals/TestBuilder.ts
@@ -99,9 +99,6 @@ function buildTestProp<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
                   ? // oxlint-disable-next-line typescript/no-non-null-assertion
                     (runDetails) => params.asyncReporter!(adaptRunDetailsForRecord(runDetails, params))
                   : undefined,
-              // Plugins are tied to the shape of the values received by the property.
-              // The record-flavour of the runner deals with `[TsParameters]` while the user deals with `TsParameters`,
-              // so we cannot forward them as-is and prefer dropping them for the moment.
               plugins: undefined,
             }
           : undefined;

--- a/packages/vitest/src/internals/TestBuilder.ts
+++ b/packages/vitest/src/internals/TestBuilder.ts
@@ -31,9 +31,6 @@ function adaptParametersForRecord<Ts>(
     examples: parameters.examples !== undefined ? parameters.examples.map((example) => example[0]) : undefined,
     reporter: originalParamaters.reporter,
     asyncReporter: originalParamaters.asyncReporter,
-    // Plugins are tied to the shape of the values received by the property.
-    // As the record-flavour of the runner deals with `[Ts]` while the user deals with `Ts`,
-    // we cannot forward them as-is and prefer dropping them for the moment.
     plugins: undefined,
   };
   return enrichedParameters;

--- a/packages/vitest/src/internals/TestBuilder.ts
+++ b/packages/vitest/src/internals/TestBuilder.ts
@@ -31,6 +31,10 @@ function adaptParametersForRecord<Ts>(
     examples: parameters.examples !== undefined ? parameters.examples.map((example) => example[0]) : undefined,
     reporter: originalParamaters.reporter,
     asyncReporter: originalParamaters.asyncReporter,
+    // Plugins are tied to the shape of the values received by the property.
+    // As the record-flavour of the runner deals with `[Ts]` while the user deals with `Ts`,
+    // we cannot forward them as-is and prefer dropping them for the moment.
+    plugins: undefined,
   };
   return enrichedParameters;
 }
@@ -98,6 +102,10 @@ function buildTestProp<Ts extends [any] | any[], TsParameters extends Ts = Ts>(
                   ? // oxlint-disable-next-line typescript/no-non-null-assertion
                     (runDetails) => params.asyncReporter!(adaptRunDetailsForRecord(runDetails, params))
                   : undefined,
+              // Plugins are tied to the shape of the values received by the property.
+              // The record-flavour of the runner deals with `[TsParameters]` while the user deals with `TsParameters`,
+              // so we cannot forward them as-is and prefer dropping them for the moment.
+              plugins: undefined,
             }
           : undefined;
       buildTestWithPropRunner(


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated
> agent (Claude Code) and has not been
> line-by-line reviewed by a human before submission.

Targets #7216 (not `main`).

From an end-user point of view: nothing changes for users of `@fast-check/jest` and `@fast-check/vitest` compared to today. `it.prop`/`test.prop` keep behaving as before, including the record flavour (`it.prop({a: fc.nat()})`). The only visible consequence of this PR is that the `plugins` option introduced by #7216 is explicitly **not** honoured on the record flavour of `.prop`: if a user passes `plugins` there, the plugins are dropped instead of being handed values with an unexpected shape. The tuple flavour (`it.prop([fc.nat()])`) forwards the parameters untouched, so plugins work there as expected.

Why: the `plugins` option added by #7216 is typed against the shape of the values received by the property (`Plugin<T, boolean>[]`). The record flavour wraps the record into a one-element tuple, so the runner deals with `[Ts]` while the user deals with `Ts`. Both adaptation helpers spread a `Required<Parameters<…>>` on purpose — so that a newly added parameter is never silently forgotten — and that spread now carries a `plugins` entry whose generic parameter does not match the target type. This is exactly what the failing type check reports on both packages:

```
src/internals/TestBuilder.ts(28,9): error TS2322: … Types of property 'plugins' are incompatible.
  Type 'Plugin<[Ts], boolean>[]' is not assignable to type 'Plugin<Ts, boolean>[]'.
```

The two directions are affected: `adaptParametersForRecord` (`[Ts]` → `Ts`, used when reporting `runConfiguration` back to the user) and the `recordParams` built in `buildTestProp` (`TsParameters` → `[TsParameters]`, passed to the runner).

Design and trade-offs: rather than casting the plugins across shapes — which would make the runner call `decorateRun`/`afterAll` with a one-element tuple where the plugin expects the record itself, silently breaking any plugin at runtime — this PR forces `plugins: undefined` on both paths, next to the other options that already need a conversion (`examples`, `reporter`, `asyncReporter`). Dropping is the conservative option and leaves the door open for a proper adaptation later, once the plugin API has settled. Adapting plugins for real would mean wrapping `decorateRun` to unwrap the tuple and re-wrap the returned runner, which deserves its own PR and its own tests.

Impact: patch for `@fast-check/jest` and `@fast-check/vitest` (changeset added, both packages marked `patch`). `fast-check` itself is untouched by this PR — its `minor` bump stays owned by #7216.

Scope: focused on unblocking the type check of the two packages impacted by the new `plugins` option; no other change is bundled.

Tests: no new test added. The regression this fixes is a compile-time one, caught by `pnpm run typecheck` on both packages — that command failed before this PR and passes with it, which is the check that would have failed without the change. The existing runtime suites of both packages (168 tests) still pass, confirming the record flavour is otherwise untouched.

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH4AvcuJMARfiqdxP5pXgN)_