### PR TITLE
⚡️ Lazily build Unicode property tables

### DIFF
--- a/.changeset/lazy-unicode-tables.md
+++ b/.changeset/lazy-unicode-tables.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Lazily build Unicode property tables used by `stringMatching`

--- a/packages/fast-check/src/arbitrary/_internals/helpers/UnicodePropertyData.ts
+++ b/packages/fast-check/src/arbitrary/_internals/helpers/UnicodePropertyData.ts
@@ -4,259 +4,285 @@ const NON_BINARY_ALIASES_TO_PROP_NAMES: Record<string, string> = {
   scx: 'Script_Extensions',
 };
 
-const BINARY_PROP_NAMES_TO_ALIASES: Record<string, string> = {
-  ASCII: 'ASCII',
-  ASCII_Hex_Digit: 'AHex',
-  Alphabetic: 'Alpha',
-  Any: 'Any',
-  Assigned: 'Assigned',
-  Bidi_Control: 'Bidi_C',
-  Bidi_Mirrored: 'Bidi_M',
-  Case_Ignorable: 'CI',
-  Cased: 'Cased',
-  Changes_When_Casefolded: 'CWCF',
-  Changes_When_Casemapped: 'CWCM',
-  Changes_When_Lowercased: 'CWL',
-  Changes_When_NFKC_Casefolded: 'CWKCF',
-  Changes_When_Titlecased: 'CWT',
-  Changes_When_Uppercased: 'CWU',
-  Dash: 'Dash',
-  Default_Ignorable_Code_Point: 'DI',
-  Deprecated: 'Dep',
-  Diacritic: 'Dia',
-  Emoji: 'Emoji',
-  Emoji_Component: 'Emoji_Component',
-  Emoji_Modifier: 'Emoji_Modifier',
-  Emoji_Modifier_Base: 'Emoji_Modifier_Base',
-  Emoji_Presentation: 'Emoji_Presentation',
-  Extended_Pictographic: 'Extended_Pictographic',
-  Extender: 'Ext',
-  Grapheme_Base: 'Gr_Base',
-  Grapheme_Extend: 'Gr_Ext',
-  Hex_Digit: 'Hex',
-  IDS_Binary_Operator: 'IDSB',
-  IDS_Trinary_Operator: 'IDST',
-  ID_Continue: 'IDC',
-  ID_Start: 'IDS',
-  Ideographic: 'Ideo',
-  Join_Control: 'Join_C',
-  Logical_Order_Exception: 'LOE',
-  Lowercase: 'Lower',
-  Math: 'Math',
-  Noncharacter_Code_Point: 'NChar',
-  Pattern_Syntax: 'Pat_Syn',
-  Pattern_White_Space: 'Pat_WS',
-  Quotation_Mark: 'QMark',
-  Radical: 'Radical',
-  Regional_Indicator: 'RI',
-  Sentence_Terminal: 'STerm',
-  Soft_Dotted: 'SD',
-  Terminal_Punctuation: 'Term',
-  Unified_Ideograph: 'UIdeo',
-  Uppercase: 'Upper',
-  Variation_Selector: 'VS',
-  White_Space: 'space',
-  XID_Continue: 'XIDC',
-  XID_Start: 'XIDS',
+type UnicodePropertyDataSet = {
+  BINARY_PROP_NAMES_TO_ALIASES: Record<string, string>;
+  BINARY_ALIASES_TO_PROP_NAMES: Record<string, string>;
+  GENERAL_CATEGORY_VALUE_TO_ALIASES: Record<string, string | string[]>;
+  GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES: Record<string, string>;
+  SCRIPT_VALUE_TO_ALIASES: Record<string, string | string[]>;
+  SCRIPT_VALUE_ALIASES_TO_VALUES: Record<string, string>;
 };
 
-const BINARY_ALIASES_TO_PROP_NAMES: Record<string, string> = inverseMap(BINARY_PROP_NAMES_TO_ALIASES);
+let dataSet: UnicodePropertyDataSet | undefined;
 
-const GENERAL_CATEGORY_VALUE_TO_ALIASES: Record<string, string | string[]> = {
-  Cased_Letter: 'LC',
-  Close_Punctuation: 'Pe',
-  Connector_Punctuation: 'Pc',
-  Control: ['Cc', 'cntrl'],
-  Currency_Symbol: 'Sc',
-  Dash_Punctuation: 'Pd',
-  Decimal_Number: ['Nd', 'digit'],
-  Enclosing_Mark: 'Me',
-  Final_Punctuation: 'Pf',
-  Format: 'Cf',
-  Initial_Punctuation: 'Pi',
-  Letter: 'L',
-  Letter_Number: 'Nl',
-  Line_Separator: 'Zl',
-  Lowercase_Letter: 'Ll',
-  Mark: ['M', 'Combining_Mark'],
-  Math_Symbol: 'Sm',
-  Modifier_Letter: 'Lm',
-  Modifier_Symbol: 'Sk',
-  Nonspacing_Mark: 'Mn',
-  Number: 'N',
-  Open_Punctuation: 'Ps',
-  Other: 'C',
-  Other_Letter: 'Lo',
-  Other_Number: 'No',
-  Other_Punctuation: 'Po',
-  Other_Symbol: 'So',
-  Paragraph_Separator: 'Zp',
-  Private_Use: 'Co',
-  Punctuation: ['P', 'punct'],
-  Separator: 'Z',
-  Space_Separator: 'Zs',
-  Spacing_Mark: 'Mc',
-  Surrogate: 'Cs',
-  Symbol: 'S',
-  Titlecase_Letter: 'Lt',
-  Unassigned: 'Cn',
-  Uppercase_Letter: 'Lu',
-};
+/**
+ * Lazily build the Unicode property tables: they are only needed by arbitraries
+ * dealing with Unicode property escapes and building them eagerly was one of the
+ * main costs paid at import time of the library.
+ */
+function getUnicodePropertyDataSet(): UnicodePropertyDataSet {
+  if (dataSet !== undefined) {
+    return dataSet;
+  }
 
-const GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES: Record<string, string> = inverseMap(GENERAL_CATEGORY_VALUE_TO_ALIASES);
+  const BINARY_PROP_NAMES_TO_ALIASES: Record<string, string> = {
+    ASCII: 'ASCII',
+    ASCII_Hex_Digit: 'AHex',
+    Alphabetic: 'Alpha',
+    Any: 'Any',
+    Assigned: 'Assigned',
+    Bidi_Control: 'Bidi_C',
+    Bidi_Mirrored: 'Bidi_M',
+    Case_Ignorable: 'CI',
+    Cased: 'Cased',
+    Changes_When_Casefolded: 'CWCF',
+    Changes_When_Casemapped: 'CWCM',
+    Changes_When_Lowercased: 'CWL',
+    Changes_When_NFKC_Casefolded: 'CWKCF',
+    Changes_When_Titlecased: 'CWT',
+    Changes_When_Uppercased: 'CWU',
+    Dash: 'Dash',
+    Default_Ignorable_Code_Point: 'DI',
+    Deprecated: 'Dep',
+    Diacritic: 'Dia',
+    Emoji: 'Emoji',
+    Emoji_Component: 'Emoji_Component',
+    Emoji_Modifier: 'Emoji_Modifier',
+    Emoji_Modifier_Base: 'Emoji_Modifier_Base',
+    Emoji_Presentation: 'Emoji_Presentation',
+    Extended_Pictographic: 'Extended_Pictographic',
+    Extender: 'Ext',
+    Grapheme_Base: 'Gr_Base',
+    Grapheme_Extend: 'Gr_Ext',
+    Hex_Digit: 'Hex',
+    IDS_Binary_Operator: 'IDSB',
+    IDS_Trinary_Operator: 'IDST',
+    ID_Continue: 'IDC',
+    ID_Start: 'IDS',
+    Ideographic: 'Ideo',
+    Join_Control: 'Join_C',
+    Logical_Order_Exception: 'LOE',
+    Lowercase: 'Lower',
+    Math: 'Math',
+    Noncharacter_Code_Point: 'NChar',
+    Pattern_Syntax: 'Pat_Syn',
+    Pattern_White_Space: 'Pat_WS',
+    Quotation_Mark: 'QMark',
+    Radical: 'Radical',
+    Regional_Indicator: 'RI',
+    Sentence_Terminal: 'STerm',
+    Soft_Dotted: 'SD',
+    Terminal_Punctuation: 'Term',
+    Unified_Ideograph: 'UIdeo',
+    Uppercase: 'Upper',
+    Variation_Selector: 'VS',
+    White_Space: 'space',
+    XID_Continue: 'XIDC',
+    XID_Start: 'XIDS',
+  };
 
-const SCRIPT_VALUE_TO_ALIASES: Record<string, string | string[]> = {
-  Adlam: 'Adlm',
-  Ahom: 'Ahom',
-  Anatolian_Hieroglyphs: 'Hluw',
-  Arabic: 'Arab',
-  Armenian: 'Armn',
-  Avestan: 'Avst',
-  Balinese: 'Bali',
-  Bamum: 'Bamu',
-  Bassa_Vah: 'Bass',
-  Batak: 'Batk',
-  Bengali: 'Beng',
-  Bhaiksuki: 'Bhks',
-  Bopomofo: 'Bopo',
-  Brahmi: 'Brah',
-  Braille: 'Brai',
-  Buginese: 'Bugi',
-  Buhid: 'Buhd',
-  Canadian_Aboriginal: 'Cans',
-  Carian: 'Cari',
-  Caucasian_Albanian: 'Aghb',
-  Chakma: 'Cakm',
-  Cham: 'Cham',
-  Cherokee: 'Cher',
-  Common: 'Zyyy',
-  Coptic: ['Copt', 'Qaac'],
-  Cuneiform: 'Xsux',
-  Cypriot: 'Cprt',
-  Cyrillic: 'Cyrl',
-  Deseret: 'Dsrt',
-  Devanagari: 'Deva',
-  Dogra: 'Dogr',
-  Duployan: 'Dupl',
-  Egyptian_Hieroglyphs: 'Egyp',
-  Elbasan: 'Elba',
-  Ethiopic: 'Ethi',
-  Georgian: 'Geor',
-  Glagolitic: 'Glag',
-  Gothic: 'Goth',
-  Grantha: 'Gran',
-  Greek: 'Grek',
-  Gujarati: 'Gujr',
-  Gunjala_Gondi: 'Gong',
-  Gurmukhi: 'Guru',
-  Han: 'Hani',
-  Hangul: 'Hang',
-  Hanifi_Rohingya: 'Rohg',
-  Hanunoo: 'Hano',
-  Hatran: 'Hatr',
-  Hebrew: 'Hebr',
-  Hiragana: 'Hira',
-  Imperial_Aramaic: 'Armi',
-  Inherited: ['Zinh', 'Qaai'],
-  Inscriptional_Pahlavi: 'Phli',
-  Inscriptional_Parthian: 'Prti',
-  Javanese: 'Java',
-  Kaithi: 'Kthi',
-  Kannada: 'Knda',
-  Katakana: 'Kana',
-  Kayah_Li: 'Kali',
-  Kharoshthi: 'Khar',
-  Khmer: 'Khmr',
-  Khojki: 'Khoj',
-  Khudawadi: 'Sind',
-  Lao: 'Laoo',
-  Latin: 'Latn',
-  Lepcha: 'Lepc',
-  Limbu: 'Limb',
-  Linear_A: 'Lina',
-  Linear_B: 'Linb',
-  Lisu: 'Lisu',
-  Lycian: 'Lyci',
-  Lydian: 'Lydi',
-  Mahajani: 'Mahj',
-  Makasar: 'Maka',
-  Malayalam: 'Mlym',
-  Mandaic: 'Mand',
-  Manichaean: 'Mani',
-  Marchen: 'Marc',
-  Medefaidrin: 'Medf',
-  Masaram_Gondi: 'Gonm',
-  Meetei_Mayek: 'Mtei',
-  Mende_Kikakui: 'Mend',
-  Meroitic_Cursive: 'Merc',
-  Meroitic_Hieroglyphs: 'Mero',
-  Miao: 'Plrd',
-  Modi: 'Modi',
-  Mongolian: 'Mong',
-  Mro: 'Mroo',
-  Multani: 'Mult',
-  Myanmar: 'Mymr',
-  Nabataean: 'Nbat',
-  New_Tai_Lue: 'Talu',
-  Newa: 'Newa',
-  Nko: 'Nkoo',
-  Nushu: 'Nshu',
-  Ogham: 'Ogam',
-  Ol_Chiki: 'Olck',
-  Old_Hungarian: 'Hung',
-  Old_Italic: 'Ital',
-  Old_North_Arabian: 'Narb',
-  Old_Permic: 'Perm',
-  Old_Persian: 'Xpeo',
-  Old_Sogdian: 'Sogo',
-  Old_South_Arabian: 'Sarb',
-  Old_Turkic: 'Orkh',
-  Oriya: 'Orya',
-  Osage: 'Osge',
-  Osmanya: 'Osma',
-  Pahawh_Hmong: 'Hmng',
-  Palmyrene: 'Palm',
-  Pau_Cin_Hau: 'Pauc',
-  Phags_Pa: 'Phag',
-  Phoenician: 'Phnx',
-  Psalter_Pahlavi: 'Phlp',
-  Rejang: 'Rjng',
-  Runic: 'Runr',
-  Samaritan: 'Samr',
-  Saurashtra: 'Saur',
-  Sharada: 'Shrd',
-  Shavian: 'Shaw',
-  Siddham: 'Sidd',
-  SignWriting: 'Sgnw',
-  Sinhala: 'Sinh',
-  Sogdian: 'Sogd',
-  Sora_Sompeng: 'Sora',
-  Soyombo: 'Soyo',
-  Sundanese: 'Sund',
-  Syloti_Nagri: 'Sylo',
-  Syriac: 'Syrc',
-  Tagalog: 'Tglg',
-  Tagbanwa: 'Tagb',
-  Tai_Le: 'Tale',
-  Tai_Tham: 'Lana',
-  Tai_Viet: 'Tavt',
-  Takri: 'Takr',
-  Tamil: 'Taml',
-  Tangut: 'Tang',
-  Telugu: 'Telu',
-  Thaana: 'Thaa',
-  Thai: 'Thai',
-  Tibetan: 'Tibt',
-  Tifinagh: 'Tfng',
-  Tirhuta: 'Tirh',
-  Ugaritic: 'Ugar',
-  Vai: 'Vaii',
-  Warang_Citi: 'Wara',
-  Yi: 'Yiii',
-  Zanabazar_Square: 'Zanb',
-};
+  const GENERAL_CATEGORY_VALUE_TO_ALIASES: Record<string, string | string[]> = {
+    Cased_Letter: 'LC',
+    Close_Punctuation: 'Pe',
+    Connector_Punctuation: 'Pc',
+    Control: ['Cc', 'cntrl'],
+    Currency_Symbol: 'Sc',
+    Dash_Punctuation: 'Pd',
+    Decimal_Number: ['Nd', 'digit'],
+    Enclosing_Mark: 'Me',
+    Final_Punctuation: 'Pf',
+    Format: 'Cf',
+    Initial_Punctuation: 'Pi',
+    Letter: 'L',
+    Letter_Number: 'Nl',
+    Line_Separator: 'Zl',
+    Lowercase_Letter: 'Ll',
+    Mark: ['M', 'Combining_Mark'],
+    Math_Symbol: 'Sm',
+    Modifier_Letter: 'Lm',
+    Modifier_Symbol: 'Sk',
+    Nonspacing_Mark: 'Mn',
+    Number: 'N',
+    Open_Punctuation: 'Ps',
+    Other: 'C',
+    Other_Letter: 'Lo',
+    Other_Number: 'No',
+    Other_Punctuation: 'Po',
+    Other_Symbol: 'So',
+    Paragraph_Separator: 'Zp',
+    Private_Use: 'Co',
+    Punctuation: ['P', 'punct'],
+    Separator: 'Z',
+    Space_Separator: 'Zs',
+    Spacing_Mark: 'Mc',
+    Surrogate: 'Cs',
+    Symbol: 'S',
+    Titlecase_Letter: 'Lt',
+    Unassigned: 'Cn',
+    Uppercase_Letter: 'Lu',
+  };
 
-const SCRIPT_VALUE_ALIASES_TO_VALUES: Record<string, string> = inverseMap(SCRIPT_VALUE_TO_ALIASES);
+  const SCRIPT_VALUE_TO_ALIASES: Record<string, string | string[]> = {
+    Adlam: 'Adlm',
+    Ahom: 'Ahom',
+    Anatolian_Hieroglyphs: 'Hluw',
+    Arabic: 'Arab',
+    Armenian: 'Armn',
+    Avestan: 'Avst',
+    Balinese: 'Bali',
+    Bamum: 'Bamu',
+    Bassa_Vah: 'Bass',
+    Batak: 'Batk',
+    Bengali: 'Beng',
+    Bhaiksuki: 'Bhks',
+    Bopomofo: 'Bopo',
+    Brahmi: 'Brah',
+    Braille: 'Brai',
+    Buginese: 'Bugi',
+    Buhid: 'Buhd',
+    Canadian_Aboriginal: 'Cans',
+    Carian: 'Cari',
+    Caucasian_Albanian: 'Aghb',
+    Chakma: 'Cakm',
+    Cham: 'Cham',
+    Cherokee: 'Cher',
+    Common: 'Zyyy',
+    Coptic: ['Copt', 'Qaac'],
+    Cuneiform: 'Xsux',
+    Cypriot: 'Cprt',
+    Cyrillic: 'Cyrl',
+    Deseret: 'Dsrt',
+    Devanagari: 'Deva',
+    Dogra: 'Dogr',
+    Duployan: 'Dupl',
+    Egyptian_Hieroglyphs: 'Egyp',
+    Elbasan: 'Elba',
+    Ethiopic: 'Ethi',
+    Georgian: 'Geor',
+    Glagolitic: 'Glag',
+    Gothic: 'Goth',
+    Grantha: 'Gran',
+    Greek: 'Grek',
+    Gujarati: 'Gujr',
+    Gunjala_Gondi: 'Gong',
+    Gurmukhi: 'Guru',
+    Han: 'Hani',
+    Hangul: 'Hang',
+    Hanifi_Rohingya: 'Rohg',
+    Hanunoo: 'Hano',
+    Hatran: 'Hatr',
+    Hebrew: 'Hebr',
+    Hiragana: 'Hira',
+    Imperial_Aramaic: 'Armi',
+    Inherited: ['Zinh', 'Qaai'],
+    Inscriptional_Pahlavi: 'Phli',
+    Inscriptional_Parthian: 'Prti',
+    Javanese: 'Java',
+    Kaithi: 'Kthi',
+    Kannada: 'Knda',
+    Katakana: 'Kana',
+    Kayah_Li: 'Kali',
+    Kharoshthi: 'Khar',
+    Khmer: 'Khmr',
+    Khojki: 'Khoj',
+    Khudawadi: 'Sind',
+    Lao: 'Laoo',
+    Latin: 'Latn',
+    Lepcha: 'Lepc',
+    Limbu: 'Limb',
+    Linear_A: 'Lina',
+    Linear_B: 'Linb',
+    Lisu: 'Lisu',
+    Lycian: 'Lyci',
+    Lydian: 'Lydi',
+    Mahajani: 'Mahj',
+    Makasar: 'Maka',
+    Malayalam: 'Mlym',
+    Mandaic: 'Mand',
+    Manichaean: 'Mani',
+    Marchen: 'Marc',
+    Medefaidrin: 'Medf',
+    Masaram_Gondi: 'Gonm',
+    Meetei_Mayek: 'Mtei',
+    Mende_Kikakui: 'Mend',
+    Meroitic_Cursive: 'Merc',
+    Meroitic_Hieroglyphs: 'Mero',
+    Miao: 'Plrd',
+    Modi: 'Modi',
+    Mongolian: 'Mong',
+    Mro: 'Mroo',
+    Multani: 'Mult',
+    Myanmar: 'Mymr',
+    Nabataean: 'Nbat',
+    New_Tai_Lue: 'Talu',
+    Newa: 'Newa',
+    Nko: 'Nkoo',
+    Nushu: 'Nshu',
+    Ogham: 'Ogam',
+    Ol_Chiki: 'Olck',
+    Old_Hungarian: 'Hung',
+    Old_Italic: 'Ital',
+    Old_North_Arabian: 'Narb',
+    Old_Permic: 'Perm',
+    Old_Persian: 'Xpeo',
+    Old_Sogdian: 'Sogo',
+    Old_South_Arabian: 'Sarb',
+    Old_Turkic: 'Orkh',
+    Oriya: 'Orya',
+    Osage: 'Osge',
+    Osmanya: 'Osma',
+    Pahawh_Hmong: 'Hmng',
+    Palmyrene: 'Palm',
+    Pau_Cin_Hau: 'Pauc',
+    Phags_Pa: 'Phag',
+    Phoenician: 'Phnx',
+    Psalter_Pahlavi: 'Phlp',
+    Rejang: 'Rjng',
+    Runic: 'Runr',
+    Samaritan: 'Samr',
+    Saurashtra: 'Saur',
+    Sharada: 'Shrd',
+    Shavian: 'Shaw',
+    Siddham: 'Sidd',
+    SignWriting: 'Sgnw',
+    Sinhala: 'Sinh',
+    Sogdian: 'Sogd',
+    Sora_Sompeng: 'Sora',
+    Soyombo: 'Soyo',
+    Sundanese: 'Sund',
+    Syloti_Nagri: 'Sylo',
+    Syriac: 'Syrc',
+    Tagalog: 'Tglg',
+    Tagbanwa: 'Tagb',
+    Tai_Le: 'Tale',
+    Tai_Tham: 'Lana',
+    Tai_Viet: 'Tavt',
+    Takri: 'Takr',
+    Tamil: 'Taml',
+    Tangut: 'Tang',
+    Telugu: 'Telu',
+    Thaana: 'Thaa',
+    Thai: 'Thai',
+    Tibetan: 'Tibt',
+    Tifinagh: 'Tfng',
+    Tirhuta: 'Tirh',
+    Ugaritic: 'Ugar',
+    Vai: 'Vaii',
+    Warang_Citi: 'Wara',
+    Yi: 'Yiii',
+    Zanabazar_Square: 'Zanb',
+  };
+
+  dataSet = {
+    BINARY_PROP_NAMES_TO_ALIASES,
+    BINARY_ALIASES_TO_PROP_NAMES: inverseMap(BINARY_PROP_NAMES_TO_ALIASES),
+    GENERAL_CATEGORY_VALUE_TO_ALIASES,
+    GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES: inverseMap(GENERAL_CATEGORY_VALUE_TO_ALIASES),
+    SCRIPT_VALUE_TO_ALIASES,
+    SCRIPT_VALUE_ALIASES_TO_VALUES: inverseMap(SCRIPT_VALUE_TO_ALIASES),
+  };
+  return dataSet;
+}
 
 function inverseMap(data: Record<string, string | string[]>): Record<string, string> {
   const inverse: Record<string, string> = {};
@@ -273,23 +299,23 @@ function inverseMap(data: Record<string, string | string[]>): Record<string, str
   return inverse;
 }
 
-function isGeneralCategoryValue(value: string): boolean {
-  return value in GENERAL_CATEGORY_VALUE_TO_ALIASES || value in GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES;
+function isGeneralCategoryValue(data: UnicodePropertyDataSet, value: string): boolean {
+  return value in data.GENERAL_CATEGORY_VALUE_TO_ALIASES || value in data.GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES;
 }
 
-function isBinaryPropertyName(name: string): boolean {
-  return name in BINARY_PROP_NAMES_TO_ALIASES || name in BINARY_ALIASES_TO_PROP_NAMES;
+function isBinaryPropertyName(data: UnicodePropertyDataSet, name: string): boolean {
+  return name in data.BINARY_PROP_NAMES_TO_ALIASES || name in data.BINARY_ALIASES_TO_PROP_NAMES;
 }
 
-function getCanonicalName(name: string): string {
+function getCanonicalName(data: UnicodePropertyDataSet, name: string): string {
   if (name in NON_BINARY_ALIASES_TO_PROP_NAMES) {
     return NON_BINARY_ALIASES_TO_PROP_NAMES[name];
   }
-  if (name in BINARY_ALIASES_TO_PROP_NAMES) {
-    return BINARY_ALIASES_TO_PROP_NAMES[name];
+  if (name in data.BINARY_ALIASES_TO_PROP_NAMES) {
+    return data.BINARY_ALIASES_TO_PROP_NAMES[name];
   }
   if (
-    name in BINARY_PROP_NAMES_TO_ALIASES ||
+    name in data.BINARY_PROP_NAMES_TO_ALIASES ||
     name === 'General_Category' ||
     name === 'Script' ||
     name === 'Script_Extensions'
@@ -299,20 +325,20 @@ function getCanonicalName(name: string): string {
   throw new Error(`Unknown Unicode property name: ${name}`);
 }
 
-function getCanonicalValue(value: string): string {
-  if (value in GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES) {
-    return GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES[value];
+function getCanonicalValue(data: UnicodePropertyDataSet, value: string): string {
+  if (value in data.GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES) {
+    return data.GENERAL_CATEGORY_VALUE_ALIASES_TO_VALUES[value];
   }
-  if (value in SCRIPT_VALUE_ALIASES_TO_VALUES) {
-    return SCRIPT_VALUE_ALIASES_TO_VALUES[value];
+  if (value in data.SCRIPT_VALUE_ALIASES_TO_VALUES) {
+    return data.SCRIPT_VALUE_ALIASES_TO_VALUES[value];
   }
-  if (value in BINARY_ALIASES_TO_PROP_NAMES) {
-    return BINARY_ALIASES_TO_PROP_NAMES[value];
+  if (value in data.BINARY_ALIASES_TO_PROP_NAMES) {
+    return data.BINARY_ALIASES_TO_PROP_NAMES[value];
   }
   if (
-    value in GENERAL_CATEGORY_VALUE_TO_ALIASES ||
-    value in SCRIPT_VALUE_TO_ALIASES ||
-    value in BINARY_PROP_NAMES_TO_ALIASES
+    value in data.GENERAL_CATEGORY_VALUE_TO_ALIASES ||
+    value in data.SCRIPT_VALUE_TO_ALIASES ||
+    value in data.BINARY_PROP_NAMES_TO_ALIASES
   ) {
     return value;
   }
@@ -338,6 +364,7 @@ export type ResolvedUnicodeProperty = {
  * @param negative - true for \P\{\}, false for \p\{\}
  */
 export function resolveUnicodeProperty(propertySpec: string, negative: boolean): ResolvedUnicodeProperty {
+  const data = getUnicodePropertyDataSet();
   const equalIndex = propertySpec.indexOf('=');
   if (equalIndex !== -1) {
     // Explicit form: \p{Name=Value}
@@ -350,13 +377,13 @@ export function resolveUnicodeProperty(propertySpec: string, negative: boolean):
       negative,
       shorthand: false,
       binary: false,
-      canonicalName: getCanonicalName(name),
-      canonicalValue: getCanonicalValue(value),
+      canonicalName: getCanonicalName(data, name),
+      canonicalValue: getCanonicalValue(data, value),
     };
   }
 
   // Shorthand form: \p{Value}
-  if (isGeneralCategoryValue(propertySpec)) {
+  if (isGeneralCategoryValue(data, propertySpec)) {
     return {
       type: 'UnicodeProperty',
       name: 'General_Category',
@@ -365,12 +392,12 @@ export function resolveUnicodeProperty(propertySpec: string, negative: boolean):
       shorthand: true,
       binary: false,
       canonicalName: 'General_Category',
-      canonicalValue: getCanonicalValue(propertySpec),
+      canonicalValue: getCanonicalValue(data, propertySpec),
     };
   }
 
-  if (isBinaryPropertyName(propertySpec)) {
-    const canonicalName = getCanonicalName(propertySpec);
+  if (isBinaryPropertyName(data, propertySpec)) {
+    const canonicalName = getCanonicalName(data, propertySpec);
     return {
       type: 'UnicodeProperty',
       name: propertySpec,


### PR DESCRIPTION
## Description

> AI-agent disclosure: this PR was authored by an automated agent (Claude Code) and has not been line-by-line reviewed by a human before submission.

Make `import`-ing fast-check faster: the Unicode property alias tables and their three `inverseMap(...)` inversions are now built lazily on first use of `resolveUnicodeProperty` (i.e. first `stringMatching` with a `\p{...}` escape) and memoized, instead of eagerly at import time. No API or behavior change.

Time to import fast-check (median over 120 fresh Node processes per variant, interleaved):

| | import time |
| --- | --- |
| without the optim | 17.98 ms |
| with the optim | **17.23 ms** (−750 µs ± 128 µs SE) |

Impact: patch (changeset included). No new tests: pure internal refactoring, covered by the existing suites.

<details>
<summary>Measurement methodology and design details</summary>

**Why this module:** instrumenting every module boundary of the built bundle with `process.hrtime` marks (medians over 31 fresh Node processes) ranked `UnicodePropertyData.ts` as the single worst import-time offender: ~360 µs of top-level evaluation, close to 40% of all time spent evaluating fast-check's own modules on import. The rest of an import is dominated by parsing the bundle and loading `pure-rand`.

**How the gain was measured:** interleaved A/B benchmark of the built ESM bundle, one fresh Node process per run, 120 runs per variant, comparing medians; the reported ± is the standard error of the median difference (delta is >2 SE, hence significant). The measured gain exceeds the ~360 µs evaluation cost because moving the large literals into a function body also defers their eager top-level compilation — V8 only pre-parses the function until it is first called.

**Design:** all tables move into a single memoized `getUnicodePropertyDataSet()` builder and the lookup helpers now receive the data set explicitly. The tiny 3-entry `NON_BINARY_ALIASES_TO_PROP_NAMES` map stays eager as it costs nothing. One lazy getter per table was considered and rejected as noisier for no extra benefit. Users who never touch Unicode property escapes never pay for these tables; users who do pay the same cost as before, once, at first use.

**Validation:** `tsc --noEmit`, prettier, oxlint (same pre-existing warnings as baseline), `TokenizeRegex.spec.ts` + `UnicodePropertyArbitraryHelper.spec.ts` + `stringMatching.spec.ts` (181 tests) all passing, `test-bundle` passing, and sampled outputs of `stringMatching(/\p{Letter}\p{Nd}\p{Script=Greek}/u)` on the built bundle verified unchanged.

</details>

## Checklist

— _Don't delete this checklist and make sure you do the following before opening the PR_

- [ ] I have a full understanding of every line in this PR — whether the code was hand-written, AI-generated, copied from external sources or produced by any other tool
- [ ] I flagged the impact of my change (minor / patch / major) either by running `pnpm run bump` or by following the instructions from the changeset bot
- [ ] I kept this PR focused on a single concern and did not bundle unrelated changes
- [ ] I followed the [gitmoji](https://gitmoji.dev/) specification for the name of the PR, including the package scope (e.g. `🐛(vitest) Something...`) when the change targets a package other than `fast-check`
- [ ] I added relevant tests and they would have failed without my PR (when applicable)

<!-- PRs not checking all the boxes may take longer before being reviewed -->
<!-- More about contributing at https://github.com/dubzzz/fast-check/blob/main/CONTRIBUTING.md -->