### PR TITLE
⚡️ Faster `onAllRunsComplete` and `afterAll` when hooks run synchronously

### DIFF
--- a/.changeset/afterall-sync-flow-fast.md
+++ b/.changeset/afterall-sync-flow-fast.md
@@ -1,0 +1,5 @@
+---
+'fast-check': patch
+---
+
+⚡️ Faster `onAllRunsComplete` and `afterAll` when hooks run synchronously

--- a/packages/fast-check/perf/completion-hooks.bench.mjs
+++ b/packages/fast-check/perf/completion-hooks.bench.mjs
@@ -1,0 +1,74 @@
+// Micro-benchmark for the plugin completion hooks (`onAllRunsComplete` and `afterAll`).
+//
+// Each benched operation is one `fc.check` call on an asynchronous property: completion
+// hooks run once per check, so the benchmark stresses many small checks rather than one
+// large one.
+//
+// Usage: node perf/completion-hooks.bench.mjs [path-to-fast-check-entry]
+//   path-to-fast-check-entry — defaults to ../lib/fast-check.js (the built library).
+//   NUM_RUNS       — numRuns forwarded to every check (default: 1)
+//   CALLS_PER_SAMPLE, SAMPLES, WARMUP_SAMPLES — sampling knobs
+//   SCENARIO       — only run scenarios whose name contains this substring
+//   FORMAT=json    — one JSON line per scenario instead of the human-readable table
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const libPath = process.argv[2] ?? new URL('../lib/fast-check.js', import.meta.url).pathname;
+const fc = await import(pathToFileURL(libPath).href);
+
+const numRuns = Number(process.env.NUM_RUNS ?? '1');
+const callsPerSample = Number(process.env.CALLS_PER_SAMPLE ?? '200');
+const samples = Number(process.env.SAMPLES ?? '15');
+const warmupSamples = Number(process.env.WARMUP_SAMPLES ?? '5');
+const format = process.env.FORMAT ?? 'human';
+
+const syncHooksPlugin = () => ({ onAllRunsComplete: () => undefined, afterAll: () => undefined });
+const asyncHooksPlugin = () => ({ onAllRunsComplete: async () => undefined, afterAll: async () => undefined });
+const scenarios = [
+  { name: 'no plugin', plugins: [] },
+  { name: '2 plugins, sync hooks', plugins: [syncHooksPlugin, syncHooksPlugin] },
+  { name: '10 plugins, sync hooks', plugins: Array.from({ length: 10 }, () => syncHooksPlugin) },
+  {
+    name: '5 plugins, 1 async + 4 sync',
+    plugins: [asyncHooksPlugin, ...Array.from({ length: 4 }, () => syncHooksPlugin)],
+  },
+  { name: '5 plugins, async hooks', plugins: Array.from({ length: 5 }, () => asyncHooksPlugin) },
+];
+
+async function benchScenario(scenario) {
+  const property = fc.asyncProperty(fc.integer(), async (_x) => true);
+  const parameters = { numRuns, seed: 42, plugins: scenario.plugins };
+  const opsPerSec = [];
+  for (let sampleIndex = 0; sampleIndex !== warmupSamples + samples; ++sampleIndex) {
+    const startMs = performance.now();
+    for (let call = 0; call !== callsPerSample; ++call) {
+      const details = await fc.check(property, parameters);
+      if (details.failed) {
+        throw new Error('Benchmark property unexpectedly failed');
+      }
+    }
+    const elapsedMs = performance.now() - startMs;
+    if (sampleIndex >= warmupSamples) {
+      opsPerSec.push((callsPerSample * 1000) / elapsedMs);
+    }
+  }
+  opsPerSec.sort((a, b) => a - b);
+  const median = opsPerSec[opsPerSec.length >> 1];
+  const mean = opsPerSec.reduce((acc, value) => acc + value, 0) / opsPerSec.length;
+  const stddev = Math.sqrt(opsPerSec.reduce((acc, value) => acc + (value - mean) ** 2, 0) / opsPerSec.length);
+  return { scenario: scenario.name, numRuns, median, mean, rsdPercent: (100 * stddev) / mean };
+}
+
+const scenarioFilter = process.env.SCENARIO ?? '';
+for (const scenario of scenarios.filter((s) => s.name.includes(scenarioFilter))) {
+  const result = await benchScenario(scenario);
+  if (format === 'json') {
+    console.log(JSON.stringify(result));
+  } else {
+    const median = result.median.toFixed(0).padStart(8);
+    console.log(
+      `${result.scenario.padEnd(30)} ${median} checks/s (±${result.rsdPercent.toFixed(1)}%, numRuns=${result.numRuns})`,
+    );
+  }
+}

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -133,32 +133,29 @@ function runPluginCompletionHooks<Ts>(
         interceptedError = error;
       }
     };
