### PR TITLE
✨ Add `timeout` plugin to stop long running predicates

### DIFF
--- a/.changeset/brave-clocks-tickle.md
+++ b/.changeset/brave-clocks-tickle.md
@@ -1,0 +1,5 @@
+---
+"fast-check": minor
+---
+
+✨ Add the `timeout` plugin to stop long-running predicates

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -23,15 +23,9 @@ function timeoutRunner(
   value: unknown,
 ): ReturnType<typeof nestedRun> {
   const t = timeoutAfter(timeMs);
-  const runOut = nestedRun(value);
-  if (runOut === null || !('then' in runOut)) {
-    // synchronous run: it already came to an end, no need to wait for any timeout
-    t.clear();
-    return runOut;
-  }
-  const raced = Promise.race([runOut, t.promise]);
-  raced.then(t.clear, t.clear); // always clear timeout handle - catch should never occur
-  return raced;
+  const propRun = Promise.race([nestedRun(value), t.promise]);
+  propRun.then(t.clear, t.clear); // always clear timeout handle - catch should never occur
+  return propRun;
 }
 
 /**

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -29,11 +29,12 @@ function timeoutRunner(
 }
 
 /**
- * Fail the run of your predicate if it takes more than `timeMs` milliseconds to complete.
- * As predicates cannot be stopped, the underlying execution keeps running but its outcome gets ignored.
+ * Mark the execution of a predicate as failed if it exceeds `timeMs` milliseconds to complete.
  *
- * Only useful for asynchronous properties: a synchronous predicate can never be observed timing out
- * as it already came to an end when we get its outcome.
+ * WARNING: It won't really stop a running predicate.
+ * It mostly returns earlier for the test runner to move forward.
+ *
+ * NOTE: Does not have any effect on a synchronously running predicate.
  *
  * @example
  * ```ts

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -1,0 +1,79 @@
+import type { IRawProperty, PropertyFailure } from '../property/IRawProperty.js';
+import { Error } from '../../utils/globals.js';
+import type { Plugin, PluginInstance } from './Plugin.js';
+
+const safeSetTimeout = setTimeout;
+const safeClearTimeout = clearTimeout;
+
+/** @internal */
+function timeoutAfter(timeMs: number, setTimeoutSafe: typeof setTimeout, clearTimeoutSafe: typeof clearTimeout) {
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const promise = new Promise<PropertyFailure>((resolve) => {
+    timeoutHandle = setTimeoutSafe(() => {
+      resolve({ error: new Error(`Property timeout: exceeded limit of ${timeMs} milliseconds`) });
+    }, timeMs);
+  });
+  return {
+    // `timeoutHandle` will always be initialised at this point: body of `new Promise` has already been executed
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    clear: () => clearTimeoutSafe(timeoutHandle!),
+    promise,
+  };
+}
+
+/** @internal */
+function timeoutRunner(
+  timeMs: number,
+  setTimeoutSafe: typeof setTimeout,
+  clearTimeoutSafe: typeof clearTimeout,
+  nestedRun: IRawProperty<unknown, boolean>['run'],
+  value: unknown,
+): ReturnType<typeof nestedRun> {
+  const t = timeoutAfter(timeMs, setTimeoutSafe, clearTimeoutSafe);
+  const runOut = nestedRun(value);
+  if (runOut === null || !('then' in runOut)) {
+    // synchronous run: it already came to an end, no need to wait for any timeout
+    t.clear();
+    return runOut;
+  }
+  const raced = Promise.race([runOut, t.promise]);
+  raced.then(t.clear, t.clear); // always clear timeout handle - catch should never occur
+  return raced;
+}
+
+/** @internal */
+export function buildTimeoutPlugin(
+  timeMs: number,
+  setTimeoutSafe: typeof setTimeout,
+  clearTimeoutSafe: typeof clearTimeout,
+): Plugin<unknown> {
+  return (): PluginInstance<unknown> => {
+    return {
+      decorateRun: (nestedRun) => (value) => timeoutRunner(timeMs, setTimeoutSafe, clearTimeoutSafe, nestedRun, value),
+    };
+  };
+}
+
+/**
+ * Fail the run of your predicate if it takes more than `timeMs` milliseconds to complete.
+ * As predicates cannot be stopped, the underlying execution keeps running but its outcome gets ignored.
+ *
+ * Only useful for asynchronous properties: a synchronous predicate can never be observed timing out
+ * as it already came to an end when we get its outcome.
+ *
+ * @example
+ * ```ts
+ * fc.assert(
+ *   fc.asyncProperty(..., async (...) => {...}),
+ *   { plugins: [fc.timeoutPlugin(1000)] }
+ * )
+ * ```
+ *
+ * @param timeMs - Maximal number of milliseconds granted to an execution of the predicate
+ *
+ * @remarks Since 4.10.0
+ * @public
+ */
+export function timeout(timeMs: number): Plugin<unknown> {
+  return buildTimeoutPlugin(timeMs, safeSetTimeout, safeClearTimeout);
+}

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -31,10 +31,10 @@ function timeoutRunner(
 /**
  * Mark the execution of a predicate as failed if it exceeds `timeMs` milliseconds to complete.
  *
- * WARNING: It won't really stop a running predicate.
- * It mostly returns earlier for the test runner to move forward.
+ * WARNING: It cannot stop a running predicate.
+ * It mainly returns earlier so the test runner can move forward.
  *
- * NOTE: Does not have any effect on a synchronously running predicate.
+ * NOTE: It has no effect on a synchronously running predicate.
  *
  * @example
  * ```ts

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -2,21 +2,18 @@ import type { IRawProperty, PropertyFailure } from '../property/IRawProperty.js'
 import { Error } from '../../utils/globals.js';
 import type { Plugin, PluginInstance } from './Plugin.js';
 
-const safeSetTimeout = setTimeout;
-const safeClearTimeout = clearTimeout;
-
 /** @internal */
-function timeoutAfter(timeMs: number, setTimeoutSafe: typeof setTimeout, clearTimeoutSafe: typeof clearTimeout) {
+function timeoutAfter(timeMs: number) {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const promise = new Promise<PropertyFailure>((resolve) => {
-    timeoutHandle = setTimeoutSafe(() => {
+    timeoutHandle = setTimeout(() => {
       resolve({ error: new Error(`Property timeout: exceeded limit of ${timeMs} milliseconds`) });
     }, timeMs);
   });
   return {
     // `timeoutHandle` will always be initialised at this point: body of `new Promise` has already been executed
     // oxlint-disable-next-line typescript/no-non-null-assertion
-    clear: () => clearTimeoutSafe(timeoutHandle!),
+    clear: () => clearTimeout(timeoutHandle!),
     promise,
   };
 }
@@ -24,12 +21,10 @@ function timeoutAfter(timeMs: number, setTimeoutSafe: typeof setTimeout, clearTi
 /** @internal */
 function timeoutRunner(
   timeMs: number,
-  setTimeoutSafe: typeof setTimeout,
-  clearTimeoutSafe: typeof clearTimeout,
   nestedRun: IRawProperty<unknown, boolean>['run'],
   value: unknown,
 ): ReturnType<typeof nestedRun> {
-  const t = timeoutAfter(timeMs, setTimeoutSafe, clearTimeoutSafe);
+  const t = timeoutAfter(timeMs);
   const runOut = nestedRun(value);
   if (runOut === null || !('then' in runOut)) {
     // synchronous run: it already came to an end, no need to wait for any timeout
@@ -39,19 +34,6 @@ function timeoutRunner(
   const raced = Promise.race([runOut, t.promise]);
   raced.then(t.clear, t.clear); // always clear timeout handle - catch should never occur
   return raced;
-}
-
-/** @internal */
-export function buildTimeoutPlugin(
-  timeMs: number,
-  setTimeoutSafe: typeof setTimeout,
-  clearTimeoutSafe: typeof clearTimeout,
-): Plugin<unknown> {
-  return (): PluginInstance<unknown> => {
-    return {
-      decorateRun: (nestedRun) => (value) => timeoutRunner(timeMs, setTimeoutSafe, clearTimeoutSafe, nestedRun, value),
-    };
-  };
 }
 
 /**
@@ -75,5 +57,9 @@ export function buildTimeoutPlugin(
  * @public
  */
 export function timeout(timeMs: number): Plugin<unknown> {
-  return buildTimeoutPlugin(timeMs, safeSetTimeout, safeClearTimeout);
+  return (): PluginInstance<unknown> => {
+    return {
+      decorateRun: (nestedRun) => (value) => timeoutRunner(timeMs, nestedRun, value),
+    };
+  };
 }

--- a/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
+++ b/packages/fast-check/src/check/plugin/TimeoutPlugin.ts
@@ -4,16 +4,14 @@ import type { Plugin, PluginInstance } from './Plugin.js';
 
 /** @internal */
 function timeoutAfter(timeMs: number) {
-  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined = undefined;
   const promise = new Promise<PropertyFailure>((resolve) => {
     timeoutHandle = setTimeout(() => {
       resolve({ error: new Error(`Property timeout: exceeded limit of ${timeMs} milliseconds`) });
     }, timeMs);
   });
   return {
-    // `timeoutHandle` will always be initialised at this point: body of `new Promise` has already been executed
-    // oxlint-disable-next-line typescript/no-non-null-assertion
-    clear: () => clearTimeout(timeoutHandle!),
+    clear: () => clearTimeout(timeoutHandle),
     promise,
   };
 }

--- a/packages/fast-check/src/fast-check-default.ts
+++ b/packages/fast-check/src/fast-check-default.ts
@@ -211,6 +211,7 @@ import type { RandomGenerator } from './random/generator/RandomGenerator.js';
 import type { Plugin, PluginInstance } from './check/plugin/Plugin.js';
 import { installGlobalPlugin } from './check/runner/configuration/GlobalPlugins.js';
 import { beforeEach as beforeEachPlugin } from './check/plugin/LifeCyclePlugins.js';
+import { timeout as timeoutPlugin } from './check/plugin/TimeoutPlugin.js';
 
 // Explicit cast into string to avoid to have __type: "process.env.__PACKAGE_TYPE__"
 /**
@@ -456,6 +457,7 @@ export {
   resetConfigureGlobal,
   installGlobalPlugin,
   beforeEachPlugin,
+  timeoutPlugin,
   ExecutionStatus,
   Random,
   Stream,

--- a/packages/fast-check/test/e2e/Plugins.spec.ts
+++ b/packages/fast-check/test/e2e/Plugins.spec.ts
@@ -134,6 +134,20 @@ describe(`Plugins (seed: ${seed})`, () => {
     ]);
   });
 
+  it('should stop long-running predicates with the timeout plugin', async () => {
+    // Arrange / Act
+    const out = await fc.check(
+      fc.asyncProperty(fc.integer(), async (_x) => {
+        return new Promise<boolean>(() => {}); // never ending predicate
+      }),
+      { plugins: [fc.timeoutPlugin(10)], endOnFailure: true },
+    );
+
+    // Assert
+    expect(out.failed).toBe(true);
+    expect((out.errorInstance as Error).message).toContain('Property timeout: exceeded limit of 10 milliseconds');
+  });
+
   it('should support mixes of sync and async afterAll', async () => {
     // Arrange
     const probes: string[] = [];

--- a/packages/fast-check/test/e2e/TimeoutPlugin.spec.ts
+++ b/packages/fast-check/test/e2e/TimeoutPlugin.spec.ts
@@ -1,19 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fc from '../../src/fast-check.js';
 import { seed } from './seed.js';
 
 describe(`TimeoutPlugin (seed: ${seed})`, () => {
-  it('should stop long-running predicates with the timeout plugin', async () => {
-    // Arrange / Act
-    const out = await fc.check(
-      fc.asyncProperty(fc.integer(), async (_x) => {
-        return new Promise<boolean>(() => {}); // never ending predicate
-      }),
-      { plugins: [fc.timeout(10)], endOnFailure: true },
-    );
-
-    // Assert
-    expect(out.failed).toBe(true);
-    expect((out.errorInstance as Error).message).toContain('Property timeout: exceeded limit of 10 milliseconds');
+  beforeEach(() => {
+    vi.clearAllTimers();
   });
+
+  it.each([
+    { ordering: 'timeout, beforeEach, afterEach', timeoutFirst: true },
+    { ordering: 'beforeEach, afterEach, timeout', timeoutFirst: false },
+  ])(
+    'should always run hooks not wrapped by the timeout even in case of timeout (plugins: $ordering)',
+    async ({ timeoutFirst }) => {
+      // Arrange
+      vi.useFakeTimers();
+      let numRuns = 0;
+      const beforeEach = vi.fn();
+      const afterEach = vi.fn();
+      const hooksPlugins = [fc.beforeEach(beforeEach), fc.afterEach(afterEach)];
+      const plugins = timeoutFirst ? [fc.timeout(10), ...hooksPlugins] : [...hooksPlugins, fc.timeout(10)];
+
+      // Act
+      const outPromise = fc.check(
+        fc.asyncProperty(fc.noShrink(fc.integer()), async (_x) => {
+          ++numRuns;
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100); // delay of 100ms (longer than timeout)
+          });
+        }),
+        { plugins },
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      const out = await outPromise;
+
+      // Assert
+      expect(out.failed).toBe(true);
+      expect(out.interrupted).toBe(false);
+      expect(out.numRuns).toBe(1); // only once, it timeouts on first run and then shrink (no-shrink here)
+      expect(out.numShrinks).toBe(0);
+      expect(out.numSkips).toBe(0);
+      expect((out.errorInstance as Error).message).toContain('Property timeout: exceeded limit of 10 milliseconds');
+      expect(numRuns).toBe(1);
+      expect(beforeEach).toHaveBeenCalledTimes(1); // called before the predicate even starts
+      if (timeoutFirst) {
+        expect(afterEach).toHaveBeenCalledTimes(0); // predicate still running and afterEach waits for it to end before being fired
+        await vi.advanceTimersByTimeAsync(100);
+        expect(afterEach).toHaveBeenCalledTimes(1); // triggered once the predicate ends, so after we received the status for the run
+      } else {
+        expect(afterEach).toHaveBeenCalledTimes(1); // predicate still running, but afterEach wraps the timeout-ed section so it gets triggered
+      }
+    },
+  );
 });

--- a/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
+++ b/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildTimeoutPlugin, timeout } from '../../../../src/check/plugin/TimeoutPlugin.js';
+import type { IRawProperty } from '../../../../src/check/property/IRawProperty.js';
+import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure.js';
+
+describe('TimeoutPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('should forward inputs to run', async () => {
+    // Arrange
+    vi.useFakeTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(null);
+    const expectedRunInput = { anything: Symbol('something') };
+
+    // Act
+    const finalRun = timeoutPluginRun(10, nestedRun);
+    const runPromise = finalRun(expectedRunInput);
+    vi.advanceTimersByTime(10);
+    await runPromise;
+
+    // Assert
+    expect(nestedRun).toHaveBeenCalledTimes(1);
+    expect(nestedRun).toHaveBeenCalledWith(expectedRunInput);
+  });
+
+  it('should not timeout if it succeeds in time', async () => {
+    // Arrange
+    vi.useFakeTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
+      new Promise(function (resolve) {
+        setTimeout(() => resolve(null), 10);
+      }),
+    );
+
+    // Act
+    const finalRun = timeoutPluginRun(100, nestedRun);
+    const runPromise = finalRun({});
+    vi.advanceTimersByTime(10);
+    await runPromise;
+
+    // Assert
+    expect(await runPromise).toBe(null);
+  });
+
+  it('should not timeout if it fails in time', async () => {
+    // Arrange
+    const errorFromUnderlying = { error: new Error('plop') };
+    vi.useFakeTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
+      new Promise(function (resolve) {
+        // underlying run is not supposed to throw (reject)
+        setTimeout(() => resolve(errorFromUnderlying), 10);
+      }),
+    );
+
+    // Act
+    const finalRun = timeoutPluginRun(100, nestedRun);
+    const runPromise = finalRun({});
+    vi.advanceTimersByTime(10);
+    await runPromise;
+
+    // Assert
+    expect(await runPromise).toBe(errorFromUnderlying);
+  });
+
+  it('should clear all started timeouts on success', async () => {
+    // Arrange
+    vi.useFakeTimers();
+    vi.spyOn(global, 'setTimeout');
+    vi.spyOn(global, 'clearTimeout');
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(null);
+
+    // Act
+    const finalRun = timeoutPluginRun(100, nestedRun);
+    await finalRun({});
+
+    // Assert
+    expect(setTimeout).toBeCalledTimes(1);
+    expect(clearTimeout).toBeCalledTimes(1);
+  });
+
+  it('should clear all started timeouts on failure', async () => {
+    // Arrange
+    const errorFromUnderlying = { error: new Error('plop') };
+    vi.useFakeTimers();
+    vi.spyOn(global, 'setTimeout');
+    vi.spyOn(global, 'clearTimeout');
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(errorFromUnderlying);
+
+    // Act
+    const finalRun = timeoutPluginRun(100, nestedRun);
+    await finalRun({});
+
+    // Assert
+    expect(setTimeout).toBeCalledTimes(1);
+    expect(clearTimeout).toBeCalledTimes(1);
+  });
+
+  it('should timeout if it takes to long', async () => {
+    // Arrange
+    vi.useFakeTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
+      new Promise(function (resolve) {
+        setTimeout(() => resolve(null), 100);
+      }),
+    );
+
+    // Act
+    const finalRun = timeoutPluginRun(10, nestedRun);
+    const runPromise = finalRun({});
+    vi.advanceTimersByTime(10);
+
+    // Assert
+    expect(await runPromise).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
+  });
+
+  it('should timeout if it never ends', async () => {
+    // Arrange
+    vi.useFakeTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(new Promise(() => {}));
+
+    // Act
+    const finalRun = timeoutPluginRun(10, nestedRun);
+    const runPromise = finalRun({});
+    vi.advanceTimersByTime(10);
+
+    // Assert
+    expect(await runPromise).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
+  });
+
+  it.each([
+    { name: 'success', runOutput: null },
+    { name: 'precondition failure', runOutput: new PreconditionFailure() },
+    { name: 'failure', runOutput: { error: new Error('plop') } },
+  ])('should preserve synchronous runs untouched and clear the started timeout on $name', ({ runOutput }) => {
+    // Arrange
+    vi.useFakeTimers();
+    vi.spyOn(global, 'setTimeout');
+    vi.spyOn(global, 'clearTimeout');
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(runOutput);
+
+    // Act
+    const finalRun = timeoutPluginRun(100, nestedRun);
+    const out = finalRun({});
+
+    // Assert
+    expect(out).toBe(runOutput); // sync run, sync output: nothing to race against the timeout
+    expect(setTimeout).toBeCalledTimes(1);
+    expect(clearTimeout).toBeCalledTimes(1);
+  });
+
+  it('should define one decorateRun per instance without merging with other instances', () => {
+    // Arrange
+    let pluginIndex = 0;
+    const sharedContext = {};
+
+    // Act
+    const instanceA = timeout(10)(pluginIndex++, sharedContext);
+    const instanceB = timeout(10)(pluginIndex++, sharedContext);
+
+    // Assert
+    expect(instanceA.decorateRun).not.toBe(undefined);
+    expect(instanceB.decorateRun).not.toBe(undefined);
+    expect(instanceB.decorateRun).not.toBe(instanceA.decorateRun);
+  });
+
+  it('should timeout with real timers when relying on the public plugin', async () => {
+    // Arrange
+    vi.useRealTimers();
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(new Promise(() => {}));
+    const instance = timeout(10)(0, {});
+
+    // Act
+    const finalRun = instance.decorateRun!(nestedRun);
+
+    // Assert
+    expect(await finalRun({})).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
+  });
+});
+
+// Helpers
+
+function timeoutPluginRun(timeMs: number, nestedRun: IRawProperty<unknown, boolean>['run']) {
+  const plugin = buildTimeoutPlugin(timeMs, setTimeout, clearTimeout);
+  const instance = plugin(0, {});
+  return instance.decorateRun!(nestedRun);
+}

--- a/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
+++ b/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { timeout } from '../../../../src/check/plugin/TimeoutPlugin.js';
 import type { IRawProperty } from '../../../../src/check/property/IRawProperty.js';
-import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure.js';
 
 describe('TimeoutPlugin', () => {
   beforeEach(() => {
@@ -128,42 +127,6 @@ describe('TimeoutPlugin', () => {
 
     // Assert
     expect(await runPromise).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
-  });
-
-  it.each([
-    { name: 'success', runOutput: null },
-    { name: 'precondition failure', runOutput: new PreconditionFailure() },
-    { name: 'failure', runOutput: { error: new Error('plop') } },
-  ])('should preserve synchronous runs untouched and clear the started timeout on $name', ({ runOutput }) => {
-    // Arrange
-    vi.useFakeTimers();
-    vi.spyOn(global, 'setTimeout');
-    vi.spyOn(global, 'clearTimeout');
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(runOutput);
-
-    // Act
-    const finalRun = timeoutPluginRun(100, nestedRun);
-    const out = finalRun({});
-
-    // Assert
-    expect(out).toBe(runOutput); // sync run, sync output: nothing to race against the timeout
-    expect(setTimeout).toBeCalledTimes(1);
-    expect(clearTimeout).toBeCalledTimes(1);
-  });
-
-  it('should define one decorateRun per instance without merging with other instances', () => {
-    // Arrange
-    let pluginIndex = 0;
-    const sharedContext = {};
-
-    // Act
-    const instanceA = timeout(10)(pluginIndex++, sharedContext);
-    const instanceB = timeout(10)(pluginIndex++, sharedContext);
-
-    // Assert
-    expect(instanceA.decorateRun).not.toBe(undefined);
-    expect(instanceB.decorateRun).not.toBe(undefined);
-    expect(instanceB.decorateRun).not.toBe(instanceA.decorateRun);
   });
 });
 

--- a/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
+++ b/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { timeout } from '../../../../src/check/plugin/TimeoutPlugin.js';
+import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure.js';
 import type { IRawProperty } from '../../../../src/check/property/IRawProperty.js';
 
 describe('TimeoutPlugin', () => {
@@ -24,12 +25,16 @@ describe('TimeoutPlugin', () => {
     expect(nestedRun).toHaveBeenCalledWith(expectedRunInput);
   });
 
-  it('should not timeout if it succeeds in time', async () => {
+  it.each([
+    { outcome: 'succeeds', output: null },
+    { outcome: 'fails', output: { error: new Error('plop') } },
+    { outcome: 'skips on precondition', output: new PreconditionFailure() },
+  ])('should not timeout if it $outcome in time', async ({ output }) => {
     // Arrange
     vi.useFakeTimers();
     const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
       new Promise(function (resolve) {
-        setTimeout(() => resolve(null), 10);
+        setTimeout(() => resolve(output), 10);
       }),
     );
 
@@ -40,36 +45,19 @@ describe('TimeoutPlugin', () => {
     await runPromise;
 
     // Assert
-    expect(await runPromise).toBe(null);
+    expect(await runPromise).toBe(output);
   });
 
-  it('should not timeout if it fails in time', async () => {
-    // Arrange
-    const errorFromUnderlying = { error: new Error('plop') };
-    vi.useFakeTimers();
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
-      new Promise(function (resolve) {
-        // underlying run is not supposed to throw (reject)
-        setTimeout(() => resolve(errorFromUnderlying), 10);
-      }),
-    );
-
-    // Act
-    const finalRun = timeoutPluginRun(100, nestedRun);
-    const runPromise = finalRun({});
-    vi.advanceTimersByTime(10);
-    await runPromise;
-
-    // Assert
-    expect(await runPromise).toBe(errorFromUnderlying);
-  });
-
-  it('should clear all started timeouts on success', async () => {
+  it.each([
+    { outcome: 'success', output: null },
+    { outcome: 'failure', output: { error: new Error('plop') } },
+    { outcome: 'precondition failure', output: new PreconditionFailure() },
+  ])('should clear all started timeouts on $outcome', async ({ output }) => {
     // Arrange
     vi.useFakeTimers();
     vi.spyOn(global, 'setTimeout');
     vi.spyOn(global, 'clearTimeout');
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(null);
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(output);
 
     // Act
     const finalRun = timeoutPluginRun(100, nestedRun);
@@ -80,45 +68,19 @@ describe('TimeoutPlugin', () => {
     expect(clearTimeout).toBeCalledTimes(1);
   });
 
-  it('should clear all started timeouts on failure', async () => {
-    // Arrange
-    const errorFromUnderlying = { error: new Error('plop') };
-    vi.useFakeTimers();
-    vi.spyOn(global, 'setTimeout');
-    vi.spyOn(global, 'clearTimeout');
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockResolvedValueOnce(errorFromUnderlying);
-
-    // Act
-    const finalRun = timeoutPluginRun(100, nestedRun);
-    await finalRun({});
-
-    // Assert
-    expect(setTimeout).toBeCalledTimes(1);
-    expect(clearTimeout).toBeCalledTimes(1);
-  });
-
-  it('should timeout if it takes to long', async () => {
+  it.each([
+    {
+      behavior: 'takes too long',
+      buildNestedRunPromise: () => new Promise<null>((resolve) => setTimeout(() => resolve(null), 100)),
+    },
+    {
+      behavior: 'never ends',
+      buildNestedRunPromise: () => new Promise<null>(() => {}),
+    },
+  ])('should timeout if it $behavior', async ({ buildNestedRunPromise }) => {
     // Arrange
     vi.useFakeTimers();
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(
-      new Promise(function (resolve) {
-        setTimeout(() => resolve(null), 100);
-      }),
-    );
-
-    // Act
-    const finalRun = timeoutPluginRun(10, nestedRun);
-    const runPromise = finalRun({});
-    vi.advanceTimersByTime(10);
-
-    // Assert
-    expect(await runPromise).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
-  });
-
-  it('should timeout if it never ends', async () => {
-    // Arrange
-    vi.useFakeTimers();
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(new Promise(() => {}));
+    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(buildNestedRunPromise());
 
     // Act
     const finalRun = timeoutPluginRun(10, nestedRun);

--- a/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
+++ b/packages/fast-check/test/unit/check/plugin/TimeoutPlugin.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildTimeoutPlugin, timeout } from '../../../../src/check/plugin/TimeoutPlugin.js';
+import { timeout } from '../../../../src/check/plugin/TimeoutPlugin.js';
 import type { IRawProperty } from '../../../../src/check/property/IRawProperty.js';
 import { PreconditionFailure } from '../../../../src/check/precondition/PreconditionFailure.js';
 
@@ -165,25 +165,11 @@ describe('TimeoutPlugin', () => {
     expect(instanceB.decorateRun).not.toBe(undefined);
     expect(instanceB.decorateRun).not.toBe(instanceA.decorateRun);
   });
-
-  it('should timeout with real timers when relying on the public plugin', async () => {
-    // Arrange
-    vi.useRealTimers();
-    const nestedRun = vi.fn<IRawProperty<unknown, boolean>['run']>().mockReturnValueOnce(new Promise(() => {}));
-    const instance = timeout(10)(0, {});
-
-    // Act
-    const finalRun = instance.decorateRun!(nestedRun);
-
-    // Assert
-    expect(await finalRun({})).toEqual({ error: new Error(`Property timeout: exceeded limit of 10 milliseconds`) });
-  });
 });
 
 // Helpers
 
 function timeoutPluginRun(timeMs: number, nestedRun: IRawProperty<unknown, boolean>['run']) {
-  const plugin = buildTimeoutPlugin(timeMs, setTimeout, clearTimeout);
-  const instance = plugin(0, {});
+  const instance = timeout(timeMs)(0, {});
   return instance.decorateRun!(nestedRun);
 }

--- a/website/docs/core-blocks/plugins/index.md
+++ b/website/docs/core-blocks/plugins/index.md
@@ -58,13 +58,9 @@ await fc.assert(
 );
 ```
 
-For each execution of the predicate:
+The plugins setup above makes use of two instances of the `timeout` plugin. The first instance of it is responsible to make sure that the time taken by the `beforeEach` cleanup plus the one taken by the predicate will never exceed 10 seconds. The second one, only wraps the predicate and makes sure that it won't take more than 5 seconds.
 
-1. the 10-second `timeout` starts first: it wraps everything declared after it — the database reset, the 5-second `timeout` and the predicate,
-2. the `beforeEach` hook then resets the database,
-3. the 5-second `timeout` starts last, right before the predicate: it only wraps the predicate.
-
-As a consequence, a run fails as soon as a single call to the search endpoint takes more than 5 seconds, or when the database reset and the call together take more than 10 seconds. Order matters: moving `timeout(5_000)` before the `beforeEach` would make the reset count against the 5-second budget too, and the 10-second limit could then never fire.
+This short example clearly highlights why the declaration order of plugins is crucial. Two different orders may result in totally different expectations. Correctly ordering them will make you capable of finely configure your flows to fit your needs.
 
 ## The plugins
 

--- a/website/docs/core-blocks/plugins/index.md
+++ b/website/docs/core-blocks/plugins/index.md
@@ -6,7 +6,7 @@ description: Extend the default execution flow provided by runners to meet your 
 
 # Plugins
 
-Plugins provide a way to extend and refine the runtime and execution behavior of your properties. In the same way building custom arbitraries gives you the flexibility to tweak the generation flows, plugins gives you ways to customize how your properties run.
+Plugins provide a way to extend and refine the runtime and execution behavior of your properties. In the same way building custom arbitraries gives you the flexibility to tweak generation flows, plugins give you ways to customize how your properties run.
 
 Plugins are designed to support things such as:
 
@@ -36,9 +36,9 @@ Installed plugins run before the ones passed to the runner, so the snippet above
 
 ## Combining plugins
 
-Plugins have been designed to be combined together. When multiple plugins get defined for the same assertion, they execute themselves in declaration order. The first plugin runs first and wraps the execution of the second one until we reach the main operation. Plugins can wrap various stages of the flows including the execution of the predicate function.
+Plugins have been designed to be combined together. When multiple plugins get defined for the same assertion, they execute in declaration order. The first plugin runs first and wraps the execution of the second one until we reach the main operation. Plugins can wrap various stages of the flow, including the execution of the predicate function.
 
-Let's illustrate how plugins get combined on a property checking a search endpoint. In this example the database gets bring back to a clean state before each run:
+Let's illustrate how plugins get combined on a property checking a search endpoint. In this example, the database is brought back to a clean state before each run:
 
 ```ts
 await fc.assert(
@@ -58,9 +58,9 @@ await fc.assert(
 );
 ```
 
-The plugins setup above makes use of two instances of the `timeout` plugin. The first instance of it is responsible to make sure that the time taken by the `beforeEach` cleanup plus the one taken by the predicate will never exceed 10 seconds. The second one, only wraps the predicate and makes sure that it won't take more than 5 seconds.
+The plugin setup above makes use of two instances of the `timeout` plugin. The first instance is responsible for making sure that the time taken by the `beforeEach` cleanup plus the one taken by the predicate never exceeds 10 seconds. The second one only wraps the predicate and makes sure that it won't take more than 5 seconds.
 
-This short example clearly highlights why the declaration order of plugins is crucial. Two different orders may result in totally different expectations. Correctly ordering them will make you capable of finely configure your flows to fit your needs.
+This short example clearly highlights why the declaration order of plugins is crucial. Two different orders may result in totally different expectations. Correctly ordering them will make you capable of finely configuring your flows to fit your needs.
 
 ## The plugins
 

--- a/website/docs/core-blocks/plugins/index.md
+++ b/website/docs/core-blocks/plugins/index.md
@@ -36,9 +36,9 @@ Installed plugins run before the ones passed to the runner, so the snippet above
 
 ## Combining plugins
 
-Plugins wrap every execution of the predicate and the declaration order defines the nesting: the first declared plugin is the outermost wrapper, each subsequent one sits a bit closer to the predicate.
+Plugins have been designed to be combined together. When multiple plugins get defined for the same assertion, they execute themselves in declaration order. The first plugin runs first and wraps the execution of the second one until we reach the main operation. Plugins can wrap various stages of the flows including the execution of the predicate function.
 
-Let's illustrate it on a property checking a search endpoint, with the database brought back to a clean state before each run:
+Let's illustrate how plugins get combined on a property checking a search endpoint. In this example the database gets bring back to a clean state before each run:
 
 ```ts
 await fc.assert(

--- a/website/docs/core-blocks/plugins/index.md
+++ b/website/docs/core-blocks/plugins/index.md
@@ -34,6 +34,38 @@ fc.installGlobalPlugin(pluginA());
 
 Installed plugins run before the ones passed to the runner, so the snippet above followed by `fc.assert(myProp, { plugins: [pluginB()] })` is equivalent to `plugins: [pluginA(), pluginB()]`.
 
+## Combining plugins
+
+Plugins wrap every execution of the predicate and the declaration order defines the nesting: the first declared plugin is the outermost wrapper, each subsequent one sits a bit closer to the predicate.
+
+Let's illustrate it on a property checking a search endpoint, with the database brought back to a clean state before each run:
+
+```ts
+await fc.assert(
+  fc.asyncProperty(fc.string(), async (query) => {
+    const results = await searchService.search(query);
+    // ...assertions on the results...
+  }),
+  {
+    plugins: [
+      timeout(10_000),
+      beforeEach(async () => {
+        await database.reset(); // bring back a clean state, possibly slow
+      }),
+      timeout(5_000),
+    ],
+  },
+);
+```
+
+For each execution of the predicate:
+
+1. the 10-second `timeout` starts first: it wraps everything declared after it — the database reset, the 5-second `timeout` and the predicate,
+2. the `beforeEach` hook then resets the database,
+3. the 5-second `timeout` starts last, right before the predicate: it only wraps the predicate.
+
+As a consequence, a run fails as soon as a single call to the search endpoint takes more than 5 seconds, or when the database reset and the call together take more than 10 seconds. Order matters: moving `timeout(5_000)` before the `beforeEach` would make the reset count against the 5-second budget too, and the 10-second limit could then never fire.
+
 ## The plugins
 
 We come up with a set of plugins to extend the library using built-in plugins. The following pages provide extended details and deep dive into each of them.

--- a/website/docs/core-blocks/plugins/timeout.md
+++ b/website/docs/core-blocks/plugins/timeout.md
@@ -1,0 +1,23 @@
+---
+slug: /core-blocks/plugins/timeout/
+---
+
+# Timeout
+
+The timeout plugin stops predicates running for too long.
+
+## `timeout`
+
+The `timeout` plugin marks the current execution of your predicate as failed if it did not complete within the requested delay expressed in milliseconds.
+
+```ts
+{
+  plugins: [
+    timeout(1000), // fail any execution of the predicate taking more than 1 second
+  ];
+}
+```
+
+As predicates cannot be stopped, whenever a timeout occurs the underlying execution keeps running in the background but its outcome gets ignored. Note also that the plugin can only be useful for asynchronous properties: a synchronous predicate can never be observed timing out as it already came to an end when the runner gets its outcome back.
+
+Resources: [API reference](/docs/api/functions/timeoutPlugin).

--- a/website/docs/core-blocks/plugins/timeout.md
+++ b/website/docs/core-blocks/plugins/timeout.md
@@ -23,7 +23,7 @@ As predicates cannot be stopped, whenever a timeout occurs the underlying execut
 :::
 
 :::warning[Synchronous predicates can't be interrupted]
-The plugin has no impact on purely synchronous predicates. It can't stop them so timeout won't really be capable of interrupting them.
+The plugin has no impact on purely synchronous predicates. It cannot stop them, so timeout cannot interrupt them.
 :::
 
 Resources: [API reference](/docs/api/functions/timeout).

--- a/website/docs/core-blocks/plugins/timeout.md
+++ b/website/docs/core-blocks/plugins/timeout.md
@@ -18,6 +18,12 @@ The `timeout` plugin marks the current execution of your predicate as failed if 
 }
 ```
 
-As predicates cannot be stopped, whenever a timeout occurs the underlying execution keeps running in the background but its outcome gets ignored. Note also that the plugin can only be useful for asynchronous properties: a synchronous predicate can never be observed timing out as it already came to an end when the runner gets its outcome back.
+:::warning[Predicates can't be stopped]
+As predicates cannot be stopped, whenever a timeout occurs the underlying execution keeps running in the background but its outcome gets ignored.
+:::
+
+:::warning[Synchronous predicates can't be interrupted]
+The plugin has no impact on purely synchronous predicates. It can't stop them so timeout won't really be capable of interrupting them.
+:::
 
 Resources: [API reference](/docs/api/functions/timeout).


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

<!-- Describe your change and explain what this PR is trying to solve -->

This PR ports the behavior of `TimeoutProperty` to the plugin API as a new `timeout` plugin, exposed publicly as `fc.timeout`. Users can now fail long-running executions of their predicates by declaring the plugin, either per run or globally:

```ts
await fc.assert(
  fc.asyncProperty(fc.integer(), async (x) => {
    /* ... */
  }),
  { plugins: [fc.timeout(1000)] },
);
```

Any execution of the predicate taking more than the requested delay gets marked as failed with the same error as the one produced by the `timeout` parameter: `Property timeout: exceeded limit of N milliseconds`. As predicates cannot be stopped, the underlying execution keeps running in the background but its outcome gets ignored.

Design notes for the reviewer:

- The plugin follows the pattern introduced by the `beforeEach` plugin (including the plain export name, aligned with the `beforeEach`/`afterEach` renaming from #7227), but contrary to it each `timeout(...)` produces its own standalone instance: no merging via the cross-plugin context.
- `TimeoutProperty` was only wired for asynchronous properties by `decorateProperty`, while a plugin cannot know upfront whether the property is asynchronous. To respect the sync-in-sync-out contract of `decorateRun`, the plugin starts its timer, calls the nested run and, when the output is synchronous, clears the pending timer and forwards the output synchronously. The plugin is therefore a safe no-op on synchronous properties, even if only meaningful for asynchronous ones.
- The `timeout` parameter and `TimeoutProperty` are left untouched: rewiring the parameter through the plugin would change semantics (a plugin wraps `runBeforeEach`/`runAfterEach` too, which `TimeoutProperty` explicitly excludes), so it is kept for a potential follow-up.
- Impact flagged as minor via a changeset. The PR stays focused on adding this single plugin (with its tests and documentation).
- Documentation: besides the dedicated page for the plugin, the general plugins page gains a "Combining plugins" section built on a realistic `timeout(10_000)` / `beforeEach(...)` / `timeout(5_000)` example, explaining that declaration order defines the nesting — the outer timeout covering the setup hook and the predicate, the inner one covering the predicate alone.
- Tests: the applicable specs of `TimeoutProperty.spec.ts` were ported against `decorateRun` (success/failure in time, timeout on slow and never-ending runs, timer cleanup on both outcomes), plus new cases covering the synchronous pass-through and the absence of instance merging. An end-to-end check through `fc.check` lives in a dedicated `test/e2e/TimeoutPlugin.spec.ts`, following the dedicated e2e file introduced for life-cycle plugins. They would have failed without this PR since the plugin did not exist.

Note: expect a trivial conflict with #7229/#7230/#7231 on the plugin import/export lines of `fast-check-default.ts` — whichever merges later needs a one-line rebase.

<!-- Add any additional context here -->

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->
