### PR TITLE
⚡️ Avoid unneeded Promise overhead in life-cycle plugins

### DIFF
--- a/.changeset/light-hooks-hurry.md
+++ b/.changeset/light-hooks-hurry.md
@@ -1,0 +1,5 @@
+---
+"fast-check": patch
+---
+
+⚡️ Avoid unneeded `Promise` overhead in life-cycle plugins

--- a/packages/fast-check/src/check/plugin/LifeCyclePlugins.ts
+++ b/packages/fast-check/src/check/plugin/LifeCyclePlugins.ts
@@ -1,4 +1,5 @@
-import type { IRawProperty } from '../property/IRawProperty.js';
+import type { IRawProperty, PropertyFailure } from '../property/IRawProperty.js';
+import type { PreconditionFailure } from '../precondition/PreconditionFailure.js';
 import type { Plugin, PluginInstance } from './Plugin.js';
 
 const LifeCyclePluginSymbol = Symbol.for('fast-check/plugin/life-cycle');
@@ -36,144 +37,106 @@ function computeResultingAfterHooks(
   return afterAndPluginIndices.map((details) => details.fn);
 }
 
+type PredicateOutput = PreconditionFailure | PropertyFailure | null; // null means success
+
+/**
+ * Run all the before hooks starting at startIndex, in declaration order.
+ * Stays fully synchronous while hooks are synchronous: a Promise is only allocated when one of the
+ * hooks returns one, in which case the remaining hooks get executed by re-entering this very same
+ * loop from within the resolution of the Promise.
+ * Returns null when everything ran synchronously. A before hook throwing synchronously propagates
+ * to the caller (or rejects the returned Promise when already in an asynchronous flow).
+ */
+function runBeforeHooks(
+  hooks: LifeCycleHooks,
+  teardownFunctions: { index: number; fn: TeardownFunction }[],
+  startIndex: number,
+): Promise<null> | null {
+  const beforeHooks = hooks.beforeHooks;
+  for (let index = startIndex; index !== beforeHooks.length; ++index) {
+    const out = beforeHooks[index]();
+    if (typeof out === 'function') {
+      teardownFunctions.push({ index, fn: out });
+    } else if (typeof out === 'object') {
+      const asyncIndex = index;
+      return out.then((beforeOut) => {
+        if (beforeOut !== undefined) {
+          teardownFunctions.push({ index: asyncIndex, fn: beforeOut });
+        }
+        return runBeforeHooks(hooks, teardownFunctions, asyncIndex + 1);
+      });
+    }
+  }
+  return null;
+}
+
+/**
+ * Run all the after hooks and teardowns from startIndex down to 0 (they run in reverse order).
+ * Stays fully synchronous while hooks are synchronous: a Promise is only allocated when one of the
+ * hooks returns one, in which case the remaining hooks get executed by re-entering this very same
+ * loop from within the settlement of the Promise.
+ * All the hooks always run: a failing one never stops the others. The first failure encountered
+ * only becomes the output when previous was a success.
+ */
+function runAfterHooks(
+  resultingAfterHooks: (TeardownFunction | AfterEachHook)[],
+  startIndex: number,
+  previous: PredicateOutput,
+): Promise<PredicateOutput> | PredicateOutput {
+  for (let index = startIndex; index >= 0; --index) {
+    let out: Promise<void> | void = undefined;
+    try {
+      out = resultingAfterHooks[index]();
+    } catch (error) {
+      // TODO Switch to ?? when the node range defined by fast-check accepts it
+      previous = previous || { error };
+    }
+    if (typeof out === 'object') {
+      const asyncIndex = index;
+      const previousSoFar = previous;
+      return out.then(
+        () => runAfterHooks(resultingAfterHooks, asyncIndex - 1, previousSoFar),
+        // TODO Switch to ?? when the node range defined by fast-check accepts it
+        (error) => runAfterHooks(resultingAfterHooks, asyncIndex - 1, previousSoFar || { error }),
+      );
+    }
+  }
+  return previous;
+}
+
 function lifeCycleHooksRunner(
   hooks: LifeCycleHooks,
   nestedRun: IRawProperty<unknown, boolean>['run'],
   value: unknown,
 ): ReturnType<typeof nestedRun> {
-  let wrappedRunOutput: Awaited<ReturnType<typeof nestedRun>> = null; // null means success
-  let wrappedRunContinuation: Promise<Awaited<ReturnType<typeof nestedRun>>> | undefined = undefined;
-
-  // Before hooks
   const teardownFunctions: { index: number; fn: TeardownFunction }[] = [];
-  if (hooks.beforeHooks.length !== 0) {
-    try {
-      for (let index = 0; index !== hooks.beforeHooks.length; ++index) {
-        const before = hooks.beforeHooks[index];
-        if (wrappedRunContinuation === undefined) {
-          const out = before();
-          if (typeof out === 'function') {
-            teardownFunctions.push({ index, fn: out });
-          }
-          if (typeof out === 'object') {
-            wrappedRunContinuation = out.then((beforeOut) => {
-              if (beforeOut !== undefined) {
-                teardownFunctions.push({ index, fn: beforeOut });
-              }
-              return null;
-            });
-          }
-        } else {
-          wrappedRunContinuation = wrappedRunContinuation.then(() => {
-            const beforeOut = before();
-            if (beforeOut === undefined) {
-              return null;
-            }
-            if (typeof beforeOut === 'function') {
-              teardownFunctions.push({ index, fn: beforeOut });
-              return null;
-            }
-            return beforeOut.then((beforeOutNested) => {
-              if (beforeOutNested !== undefined) {
-                teardownFunctions.push({ index, fn: beforeOutNested });
-              }
-              return null;
-            });
-          });
-        }
-      }
-    } catch (error) {
-      wrappedRunOutput = { error };
-    }
-  }
 
-  // Predicate
-
-  if (wrappedRunOutput === null) {
-    if (wrappedRunContinuation === undefined) {
-      // We are currently into a sync flow
-      const out = nestedRun(value);
-      if (out !== null && 'then' in out) {
-        wrappedRunContinuation = out;
-      } else {
-        wrappedRunOutput = out;
-      }
-    } else {
-      // We switched to an async flow
-      wrappedRunContinuation = wrappedRunContinuation.then(
-        () => nestedRun(value),
-        (error) => ({ error }), // beforeEach flows do not catch anything, they always result into succes being null or throw
-      );
-    }
-  }
-
-  // After hooks
-  if (wrappedRunContinuation === undefined) {
+  function runAfterPart(previous: PredicateOutput): Promise<PredicateOutput> | PredicateOutput {
     const resultingAfterHooks = computeResultingAfterHooks(teardownFunctions, hooks);
-    for (let index = resultingAfterHooks.length - 1; index >= 0; --index) {
-      const after = resultingAfterHooks[index];
-      if (wrappedRunContinuation === undefined) {
-        try {
-          const out = after();
-          if (typeof out === 'object') {
-            wrappedRunContinuation = out.then(
-              () => wrappedRunOutput,
-              // TODO Switch to ?? when the node range defined by fast-check accepts it
-              (error) => wrappedRunOutput || { error },
-            );
-          }
-        } catch (error) {
-          wrappedRunOutput = { error };
-        }
-      } else {
-        wrappedRunContinuation = wrappedRunContinuation.then((previous) => {
-          try {
-            const out = after();
-            if (typeof out === 'object') {
-              return out.then(
-                () => previous,
-                // TODO Switch to ?? when the node range defined by fast-check accepts it
-                (error) => previous || { error },
-              );
-            }
-            return previous;
-          } catch (error) {
-            // TODO Switch to ?? when the node range defined by fast-check accepts it
-            return previous || { error };
-          }
-        });
-      }
-    }
-  } else {
-    wrappedRunContinuation = wrappedRunContinuation.then((previousBeforeAfters) => {
-      const resultingAfterHooks = computeResultingAfterHooks(teardownFunctions, hooks);
-      if (resultingAfterHooks.length === 0) {
-        return previousBeforeAfters;
-      }
-      let afterContinuation: Promise<Awaited<ReturnType<typeof nestedRun>>> = Promise.resolve(previousBeforeAfters);
-      for (let index = resultingAfterHooks.length - 1; index >= 0; --index) {
-        const after = resultingAfterHooks[index];
-        afterContinuation = afterContinuation.then((previous) => {
-          try {
-            const out = after();
-            return out === undefined
-              ? previous
-              : out.then(
-                  () => previous,
-                  // TODO Switch to ?? when the node range defined by fast-check accepts it
-                  (error) => previous || { error },
-                );
-          } catch (error) {
-            // TODO Switch to ?? when the node range defined by fast-check accepts it
-            return previous || { error };
-          }
-        });
-      }
-      return afterContinuation;
-    });
+    return runAfterHooks(resultingAfterHooks, resultingAfterHooks.length - 1, previous);
   }
 
-  return wrappedRunContinuation === undefined ? wrappedRunOutput : wrappedRunContinuation;
+  function runPredicateAndAfterPart(): Promise<PredicateOutput> | PredicateOutput {
+    const out = nestedRun(value);
+    if (out !== null && 'then' in out) {
+      return out.then(runAfterPart);
+    }
+    return runAfterPart(out);
+  }
+
+  let beforeContinuation: Promise<null> | null = null;
+  try {
+    beforeContinuation = runBeforeHooks(hooks, teardownFunctions, 0);
+  } catch (error) {
+    return runAfterPart({ error });
+  }
+  if (beforeContinuation === null) {
+    return runPredicateAndAfterPart();
+  }
+  return beforeContinuation.then(
+    runPredicateAndAfterPart,
+    (error) => runAfterPart({ error }), // beforeEach flows do not catch anything, they always result into success being null or throw
+  );
 }
 
 /**

--- a/packages/fast-check/test/bench/lifeCyclePlugins.bench.ts
+++ b/packages/fast-check/test/bench/lifeCyclePlugins.bench.ts
@@ -1,0 +1,102 @@
+import { describe, bench } from 'vitest';
+import { fc } from './__test-helpers__/Imports.js';
+
+// Hooks increment a counter so that no hook body can be considered dead-code
+let counter = 0;
+
+function syncOnlyPlugins() {
+  return [
+    fc.beforeEach(() => {
+      counter += 1;
+    }),
+    fc.beforeEach(() => {
+      counter += 1;
+      return () => {
+        counter += 1;
+      };
+    }),
+    fc.afterEach(() => {
+      counter += 1;
+    }),
+    fc.afterEach(() => {
+      counter += 1;
+    }),
+  ];
+}
+
+function asyncThenSyncOnlyPlugins() {
+  return [
+    fc.beforeEach(async () => {
+      counter += 1;
+    }),
+    ...syncOnlyPlugins(),
+  ];
+}
+
+function asyncOnlyPlugins() {
+  return [
+    fc.beforeEach(async () => {
+      counter += 1;
+      return async () => {
+        counter += 1;
+      };
+    }),
+    fc.afterEach(async () => {
+      counter += 1;
+    }),
+  ];
+}
+
+// Longer sampling than the default to reduce the impact of the noise of the machine
+const benchOptions = { warmupTime: 300, time: 1500 };
+
+// Benchmark
+describe('life-cycle plugins', () => {
+  bench(
+    'async property without any hook',
+    () => {
+      return fc.assert(fc.asyncProperty(fc.constant(1), async (_c) => true));
+    },
+    benchOptions,
+  );
+  bench(
+    'sync property with sync-only hooks',
+    () => {
+      fc.assert(
+        fc.property(fc.constant(1), (_c) => true),
+        { plugins: syncOnlyPlugins() },
+      );
+    },
+    benchOptions,
+  );
+  bench(
+    'async property with sync-only hooks',
+    () => {
+      return fc.assert(
+        fc.asyncProperty(fc.constant(1), async (_c) => true),
+        { plugins: syncOnlyPlugins() },
+      );
+    },
+    benchOptions,
+  );
+  bench(
+    'async property with an async beforeEach followed by sync-only hooks',
+    () => {
+      return fc.assert(
+        fc.asyncProperty(fc.constant(1), async (_c) => true),
+        { plugins: asyncThenSyncOnlyPlugins() },
+      );
+    },
+    benchOptions,
+  );
+  bench(
+    'async property with async-only hooks',
+    () => {
+      return fc.assert(
+        fc.asyncProperty(fc.constant(1), async (_c) => true),
+        { plugins: asyncOnlyPlugins() },
+      );
+    },
+    benchOptions,
+  );
+});

--- a/packages/fast-check/test/bench/lifeCyclePlugins.bench.ts
+++ b/packages/fast-check/test/bench/lifeCyclePlugins.bench.ts
@@ -26,6 +26,7 @@ function syncOnlyPlugins() {
 
 function asyncThenSyncOnlyPlugins() {
   return [
+    // oxlint-disable-next-line typescript/require-await
     fc.beforeEach(async () => {
       counter += 1;
     }),
@@ -35,12 +36,15 @@ function asyncThenSyncOnlyPlugins() {
 
 function asyncOnlyPlugins() {
   return [
+    // oxlint-disable-next-line typescript/require-await
     fc.beforeEach(async () => {
       counter += 1;
+      // oxlint-disable-next-line typescript/require-await
       return async () => {
         counter += 1;
       };
     }),
+    // oxlint-disable-next-line typescript/require-await
     fc.afterEach(async () => {
       counter += 1;
     }),
@@ -55,6 +59,7 @@ describe('life-cycle plugins', () => {
   bench(
     'async property without any hook',
     () => {
+      // oxlint-disable-next-line typescript/require-await
       return fc.assert(fc.asyncProperty(fc.constant(1), async (_c) => true));
     },
     benchOptions,
@@ -73,6 +78,7 @@ describe('life-cycle plugins', () => {
     'async property with sync-only hooks',
     () => {
       return fc.assert(
+        // oxlint-disable-next-line typescript/require-await
         fc.asyncProperty(fc.constant(1), async (_c) => true),
         { plugins: syncOnlyPlugins() },
       );
@@ -83,6 +89,7 @@ describe('life-cycle plugins', () => {
     'async property with an async beforeEach followed by sync-only hooks',
     () => {
       return fc.assert(
+        // oxlint-disable-next-line typescript/require-await
         fc.asyncProperty(fc.constant(1), async (_c) => true),
         { plugins: asyncThenSyncOnlyPlugins() },
       );
@@ -93,6 +100,7 @@ describe('life-cycle plugins', () => {
     'async property with async-only hooks',
     () => {
       return fc.assert(
+        // oxlint-disable-next-line typescript/require-await
         fc.asyncProperty(fc.constant(1), async (_c) => true),
         { plugins: asyncOnlyPlugins() },
       );

--- a/packages/fast-check/test/unit/check/plugin/LifeCyclePlugins.spec.ts
+++ b/packages/fast-check/test/unit/check/plugin/LifeCyclePlugins.spec.ts
@@ -358,6 +358,117 @@ describe('LifeCyclePlugins', () => {
     );
   });
 
+  it('should chain synchronous beforeEach hooks within the same tick when following an asynchronous one', async () => {
+    // Arrange
+    const probes: string[] = [];
+    let pluginIndex = 0;
+    const store = new Map<symbol, any>();
+    const instances = [
+      beforeEach(async () => {
+        probes.push('a::beforeEach');
+      }),
+      beforeEach(() => {
+        probes.push('b::beforeEach');
+        // Anything requeued between b and c would run before this one
+        void Promise.resolve().then(() => probes.push('tick queued by b'));
+      }),
+      beforeEach(() => {
+        probes.push('c::beforeEach');
+      }),
+    ].map((plugin) => plugin(pluginIndex++, store));
+    const finalRun = produceFinalRun(() => {
+      probes.push('predicate');
+      return null;
+    }, instances);
+
+    // Act
+    await finalRun(null);
+
+    // Assert
+    // Once the asynchronous hook resolved, b and c run back-to-back within the same tick
+    expect(probes).toEqual(['a::beforeEach', 'b::beforeEach', 'c::beforeEach', 'tick queued by b', 'predicate']);
+  });
+
+  it('should chain synchronous afterEach hooks within the same tick when following an asynchronous one', async () => {
+    // Arrange
+    const probes: string[] = [];
+    let pluginIndex = 0;
+    const store = new Map<symbol, any>();
+    // afterEach hooks run in reverse declaration order: z then y then x
+    const instances = [
+      afterEach(() => {
+        probes.push('x::afterEach');
+      }),
+      afterEach(() => {
+        probes.push('y::afterEach');
+        // Anything requeued between y and x would run before this one
+        void Promise.resolve().then(() => probes.push('tick queued by y'));
+      }),
+      afterEach(async () => {
+        probes.push('z::afterEach');
+      }),
+    ].map((plugin) => plugin(pluginIndex++, store));
+    const finalRun = produceFinalRun(() => {
+      probes.push('predicate');
+      return null;
+    }, instances);
+
+    // Act
+    await finalRun(null);
+
+    // Assert
+    // Once the asynchronous hook resolved, y and x run back-to-back within the same tick
+    expect(probes).toEqual(['predicate', 'z::afterEach', 'y::afterEach', 'x::afterEach', 'tick queued by y']);
+  });
+
+  it('should not delay the output of an asynchronous run with extra ticks when hooks are synchronous', async () => {
+    // Arrange
+    const probes: string[] = [];
+    let pluginIndex = 0;
+    const store = new Map<symbol, any>();
+    // afterEach-and-teardown hooks run in reverse declaration order: afterEach then teardown
+    const instances = [
+      beforeEach(() => {
+        probes.push('beforeEach');
+        return () => {
+          probes.push('teardown');
+          // teardown runs last: from there, count how many microtask ticks elapse before finalRun resolves
+          void Promise.resolve()
+            .then(() => probes.push('tick1'))
+            .then(() => probes.push('tick2'))
+            .then(() => probes.push('tick3'))
+            .then(() => probes.push('tick4'));
+        };
+      }),
+      afterEach(() => {
+        probes.push('afterEach');
+      }),
+    ].map((plugin) => plugin(pluginIndex++, store));
+    const finalRun = produceFinalRun(async () => {
+      probes.push('predicate');
+      return null;
+    }, instances);
+
+    // Act
+    await finalRun(null);
+    probes.push('resolved');
+    await new Promise((resolve) => setTimeout(resolve)); // flush pending ticks
+
+    // Assert
+    // Fully synchronous hooks must not requeue anything: finalRun resolves on the very next tick
+    expect(probes).toEqual([
+      'beforeEach',
+      'predicate',
+      'afterEach',
+      'teardown',
+      'tick1',
+      'resolved',
+      'tick2',
+      'tick3',
+      'tick4',
+    ]);
+  });
+
   it('should merge consecutive instances of the plugin into a single instance but create a new instance at each index gap', async () => {
     await fc.assert(
       fc.property(


### PR DESCRIPTION
The runner behind the beforeEach/afterEach plugins used to chain one
`.then` per hook as soon as the flow switched to asynchronous, even for
hooks being purely synchronous, and seeded the after part with an extra
`Promise.resolve`. It now runs hooks from root synchronous loops and only
chains a `.then` when a hook actually returns a `Promise`: the loop
resumes from within its resolution for the remaining hooks.

It also aligns the failure precedence of synchronously throwing after
hooks with the asynchronous flow: the first failure is preserved instead
of being overwritten by a later after hook throwing synchronously.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015iGbbNKHix7TnTX3SuqP8U