-    // As long as every hook returns synchronously we stay synchronous, we only chain
-    // promises from the first hook returning one.
-    let continuation: Promise<void> | undefined = undefined;
-    for (const followUp of followUps) {
-      if (continuation === undefined) {
+    // Stays synchronous as long as every hook returns synchronously: promises only get
+    // involved when a hook returns one, and once it settles the loop resumes synchronously
+    // over the next hooks from within the settlement callback.
+    const runFollowUpsFrom = (startIndex: number): Promise<void> | undefined => {
+      for (let index = startIndex; index !== followUps.length; ++index) {
         try {
-          const out = followUp(details);
+          const out = followUps[index](details);
           if (out !== undefined) {
-            continuation = out.then(undefined, interceptError);
+            return out.then(
+              () => runFollowUpsFrom(index + 1),
+              (error) => {
+                interceptError(error);
+                return runFollowUpsFrom(index + 1);
+              },
+            );
           }
         } catch (error) {
           interceptError(error);
         }
-      } else {
-        continuation = continuation.then(() => {
-          try {
-            const out = followUp(details);
-            if (out !== undefined) {
-              return out.then(undefined, interceptError);
-            }
-          } catch (error) {
-            interceptError(error);
-          }
-        });
       }
-    }
+      return undefined;
+    };
+    const continuation = runFollowUpsFrom(0);
     if (continuation === undefined) {
       if (interceptedOnce) {
         throw interceptedError;

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -133,21 +133,14 @@ function runPluginCompletionHooks<Ts>(
         interceptedError = error;
       }
     };
-    // Stays synchronous as long as every hook returns synchronously: promises only get
-    // involved when a hook returns one, and once it settles the loop resumes synchronously
-    // over the next hooks from within the settlement callback.
-    const runFollowUpsFrom = (startIndex: number): Promise<void> | undefined => {
+    // Runs every hook from startIndex until one of them returns a promise: hooks running
+    // synchronously never delay their successors to another microtask tick.
+    const runFollowUpsFrom = (startIndex: number): { index: number; out: Promise<void> } | undefined => {
       for (let index = startIndex; index !== followUps.length; ++index) {
         try {
           const out = followUps[index](details);
           if (out !== undefined) {
-            return out.then(
-              () => runFollowUpsFrom(index + 1),
-              (error) => {
-                interceptError(error);
-                return runFollowUpsFrom(index + 1);
-              },
-            );
+            return { index, out };
           }
         } catch (error) {
           interceptError(error);
@@ -155,18 +148,34 @@ function runPluginCompletionHooks<Ts>(
       }
       return undefined;
     };
-    const continuation = runFollowUpsFrom(0);
-    if (continuation === undefined) {
+    const firstAsync = runFollowUpsFrom(0);
+    if (firstAsync === undefined) {
+      // Fully synchronous flow: no promise ever got involved
       if (interceptedOnce) {
         throw interceptedError;
       }
       return details;
     }
-    return continuation.then(() => {
-      if (interceptedOnce) {
-        throw interceptedError;
-      }
-      return details;
+    // A hook returned a promise: from now on the traversal is driven by settlement
+    // callbacks resolving one single deferred promise, no nested promises involved.
+    return new Promise<RunDetails<Ts>>((resolve, reject) => {
+      const resumeAfter = (pending: { index: number; out: Promise<void> }): void => {
+        const resume = () => {
+          const nextAsync = runFollowUpsFrom(pending.index + 1);
+          if (nextAsync !== undefined) {
+            resumeAfter(nextAsync);
+          } else if (interceptedOnce) {
+            reject(interceptedError);
+          } else {
+            resolve(details);
+          }
+        };
+        pending.out.then(resume, (error) => {
+          interceptError(error);
+          resume();
+        });
+      };
+      resumeAfter(firstAsync);
     });
   });
 }

--- a/packages/fast-check/src/check/runner/Runner.ts
+++ b/packages/fast-check/src/check/runner/Runner.ts
@@ -124,26 +124,53 @@ function runPluginCompletionHooks<Ts>(
   if (followUps.length === 0) {
     return runDetailsPromise;
   }
-  return runDetailsPromise.then(async (details) => {
+  return runDetailsPromise.then((details) => {
     let interceptedOnce = false;
     let interceptedError: unknown = undefined;
+    const interceptError = (error: unknown): void => {
+      if (!interceptedOnce) {
+        interceptedOnce = true;
+        interceptedError = error;
+      }
+    };
+    // As long as every hook returns synchronously we stay synchronous, we only chain
+    // promises from the first hook returning one.
+    let continuation: Promise<void> | undefined = undefined;
     for (const followUp of followUps) {
-      try {
-        const out = followUp(details);
-        if (out !== undefined) {
-          await out;
+      if (continuation === undefined) {
+        try {
+          const out = followUp(details);
+          if (out !== undefined) {
+            continuation = out.then(undefined, interceptError);
+          }
+        } catch (error) {
+          interceptError(error);
         }
-      } catch (error) {
-        if (!interceptedOnce) {
-          interceptedOnce = true;
-          interceptedError = error;
-        }
+      } else {
+        continuation = continuation.then(() => {
+          try {
+            const out = followUp(details);
+            if (out !== undefined) {
+              return out.then(undefined, interceptError);
+            }
+          } catch (error) {
+            interceptError(error);
+          }
+        });
       }
     }
-    if (interceptedOnce) {
-      throw interceptedError;
+    if (continuation === undefined) {
+      if (interceptedOnce) {
+        throw interceptedError;
+      }
+      return details;
     }
-    return details;
+    return continuation.then(() => {
+      if (interceptedOnce) {
+        throw interceptedError;
+      }
+      return details;
+    });
   });
 }
 

--- a/packages/fast-check/test/e2e/Plugins.spec.ts
+++ b/packages/fast-check/test/e2e/Plugins.spec.ts
@@ -236,6 +236,43 @@ describe(`Plugins (seed: ${seed})`, () => {
     ]);
   });
 
+  it('should not accumulate extra ticks per asynchronous hook in a chain of asynchronous hooks', async () => {
+    // Arrange
+    const probes: string[] = [];
+    const asyncPlugin = (): fc.Plugin<[number]> => () => ({
+      onAllRunsComplete: async () => undefined,
+      afterAll: async () => undefined,
+    });
+    const lastPlugin: fc.Plugin<[number]> = () => ({
+      onAllRunsComplete: async () => undefined,
+      afterAll: () => {
+        // afterAll of the first plugin runs last: when its promise settles, count how many
+        // microtask ticks elapse before check resolves
+        const out = Promise.resolve();
+        void out.then(() => {
+          let chain = Promise.resolve();
+          for (let tick = 1; tick <= 8; ++tick) {
+            chain = chain.then(() => void probes.push(`tick${tick}`));
+          }
+        });
+        return out;
+      },
+    });
+
+    // Act
+    await fc.check(
+      fc.asyncProperty(fc.integer(), async (_x) => true),
+      { plugins: [lastPlugin, asyncPlugin(), asyncPlugin()] },
+    );
+    probes.push('check resolved');
+    await new Promise((resolve) => setTimeout(resolve)); // flush pending ticks
+
+    // Assert
+    // The tick count separating the last hook from the resolution of check must not depend
+    // on how many asynchronous hooks ran before it
+    expect(probes).toEqual(['tick1', 'tick2', 'check resolved', 'tick3', 'tick4', 'tick5', 'tick6', 'tick7', 'tick8']);
+  });
+
   it('should forward errors thrown within afterAll to the user even in case of predicate failure', () => {
     // Arrange
     const reporterPlugin: fc.Plugin<[number]> = () => ({

--- a/packages/fast-check/test/e2e/Plugins.spec.ts
+++ b/packages/fast-check/test/e2e/Plugins.spec.ts
@@ -88,10 +88,10 @@ describe(`Plugins (seed: ${seed})`, () => {
     ]);
   });
 
-  it('should support purely synchronous onAllRunsComplete and afterAll on asynchronous properties', async () => {
+  it('should not delay the resolution of check when every onAllRunsComplete and afterAll is synchronous', async () => {
     // Arrange
     const probes: string[] = [];
-    const buildPlugin = (pluginName: string): fc.Plugin<[number]> => {
+    const buildPlugin = (pluginName: string, onLast?: () => void): fc.Plugin<[number]> => {
       return () => {
         return {
           onAllRunsComplete: () => {
@@ -99,25 +99,49 @@ describe(`Plugins (seed: ${seed})`, () => {
           },
           afterAll: () => {
             probes.push(`${pluginName}::afterAll`);
+            if (onLast !== undefined) {
+              onLast();
+            }
           },
         };
       };
     };
+    const queueTicksProbes = () => {
+      // a::afterAll runs last: from there, count how many microtask ticks elapse before check resolves
+      Promise.resolve()
+        .then(() => probes.push('tick1'))
+        .then(() => probes.push('tick2'))
+        .then(() => probes.push('tick3'))
+        .then(() => probes.push('tick4'));
+    };
 
     // Act
-    await fc.assert(
+    await fc.check(
       fc.asyncProperty(fc.integer(), async (_x) => true),
-      { plugins: [buildPlugin('a'), buildPlugin('b')] },
+      { plugins: [buildPlugin('a', queueTicksProbes), buildPlugin('b')] },
     );
+    probes.push('check resolved');
+    await new Promise((resolve) => setTimeout(resolve)); // flush pending ticks
 
     // Assert
-    expect(probes).toEqual(['a::onAllRunsComplete', 'b::onAllRunsComplete', 'b::afterAll', 'a::afterAll']);
+    // Fully synchronous hooks must not requeue anything: check resolves on the very next tick
+    expect(probes).toEqual([
+      'a::onAllRunsComplete',
+      'b::onAllRunsComplete',
+      'b::afterAll',
+      'a::afterAll',
+      'tick1',
+      'check resolved',
+      'tick2',
+      'tick3',
+      'tick4',
+    ]);
   });
 
-  it('should run every synchronous onAllRunsComplete and afterAll even when many throw and only forward the first error', async () => {
+  it('should not delay the rejection of check when synchronous hooks throw and only forward the first error', async () => {
     // Arrange
     const probes: string[] = [];
-    const buildPlugin = (pluginName: string): fc.Plugin<[number]> => {
+    const buildPlugin = (pluginName: string, onLast?: () => void): fc.Plugin<[number]> => {
       return () => {
         return {
           onAllRunsComplete: () => {
@@ -126,19 +150,39 @@ describe(`Plugins (seed: ${seed})`, () => {
           },
           afterAll: () => {
             probes.push(`${pluginName}::afterAll`);
+            if (onLast !== undefined) {
+              onLast();
+            }
             throw new Error(`error from ${pluginName}::afterAll`);
           },
         };
       };
     };
+    const queueTicksProbes = () => {
+      // a::afterAll runs last: from there, count how many microtask ticks elapse before check rejects
+      Promise.resolve()
+        .then(() => probes.push('tick1'))
+        .then(() => probes.push('tick2'))
+        .then(() => probes.push('tick3'))
+        .then(() => probes.push('tick4'));
+    };
 
-    // Act / Assert
-    await expect(
-      fc.assert(
+    // Act
+    let intercepted: unknown = undefined;
+    try {
+      await fc.check(
         fc.asyncProperty(fc.integer(), async (_x) => true),
-        { plugins: [buildPlugin('a'), buildPlugin('b'), buildPlugin('c')] },
-      ),
-    ).rejects.toThrow(/^error from a::onAllRunsComplete$/);
+        { plugins: [buildPlugin('a', queueTicksProbes), buildPlugin('b'), buildPlugin('c')] },
+      );
+    } catch (error) {
+      intercepted = error;
+      probes.push('check rejected');
+    }
+    await new Promise((resolve) => setTimeout(resolve)); // flush pending ticks
+
+    // Assert
+    expect(intercepted).toEqual(new Error('error from a::onAllRunsComplete'));
+    // Fully synchronous hooks must not requeue anything: check rejects on the very next tick
     expect(probes).toEqual([
       'a::onAllRunsComplete',
       'b::onAllRunsComplete',
@@ -146,6 +190,49 @@ describe(`Plugins (seed: ${seed})`, () => {
       'c::afterAll',
       'b::afterAll',
       'a::afterAll',
+      'tick1',
+      'check rejected',
+      'tick2',
+      'tick3',
+      'tick4',
+    ]);
+  });
+
+  it('should chain synchronous hooks within the same tick when following an asynchronous one', async () => {
+    // Arrange
+    const probes: string[] = [];
+    const asyncPlugin: fc.Plugin<[number]> = () => ({
+      onAllRunsComplete: async () => {
+        probes.push('a::onAllRunsComplete');
+      },
+    });
+    const buildSyncPlugin = (pluginName: string): fc.Plugin<[number]> => {
+      return () => {
+        return {
+          onAllRunsComplete: () => {
+            probes.push(`${pluginName}::onAllRunsComplete`);
+            if (pluginName === 'b') {
+              // Anything requeued between b and c would run before this one
+              void Promise.resolve().then(() => probes.push('tick queued by b'));
+            }
+          },
+        };
+      };
+    };
+
+    // Act
+    await fc.check(
+      fc.asyncProperty(fc.integer(), async (_x) => true),
+      { plugins: [asyncPlugin, buildSyncPlugin('b'), buildSyncPlugin('c')] },
+    );
+
+    // Assert
+    // Once the asynchronous hook resolved, b and c run back-to-back within the same tick
+    expect(probes).toEqual([
+      'a::onAllRunsComplete',
+      'b::onAllRunsComplete',
+      'c::onAllRunsComplete',
+      'tick queued by b',
     ]);
   });
 

--- a/packages/fast-check/test/e2e/Plugins.spec.ts
+++ b/packages/fast-check/test/e2e/Plugins.spec.ts
@@ -88,6 +88,67 @@ describe(`Plugins (seed: ${seed})`, () => {
     ]);
   });
 
+  it('should support purely synchronous onAllRunsComplete and afterAll on asynchronous properties', async () => {
+    // Arrange
+    const probes: string[] = [];
+    const buildPlugin = (pluginName: string): fc.Plugin<[number]> => {
+      return () => {
+        return {
+          onAllRunsComplete: () => {
+            probes.push(`${pluginName}::onAllRunsComplete`);
+          },
+          afterAll: () => {
+            probes.push(`${pluginName}::afterAll`);
+          },
+        };
+      };
+    };
+
+    // Act
+    await fc.assert(
+      fc.asyncProperty(fc.integer(), async (_x) => true),
+      { plugins: [buildPlugin('a'), buildPlugin('b')] },
+    );
+
+    // Assert
+    expect(probes).toEqual(['a::onAllRunsComplete', 'b::onAllRunsComplete', 'b::afterAll', 'a::afterAll']);
+  });
+
+  it('should run every synchronous onAllRunsComplete and afterAll even when many throw and only forward the first error', async () => {
+    // Arrange
+    const probes: string[] = [];
+    const buildPlugin = (pluginName: string): fc.Plugin<[number]> => {
+      return () => {
+        return {
+          onAllRunsComplete: () => {
+            probes.push(`${pluginName}::onAllRunsComplete`);
+            throw new Error(`error from ${pluginName}::onAllRunsComplete`);
+          },
+          afterAll: () => {
+            probes.push(`${pluginName}::afterAll`);
+            throw new Error(`error from ${pluginName}::afterAll`);
+          },
+        };
+      };
+    };
+
+    // Act / Assert
+    await expect(
+      fc.assert(
+        fc.asyncProperty(fc.integer(), async (_x) => true),
+        { plugins: [buildPlugin('a'), buildPlugin('b'), buildPlugin('c')] },
+      ),
+    ).rejects.toThrow(/^error from a::onAllRunsComplete$/);
+    expect(probes).toEqual([
+      'a::onAllRunsComplete',
+      'b::onAllRunsComplete',
+      'c::onAllRunsComplete',
+      'c::afterAll',
+      'b::afterAll',
+      'a::afterAll',
+    ]);
+  });
+
   it('should forward errors thrown within afterAll to the user even in case of predicate failure', () => {
     // Arrange
     const reporterPlugin: fc.Plugin<[number]> = () => ({


### PR DESCRIPTION
For asynchronous properties, the plugin completion hooks were always
executed through an async/await chain, paying one microtask tick per hook
even when every hook returns synchronously. The runner now stays on the
synchronous flow and only starts chaining promises from the first hook
actually returning one, preserving the sequential ordering, the
guarantee that every hook runs and the first-error-wins reporting.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DzTu3gxA5nJrPvuTbuutw6